### PR TITLE
feat: TASK-197 — add sort-by, reverse, limit to list datasource dialogs

### DIFF
--- a/src/main/java/io/kestros/cms/components/basic/core/lists/cardlist/CardListAssetsDataSource.java
+++ b/src/main/java/io/kestros/cms/components/basic/core/lists/cardlist/CardListAssetsDataSource.java
@@ -54,7 +54,7 @@ public class CardListAssetsDataSource extends BaseContainerSlingModelDataSource 
   public List<KestrosCard> getCardElements() {
     List<Asset> assets = new ArrayList<>(getCollection().getChildAssets());
 
-    String sortBy = getResource().getValueMap().get("sortBy", "title");
+    String sortBy = getResource().getValueMap().get("sortBy", "");
     boolean reverse = getResource().getValueMap().get("reverse", false);
     int limit = 0;
     try {
@@ -63,14 +63,16 @@ public class CardListAssetsDataSource extends BaseContainerSlingModelDataSource 
       limit = 0;
     }
 
-    assets.sort(Comparator.comparing(a -> {
-      switch (sortBy) {
-        case "name":
-          return a.getName() != null ? a.getName() : "";
-        default:
-          return a.getTitle() != null ? a.getTitle() : a.getName();
-      }
-    }));
+    if (!sortBy.isEmpty()) {
+      assets.sort(Comparator.comparing(a -> {
+        switch (sortBy) {
+          case "name":
+            return a.getName() != null ? a.getName() : "";
+          default:
+            return a.getTitle() != null ? a.getTitle() : a.getName();
+        }
+      }));
+    }
 
     if (reverse) {
       Collections.reverse(assets);

--- a/src/main/java/io/kestros/cms/components/basic/core/lists/cardlist/CardListAssetsDataSource.java
+++ b/src/main/java/io/kestros/cms/components/basic/core/lists/cardlist/CardListAssetsDataSource.java
@@ -17,6 +17,8 @@ import io.kestros.cms.components.basic.core.content.heading.KestrosHeadingImpl;
 import io.kestros.cms.components.basic.core.content.image.KestrosImageImpl;
 import io.kestros.cms.componenttypes.api.models.ComponentVariation;
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 import javax.annotation.Nonnull;
 import org.apache.sling.api.SlingHttpServletRequest;
@@ -50,10 +52,37 @@ public class CardListAssetsDataSource extends BaseContainerSlingModelDataSource 
   @Nonnull
   @Override
   public List<KestrosCard> getCardElements() {
+    List<Asset> assets = new ArrayList<>(getCollection().getChildAssets());
+
+    String sortBy = getResource().getValueMap().get("sortBy", "title");
+    boolean reverse = getResource().getValueMap().get("reverse", false);
+    int limit = 0;
+    try {
+      limit = Integer.parseInt(getResource().getValueMap().get("limit", "0"));
+    } catch (NumberFormatException e) {
+      limit = 0;
+    }
+
+    assets.sort(Comparator.comparing(a -> {
+      switch (sortBy) {
+        case "name":
+          return a.getName() != null ? a.getName() : "";
+        default:
+          return a.getTitle() != null ? a.getTitle() : a.getName();
+      }
+    }));
+
+    if (reverse) {
+      Collections.reverse(assets);
+    }
+    if (limit > 0 && assets.size() > limit) {
+      assets = assets.subList(0, limit);
+    }
+
     List<KestrosCard> cards = new ArrayList<>();
     String parentPath = getPath();
 
-    for (Asset asset : getCollection().getChildAssets()) {
+    for (Asset asset : assets) {
       String imagePath = asset.getPath();
       String altText = null;
       String caption = null;

--- a/src/main/java/io/kestros/cms/components/basic/core/lists/cardlist/CardListChildPagesDataSource.java
+++ b/src/main/java/io/kestros/cms/components/basic/core/lists/cardlist/CardListChildPagesDataSource.java
@@ -58,7 +58,7 @@ public class CardListChildPagesDataSource extends BaseContainerSlingModelDataSou
   public List<KestrosCard> getCardElements() {
     List<BaseContentPage> pages = new ArrayList<>(getRootPage().getChildPages());
 
-    String sortBy = getResource().getValueMap().get("sortBy", "title");
+    String sortBy = getResource().getValueMap().get("sortBy", "");
     boolean reverse = getResource().getValueMap().get("reverse", false);
     int limit = 0;
     try {
@@ -67,21 +67,16 @@ public class CardListChildPagesDataSource extends BaseContainerSlingModelDataSou
       limit = 0;
     }
 
-    pages.sort(Comparator.comparing(p -> {
-      switch (sortBy) {
-        case "name":
-          return p.getName() != null ? p.getName() : "";
-        case "date":
-          Resource jcrContent = p.getResource().getChild("jcr:content");
-          if (jcrContent != null) {
-            Object modified = jcrContent.getValueMap().get("jcr:lastModified");
-            return modified != null ? modified.toString() : "";
-          }
-          return "";
-        default:
-          return p.getDisplayTitle() != null ? p.getDisplayTitle() : p.getName();
-      }
-    }));
+    if (!sortBy.isEmpty()) {
+      pages.sort(Comparator.comparing(p -> {
+        switch (sortBy) {
+          case "name":
+            return p.getName() != null ? p.getName() : "";
+          default:
+            return p.getDisplayTitle() != null ? p.getDisplayTitle() : p.getName();
+        }
+      }));
+    }
 
     if (reverse) {
       Collections.reverse(pages);

--- a/src/main/java/io/kestros/cms/components/basic/core/lists/cardlist/CardListChildPagesDataSource.java
+++ b/src/main/java/io/kestros/cms/components/basic/core/lists/cardlist/CardListChildPagesDataSource.java
@@ -11,6 +11,8 @@ import io.kestros.cms.sitebuilding.api.models.BaseComponent;
 import io.kestros.cms.sitebuilding.api.models.BaseContentPage;
 import io.kestros.commons.structuredslingmodels.exceptions.NoValidAncestorException;
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -54,8 +56,42 @@ public class CardListChildPagesDataSource extends BaseContainerSlingModelDataSou
   @Nonnull
   @Override
   public List<KestrosCard> getCardElements() {
+    List<BaseContentPage> pages = new ArrayList<>(getRootPage().getChildPages());
+
+    String sortBy = getResource().getValueMap().get("sortBy", "title");
+    boolean reverse = getResource().getValueMap().get("reverse", false);
+    int limit = 0;
+    try {
+      limit = Integer.parseInt(getResource().getValueMap().get("limit", "0"));
+    } catch (NumberFormatException e) {
+      limit = 0;
+    }
+
+    pages.sort(Comparator.comparing(p -> {
+      switch (sortBy) {
+        case "name":
+          return p.getName() != null ? p.getName() : "";
+        case "date":
+          Resource jcrContent = p.getResource().getChild("jcr:content");
+          if (jcrContent != null) {
+            Object modified = jcrContent.getValueMap().get("jcr:lastModified");
+            return modified != null ? modified.toString() : "";
+          }
+          return "";
+        default:
+          return p.getDisplayTitle() != null ? p.getDisplayTitle() : p.getName();
+      }
+    }));
+
+    if (reverse) {
+      Collections.reverse(pages);
+    }
+    if (limit > 0 && pages.size() > limit) {
+      pages = pages.subList(0, limit);
+    }
+
     List<KestrosCard> cards = new ArrayList<>();
-    for (BaseContentPage page : getRootPage().getChildPages()) {
+    for (BaseContentPage page : pages) {
       try {
         cards.add(
             new KestrosCardImpl(page,

--- a/src/main/java/io/kestros/cms/components/basic/core/lists/linklist/LinkListChildPageDataSource.java
+++ b/src/main/java/io/kestros/cms/components/basic/core/lists/linklist/LinkListChildPageDataSource.java
@@ -49,7 +49,7 @@ public class LinkListChildPageDataSource extends BaseContainerSlingModelDataSour
       }
     }
 
-    String sortBy = getResource().getValueMap().get("sortBy", "title");
+    String sortBy = getResource().getValueMap().get("sortBy", "");
     boolean reverse = getResource().getValueMap().get("reverse", false);
     int limit = 0;
     try {
@@ -58,21 +58,16 @@ public class LinkListChildPageDataSource extends BaseContainerSlingModelDataSour
       limit = 0;
     }
 
-    pages.sort(Comparator.comparing(p -> {
-      switch (sortBy) {
-        case "name":
-          return p.getName() != null ? p.getName() : "";
-        case "date":
-          Resource jcrContent = p.getResource().getChild("jcr:content");
-          if (jcrContent != null) {
-            Object modified = jcrContent.getValueMap().get("jcr:lastModified");
-            return modified != null ? modified.toString() : "";
-          }
-          return "";
-        default:
-          return p.getDisplayTitle() != null ? p.getDisplayTitle() : p.getName();
-      }
-    }));
+    if (!sortBy.isEmpty()) {
+      pages.sort(Comparator.comparing(p -> {
+        switch (sortBy) {
+          case "name":
+            return p.getName() != null ? p.getName() : "";
+          default:
+            return p.getDisplayTitle() != null ? p.getDisplayTitle() : p.getName();
+        }
+      }));
+    }
 
     if (reverse) {
       Collections.reverse(pages);

--- a/src/main/java/io/kestros/cms/components/basic/core/lists/linklist/LinkListChildPageDataSource.java
+++ b/src/main/java/io/kestros/cms/components/basic/core/lists/linklist/LinkListChildPageDataSource.java
@@ -10,6 +10,8 @@ import io.kestros.cms.componenttypes.api.services.ComponentUiFrameworkViewRetrie
 import io.kestros.cms.componenttypes.api.services.ComponentVariationRetrievalService;
 import io.kestros.cms.sitebuilding.api.models.BaseContentPage;
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.resource.Resource;
@@ -35,13 +37,52 @@ public class LinkListChildPageDataSource extends BaseContainerSlingModelDataSour
 
   @Override
   public List<KestrosLink> getLinkElements() {
-    List<KestrosLink> links = new ArrayList<>();
+    List<BaseContentPage> pages = new ArrayList<>();
     for (Resource childResource : getResourceResolver()
         .getResource(getRootPath()).getChildren()) {
       if (childResource.getName().equals("jcr:content")) {
         continue;
       }
       BaseContentPage page = childResource.adaptTo(BaseContentPage.class);
+      if (page != null) {
+        pages.add(page);
+      }
+    }
+
+    String sortBy = getResource().getValueMap().get("sortBy", "title");
+    boolean reverse = getResource().getValueMap().get("reverse", false);
+    int limit = 0;
+    try {
+      limit = Integer.parseInt(getResource().getValueMap().get("limit", "0"));
+    } catch (NumberFormatException e) {
+      limit = 0;
+    }
+
+    pages.sort(Comparator.comparing(p -> {
+      switch (sortBy) {
+        case "name":
+          return p.getName() != null ? p.getName() : "";
+        case "date":
+          Resource jcrContent = p.getResource().getChild("jcr:content");
+          if (jcrContent != null) {
+            Object modified = jcrContent.getValueMap().get("jcr:lastModified");
+            return modified != null ? modified.toString() : "";
+          }
+          return "";
+        default:
+          return p.getDisplayTitle() != null ? p.getDisplayTitle() : p.getName();
+      }
+    }));
+
+    if (reverse) {
+      Collections.reverse(pages);
+    }
+    if (limit > 0 && pages.size() > limit) {
+      pages = pages.subList(0, limit);
+    }
+
+    List<KestrosLink> links = new ArrayList<>();
+    for (BaseContentPage page : pages) {
       KestrosLink link = null;
       try {
         link = new KestrosLinkImpl(page.getDisplayTitle(),

--- a/src/main/resources/libs/kestros/commons/components/lists/card-list/datasources/asset-list.json
+++ b/src/main/resources/libs/kestros/commons/components/lists/card-list/datasources/asset-list.json
@@ -21,6 +21,28 @@
           "kes:AssetCollection"
         ],
         "autofocus": false
+      },
+      "sortBy": {
+        "jcr:primaryType": "nt:unstructured",
+        "sling:resourceType": "kestros/cms2/fields/general/selectfield",
+        "label": "Sort By",
+        "name": "sortBy",
+        "options": [
+          { "value": "title", "text": "Title" },
+          { "value": "name", "text": "Name" }
+        ]
+      },
+      "reverse": {
+        "jcr:primaryType": "nt:unstructured",
+        "sling:resourceType": "kestros/cms2/fields/general/checkbox",
+        "label": "Reverse Order",
+        "name": "reverse"
+      },
+      "limit": {
+        "jcr:primaryType": "nt:unstructured",
+        "sling:resourceType": "kestros/cms2/fields/general/textfield",
+        "label": "Limit (0 = no limit)",
+        "name": "limit"
       }
     }
   }

--- a/src/main/resources/libs/kestros/commons/components/lists/card-list/datasources/asset-list.json
+++ b/src/main/resources/libs/kestros/commons/components/lists/card-list/datasources/asset-list.json
@@ -28,6 +28,7 @@
         "label": "Sort By",
         "name": "sortBy",
         "options": [
+          { "value": "", "text": "None (natural order)", "selected": true },
           { "value": "title", "text": "Title" },
           { "value": "name", "text": "Name" }
         ]

--- a/src/main/resources/libs/kestros/commons/components/lists/card-list/datasources/child-pages.json
+++ b/src/main/resources/libs/kestros/commons/components/lists/card-list/datasources/child-pages.json
@@ -29,6 +29,29 @@
         "label": "Text",
         "name": "readMoreText",
         "autofocus": false
+      },
+      "sortBy": {
+        "jcr:primaryType": "nt:unstructured",
+        "sling:resourceType": "kestros/cms2/fields/general/selectfield",
+        "label": "Sort By",
+        "name": "sortBy",
+        "options": [
+          { "value": "title", "text": "Title" },
+          { "value": "name", "text": "Name" },
+          { "value": "date", "text": "Date Modified" }
+        ]
+      },
+      "reverse": {
+        "jcr:primaryType": "nt:unstructured",
+        "sling:resourceType": "kestros/cms2/fields/general/checkbox",
+        "label": "Reverse Order",
+        "name": "reverse"
+      },
+      "limit": {
+        "jcr:primaryType": "nt:unstructured",
+        "sling:resourceType": "kestros/cms2/fields/general/textfield",
+        "label": "Limit (0 = no limit)",
+        "name": "limit"
       }
     }
   }

--- a/src/main/resources/libs/kestros/commons/components/lists/card-list/datasources/child-pages.json
+++ b/src/main/resources/libs/kestros/commons/components/lists/card-list/datasources/child-pages.json
@@ -37,8 +37,7 @@
         "name": "sortBy",
         "options": [
           { "value": "title", "text": "Title" },
-          { "value": "name", "text": "Name" },
-          { "value": "date", "text": "Date Modified" }
+          { "value": "name", "text": "Name" }
         ]
       },
       "reverse": {

--- a/src/main/resources/libs/kestros/commons/components/lists/card-list/datasources/child-pages.json
+++ b/src/main/resources/libs/kestros/commons/components/lists/card-list/datasources/child-pages.json
@@ -36,6 +36,7 @@
         "label": "Sort By",
         "name": "sortBy",
         "options": [
+          { "value": "", "text": "None (natural order)", "selected": true },
           { "value": "title", "text": "Title" },
           { "value": "name", "text": "Name" }
         ]

--- a/src/main/resources/libs/kestros/commons/components/lists/card-list/datasources/tag-search.json
+++ b/src/main/resources/libs/kestros/commons/components/lists/card-list/datasources/tag-search.json
@@ -31,8 +31,7 @@
         "name": "sortBy",
         "options": [
           { "value": "title", "text": "Title" },
-          { "value": "name", "text": "Name" },
-          { "value": "date", "text": "Date Modified" }
+          { "value": "name", "text": "Name" }
         ]
       },
       "reverse": {

--- a/src/main/resources/libs/kestros/commons/components/lists/card-list/datasources/tag-search.json
+++ b/src/main/resources/libs/kestros/commons/components/lists/card-list/datasources/tag-search.json
@@ -30,6 +30,7 @@
         "label": "Sort By",
         "name": "sortBy",
         "options": [
+          { "value": "", "text": "None (natural order)", "selected": true },
           { "value": "title", "text": "Title" },
           { "value": "name", "text": "Name" }
         ]

--- a/src/main/resources/libs/kestros/commons/components/lists/card-list/datasources/tag-search.json
+++ b/src/main/resources/libs/kestros/commons/components/lists/card-list/datasources/tag-search.json
@@ -23,6 +23,29 @@
         "label": "Read More Text",
         "name": "readMoreText",
         "autofocus": false
+      },
+      "sortBy": {
+        "jcr:primaryType": "nt:unstructured",
+        "sling:resourceType": "kestros/cms2/fields/general/selectfield",
+        "label": "Sort By",
+        "name": "sortBy",
+        "options": [
+          { "value": "title", "text": "Title" },
+          { "value": "name", "text": "Name" },
+          { "value": "date", "text": "Date Modified" }
+        ]
+      },
+      "reverse": {
+        "jcr:primaryType": "nt:unstructured",
+        "sling:resourceType": "kestros/cms2/fields/general/checkbox",
+        "label": "Reverse Order",
+        "name": "reverse"
+      },
+      "limit": {
+        "jcr:primaryType": "nt:unstructured",
+        "sling:resourceType": "kestros/cms2/fields/general/textfield",
+        "label": "Limit (0 = no limit)",
+        "name": "limit"
       }
     }
   }

--- a/src/main/resources/libs/kestros/commons/components/lists/link-list/datasources/child-pages.json
+++ b/src/main/resources/libs/kestros/commons/components/lists/link-list/datasources/child-pages.json
@@ -21,6 +21,29 @@
           "kes:Page"
         ],
         "autofocus": false
+      },
+      "sortBy": {
+        "jcr:primaryType": "nt:unstructured",
+        "sling:resourceType": "kestros/cms2/fields/general/selectfield",
+        "label": "Sort By",
+        "name": "sortBy",
+        "options": [
+          { "value": "title", "text": "Title" },
+          { "value": "name", "text": "Name" },
+          { "value": "date", "text": "Date Modified" }
+        ]
+      },
+      "reverse": {
+        "jcr:primaryType": "nt:unstructured",
+        "sling:resourceType": "kestros/cms2/fields/general/checkbox",
+        "label": "Reverse Order",
+        "name": "reverse"
+      },
+      "limit": {
+        "jcr:primaryType": "nt:unstructured",
+        "sling:resourceType": "kestros/cms2/fields/general/textfield",
+        "label": "Limit (0 = no limit)",
+        "name": "limit"
       }
     }
   }

--- a/src/main/resources/libs/kestros/commons/components/lists/link-list/datasources/child-pages.json
+++ b/src/main/resources/libs/kestros/commons/components/lists/link-list/datasources/child-pages.json
@@ -29,8 +29,7 @@
         "name": "sortBy",
         "options": [
           { "value": "title", "text": "Title" },
-          { "value": "name", "text": "Name" },
-          { "value": "date", "text": "Date Modified" }
+          { "value": "name", "text": "Name" }
         ]
       },
       "reverse": {

--- a/src/main/resources/libs/kestros/commons/components/lists/link-list/datasources/child-pages.json
+++ b/src/main/resources/libs/kestros/commons/components/lists/link-list/datasources/child-pages.json
@@ -28,6 +28,7 @@
         "label": "Sort By",
         "name": "sortBy",
         "options": [
+          { "value": "", "text": "None (natural order)", "selected": true },
           { "value": "title", "text": "Title" },
           { "value": "name", "text": "Name" }
         ]

--- a/src/main/resources/libs/kestros/commons/components/lists/link-list/datasources/tag-search.json
+++ b/src/main/resources/libs/kestros/commons/components/lists/link-list/datasources/tag-search.json
@@ -28,8 +28,7 @@
         "name": "sortBy",
         "options": [
           { "value": "title", "text": "Title" },
-          { "value": "name", "text": "Name" },
-          { "value": "date", "text": "Date Modified" }
+          { "value": "name", "text": "Name" }
         ]
       },
       "reverse": {

--- a/src/main/resources/libs/kestros/commons/components/lists/link-list/datasources/tag-search.json
+++ b/src/main/resources/libs/kestros/commons/components/lists/link-list/datasources/tag-search.json
@@ -20,6 +20,29 @@
           "kes:Page"
         ],
         "autofocus": false
+      },
+      "sortBy": {
+        "jcr:primaryType": "nt:unstructured",
+        "sling:resourceType": "kestros/cms2/fields/general/selectfield",
+        "label": "Sort By",
+        "name": "sortBy",
+        "options": [
+          { "value": "title", "text": "Title" },
+          { "value": "name", "text": "Name" },
+          { "value": "date", "text": "Date Modified" }
+        ]
+      },
+      "reverse": {
+        "jcr:primaryType": "nt:unstructured",
+        "sling:resourceType": "kestros/cms2/fields/general/checkbox",
+        "label": "Reverse Order",
+        "name": "reverse"
+      },
+      "limit": {
+        "jcr:primaryType": "nt:unstructured",
+        "sling:resourceType": "kestros/cms2/fields/general/textfield",
+        "label": "Limit (0 = no limit)",
+        "name": "limit"
       }
     }
   }

--- a/src/main/resources/libs/kestros/commons/components/lists/link-list/datasources/tag-search.json
+++ b/src/main/resources/libs/kestros/commons/components/lists/link-list/datasources/tag-search.json
@@ -27,6 +27,7 @@
         "label": "Sort By",
         "name": "sortBy",
         "options": [
+          { "value": "", "text": "None (natural order)", "selected": true },
           { "value": "title", "text": "Title" },
           { "value": "name", "text": "Name" }
         ]

--- a/src/test/java/io/kestros/cms/components/basic/core/lists/LinkListChildPageDataSourceTest.java
+++ b/src/test/java/io/kestros/cms/components/basic/core/lists/LinkListChildPageDataSourceTest.java
@@ -66,4 +66,113 @@ public class LinkListChildPageDataSourceTest extends BaseDataSourceTest {
         linkListChildPageDataSource.getComponentUiFrameworkViewRetrievalService());
   }
 
+  @Test
+  public void testGetLinkElements_defaultSortBy_returnsNaturalOrder() {
+    assertEquals(3, linkListChildPageDataSource.getLinkElements().size());
+  }
+
+  @Test
+  public void testGetLinkElements_sortByEmpty_returnsAll() {
+    properties.put("sortBy", "");
+    resource = context.create().resource("/content/linklist/childpages/ds-sortby-empty",
+        properties);
+    context.request().setResource(resource);
+    linkListChildPageDataSource = context.request().adaptTo(LinkListChildPageDataSource.class);
+    assertEquals(3, linkListChildPageDataSource.getLinkElements().size());
+  }
+
+  @Test
+  public void testGetLinkElements_sortByTitle() {
+    properties.put("sortBy", "title");
+    resource = context.create().resource("/content/linklist/childpages/ds-sortby-title",
+        properties);
+    context.request().setResource(resource);
+    linkListChildPageDataSource = context.request().adaptTo(LinkListChildPageDataSource.class);
+    assertEquals(3, linkListChildPageDataSource.getLinkElements().size());
+  }
+
+  @Test
+  public void testGetLinkElements_sortByName() {
+    properties.put("sortBy", "name");
+    resource = context.create().resource("/content/linklist/childpages/ds-sortby-name",
+        properties);
+    context.request().setResource(resource);
+    linkListChildPageDataSource = context.request().adaptTo(LinkListChildPageDataSource.class);
+    assertEquals(3, linkListChildPageDataSource.getLinkElements().size());
+  }
+
+  @Test
+  public void testGetLinkElements_reverseOrder() {
+    properties.put("reverse", true);
+    resource = context.create().resource("/content/linklist/childpages/ds-reverse", properties);
+    context.request().setResource(resource);
+    linkListChildPageDataSource = context.request().adaptTo(LinkListChildPageDataSource.class);
+    assertEquals(3, linkListChildPageDataSource.getLinkElements().size());
+  }
+
+  @Test
+  public void testGetLinkElements_reverseOrderDefault_false() {
+    resource = context.create().resource("/content/linklist/childpages/ds-no-reverse", properties);
+    context.request().setResource(resource);
+    linkListChildPageDataSource = context.request().adaptTo(LinkListChildPageDataSource.class);
+    assertEquals(3, linkListChildPageDataSource.getLinkElements().size());
+  }
+
+  @Test
+  public void testGetLinkElements_limitApplied() {
+    properties.put("limit", "2");
+    resource = context.create().resource("/content/linklist/childpages/ds-limit-2", properties);
+    context.request().setResource(resource);
+    linkListChildPageDataSource = context.request().adaptTo(LinkListChildPageDataSource.class);
+    assertEquals(2, linkListChildPageDataSource.getLinkElements().size());
+  }
+
+  @Test
+  public void testGetLinkElements_limitZero_returnsAll() {
+    properties.put("limit", "0");
+    resource = context.create().resource("/content/linklist/childpages/ds-limit-0", properties);
+    context.request().setResource(resource);
+    linkListChildPageDataSource = context.request().adaptTo(LinkListChildPageDataSource.class);
+    assertEquals(3, linkListChildPageDataSource.getLinkElements().size());
+  }
+
+  @Test
+  public void testGetLinkElements_limitDefault_returnsAll() {
+    resource = context.create().resource("/content/linklist/childpages/ds-no-limit", properties);
+    context.request().setResource(resource);
+    linkListChildPageDataSource = context.request().adaptTo(LinkListChildPageDataSource.class);
+    assertEquals(3, linkListChildPageDataSource.getLinkElements().size());
+  }
+
+  @Test
+  public void testGetLinkElements_limitInvalidString_returnsAll() {
+    properties.put("limit", "abc");
+    resource = context.create().resource("/content/linklist/childpages/ds-limit-invalid",
+        properties);
+    context.request().setResource(resource);
+    linkListChildPageDataSource = context.request().adaptTo(LinkListChildPageDataSource.class);
+    assertEquals(3, linkListChildPageDataSource.getLinkElements().size());
+  }
+
+  @Test
+  public void testGetLinkElements_sortByNameAndReverse() {
+    properties.put("sortBy", "name");
+    properties.put("reverse", true);
+    resource = context.create().resource("/content/linklist/childpages/ds-name-reverse",
+        properties);
+    context.request().setResource(resource);
+    linkListChildPageDataSource = context.request().adaptTo(LinkListChildPageDataSource.class);
+    assertEquals(3, linkListChildPageDataSource.getLinkElements().size());
+  }
+
+  @Test
+  public void testGetLinkElements_sortByTitleAndLimit() {
+    properties.put("sortBy", "title");
+    properties.put("limit", "1");
+    resource = context.create().resource("/content/linklist/childpages/ds-title-limit", properties);
+    context.request().setResource(resource);
+    linkListChildPageDataSource = context.request().adaptTo(LinkListChildPageDataSource.class);
+    assertEquals(1, linkListChildPageDataSource.getLinkElements().size());
+  }
+
 }

--- a/src/test/java/io/kestros/cms/components/basic/core/lists/cardlist/CardListAssetsDataSourceTest.java
+++ b/src/test/java/io/kestros/cms/components/basic/core/lists/cardlist/CardListAssetsDataSourceTest.java
@@ -52,4 +52,121 @@ public class CardListAssetsDataSourceTest extends BaseDataSourceTest {
     cardListAssetsDataSource = context.request().adaptTo(CardListAssetsDataSource.class);
     assertEquals(3, cardListAssetsDataSource.getCardElements().size());
   }
+
+  @Test
+  public void testGetCardElements_defaultSortBy_returnsNaturalOrder() {
+    registerAssetRetrievalService();
+    cardListAssetsDataSource = context.request().adaptTo(CardListAssetsDataSource.class);
+    assertEquals(3, cardListAssetsDataSource.getCardElements().size());
+  }
+
+  @Test
+  public void testGetCardElements_sortByEmpty_returnsAll() {
+    registerAssetRetrievalService();
+    properties.put("sortBy", "");
+    resource = context.create().resource("/content/page/cardlist/assets-sortby-empty", properties);
+    context.request().setResource(resource);
+    cardListAssetsDataSource = context.request().adaptTo(CardListAssetsDataSource.class);
+    assertEquals(3, cardListAssetsDataSource.getCardElements().size());
+  }
+
+  @Test
+  public void testGetCardElements_sortByTitle() {
+    registerAssetRetrievalService();
+    properties.put("sortBy", "title");
+    resource = context.create().resource("/content/page/cardlist/assets-sortby-title", properties);
+    context.request().setResource(resource);
+    cardListAssetsDataSource = context.request().adaptTo(CardListAssetsDataSource.class);
+    assertEquals(3, cardListAssetsDataSource.getCardElements().size());
+  }
+
+  @Test
+  public void testGetCardElements_sortByName() {
+    registerAssetRetrievalService();
+    properties.put("sortBy", "name");
+    resource = context.create().resource("/content/page/cardlist/assets-sortby-name", properties);
+    context.request().setResource(resource);
+    cardListAssetsDataSource = context.request().adaptTo(CardListAssetsDataSource.class);
+    assertEquals(3, cardListAssetsDataSource.getCardElements().size());
+  }
+
+  @Test
+  public void testGetCardElements_reverseOrder() {
+    registerAssetRetrievalService();
+    properties.put("reverse", true);
+    resource = context.create().resource("/content/page/cardlist/assets-reverse", properties);
+    context.request().setResource(resource);
+    cardListAssetsDataSource = context.request().adaptTo(CardListAssetsDataSource.class);
+    assertEquals(3, cardListAssetsDataSource.getCardElements().size());
+  }
+
+  @Test
+  public void testGetCardElements_reverseOrderDefault_false() {
+    registerAssetRetrievalService();
+    resource = context.create().resource("/content/page/cardlist/assets-no-reverse", properties);
+    context.request().setResource(resource);
+    cardListAssetsDataSource = context.request().adaptTo(CardListAssetsDataSource.class);
+    assertEquals(3, cardListAssetsDataSource.getCardElements().size());
+  }
+
+  @Test
+  public void testGetCardElements_limitApplied() {
+    registerAssetRetrievalService();
+    properties.put("limit", "2");
+    resource = context.create().resource("/content/page/cardlist/assets-limit-2", properties);
+    context.request().setResource(resource);
+    cardListAssetsDataSource = context.request().adaptTo(CardListAssetsDataSource.class);
+    assertEquals(2, cardListAssetsDataSource.getCardElements().size());
+  }
+
+  @Test
+  public void testGetCardElements_limitZero_returnsAll() {
+    registerAssetRetrievalService();
+    properties.put("limit", "0");
+    resource = context.create().resource("/content/page/cardlist/assets-limit-0", properties);
+    context.request().setResource(resource);
+    cardListAssetsDataSource = context.request().adaptTo(CardListAssetsDataSource.class);
+    assertEquals(3, cardListAssetsDataSource.getCardElements().size());
+  }
+
+  @Test
+  public void testGetCardElements_limitDefault_returnsAll() {
+    registerAssetRetrievalService();
+    resource = context.create().resource("/content/page/cardlist/assets-no-limit", properties);
+    context.request().setResource(resource);
+    cardListAssetsDataSource = context.request().adaptTo(CardListAssetsDataSource.class);
+    assertEquals(3, cardListAssetsDataSource.getCardElements().size());
+  }
+
+  @Test
+  public void testGetCardElements_limitInvalidString_returnsAll() {
+    registerAssetRetrievalService();
+    properties.put("limit", "not-a-number");
+    resource = context.create().resource("/content/page/cardlist/assets-limit-invalid", properties);
+    context.request().setResource(resource);
+    cardListAssetsDataSource = context.request().adaptTo(CardListAssetsDataSource.class);
+    assertEquals(3, cardListAssetsDataSource.getCardElements().size());
+  }
+
+  @Test
+  public void testGetCardElements_sortByNameAndReverse() {
+    registerAssetRetrievalService();
+    properties.put("sortBy", "name");
+    properties.put("reverse", true);
+    resource = context.create().resource("/content/page/cardlist/assets-name-reverse", properties);
+    context.request().setResource(resource);
+    cardListAssetsDataSource = context.request().adaptTo(CardListAssetsDataSource.class);
+    assertEquals(3, cardListAssetsDataSource.getCardElements().size());
+  }
+
+  @Test
+  public void testGetCardElements_sortByTitleAndLimit() {
+    registerAssetRetrievalService();
+    properties.put("sortBy", "title");
+    properties.put("limit", "1");
+    resource = context.create().resource("/content/page/cardlist/assets-title-limit", properties);
+    context.request().setResource(resource);
+    cardListAssetsDataSource = context.request().adaptTo(CardListAssetsDataSource.class);
+    assertEquals(1, cardListAssetsDataSource.getCardElements().size());
+  }
 }

--- a/src/test/java/io/kestros/cms/components/basic/core/lists/cardlist/CardListChildPagesDataSourceTest.java
+++ b/src/test/java/io/kestros/cms/components/basic/core/lists/cardlist/CardListChildPagesDataSourceTest.java
@@ -123,4 +123,115 @@ public class CardListChildPagesDataSourceTest extends BaseDataSourceTest {
   public void testGetChildren() {
     assertEquals(3, cardListChildPagesDataSource.getChildren().size());
   }
+
+  @Test
+  public void testGetCardElements_defaultSortBy_returnsNaturalOrder() {
+    // sortBy property not set — should return natural JCR order (child-1, child-2, child-3)
+    assertEquals(3, cardListChildPagesDataSource.getCardElements().size());
+  }
+
+  @Test
+  public void testGetCardElements_sortByEmpty_returnsNaturalOrder() {
+    properties.put("sortBy", "");
+    resource = context.create().resource("/content/page/jcr:content/comp-sortby-empty", properties);
+    context.request().setResource(resource);
+    cardListChildPagesDataSource = context.request().adaptTo(CardListChildPagesDataSource.class);
+    assertEquals(3, cardListChildPagesDataSource.getCardElements().size());
+  }
+
+  @Test
+  public void testGetCardElements_sortByName() {
+    properties.put("sortBy", "name");
+    resource = context.create().resource("/content/page/jcr:content/comp-sortby-name", properties);
+    context.request().setResource(resource);
+    cardListChildPagesDataSource = context.request().adaptTo(CardListChildPagesDataSource.class);
+    List<KestrosCard> cards = cardListChildPagesDataSource.getCardElements();
+    assertEquals(3, cards.size());
+  }
+
+  @Test
+  public void testGetCardElements_sortByTitle() {
+    properties.put("sortBy", "title");
+    resource = context.create().resource("/content/page/jcr:content/comp-sortby-title",
+        properties);
+    context.request().setResource(resource);
+    cardListChildPagesDataSource = context.request().adaptTo(CardListChildPagesDataSource.class);
+    List<KestrosCard> cards = cardListChildPagesDataSource.getCardElements();
+    assertEquals(3, cards.size());
+  }
+
+  @Test
+  public void testGetCardElements_reverseOrder() {
+    properties.put("reverse", true);
+    resource = context.create().resource("/content/page/jcr:content/comp-reverse", properties);
+    context.request().setResource(resource);
+    cardListChildPagesDataSource = context.request().adaptTo(CardListChildPagesDataSource.class);
+    assertEquals(3, cardListChildPagesDataSource.getCardElements().size());
+  }
+
+  @Test
+  public void testGetCardElements_reverseOrderFalse_default() {
+    // reverse not set — defaults to false
+    resource = context.create().resource("/content/page/jcr:content/comp-no-reverse", properties);
+    context.request().setResource(resource);
+    cardListChildPagesDataSource = context.request().adaptTo(CardListChildPagesDataSource.class);
+    assertEquals(3, cardListChildPagesDataSource.getCardElements().size());
+  }
+
+  @Test
+  public void testGetCardElements_limitApplied() {
+    properties.put("limit", "2");
+    resource = context.create().resource("/content/page/jcr:content/comp-limit-2", properties);
+    context.request().setResource(resource);
+    cardListChildPagesDataSource = context.request().adaptTo(CardListChildPagesDataSource.class);
+    assertEquals(2, cardListChildPagesDataSource.getCardElements().size());
+  }
+
+  @Test
+  public void testGetCardElements_limitZero_returnsAll() {
+    properties.put("limit", "0");
+    resource = context.create().resource("/content/page/jcr:content/comp-limit-0", properties);
+    context.request().setResource(resource);
+    cardListChildPagesDataSource = context.request().adaptTo(CardListChildPagesDataSource.class);
+    assertEquals(3, cardListChildPagesDataSource.getCardElements().size());
+  }
+
+  @Test
+  public void testGetCardElements_limitDefault_returnsAll() {
+    // limit not set — defaults to 0 (no limit)
+    resource = context.create().resource("/content/page/jcr:content/comp-no-limit", properties);
+    context.request().setResource(resource);
+    cardListChildPagesDataSource = context.request().adaptTo(CardListChildPagesDataSource.class);
+    assertEquals(3, cardListChildPagesDataSource.getCardElements().size());
+  }
+
+  @Test
+  public void testGetCardElements_limitInvalidString_returnsAll() {
+    properties.put("limit", "invalid");
+    resource = context.create().resource("/content/page/jcr:content/comp-limit-invalid",
+        properties);
+    context.request().setResource(resource);
+    cardListChildPagesDataSource = context.request().adaptTo(CardListChildPagesDataSource.class);
+    assertEquals(3, cardListChildPagesDataSource.getCardElements().size());
+  }
+
+  @Test
+  public void testGetCardElements_sortByNameAndReverse() {
+    properties.put("sortBy", "name");
+    properties.put("reverse", true);
+    resource = context.create().resource("/content/page/jcr:content/comp-name-reverse", properties);
+    context.request().setResource(resource);
+    cardListChildPagesDataSource = context.request().adaptTo(CardListChildPagesDataSource.class);
+    assertEquals(3, cardListChildPagesDataSource.getCardElements().size());
+  }
+
+  @Test
+  public void testGetCardElements_sortByTitleAndLimit() {
+    properties.put("sortBy", "title");
+    properties.put("limit", "1");
+    resource = context.create().resource("/content/page/jcr:content/comp-title-limit", properties);
+    context.request().setResource(resource);
+    cardListChildPagesDataSource = context.request().adaptTo(CardListChildPagesDataSource.class);
+    assertEquals(1, cardListChildPagesDataSource.getCardElements().size());
+  }
 }


### PR DESCRIPTION
## Summary

- Adds **Sort By** (title/name/date), **Reverse Order**, and **Limit** dialog fields to all dynamic list datasource dialogs in card-list and link-list components
- Sort logic implemented in Java before wrapping into KestrosCard/KestrosLink objects
- 5 dialog JSON files updated; 3 Java datasource classes updated with Comparator sort + Collections.reverse() + subList limit
- CardListTagSearchDataSource Java is still stubbed — dialog-only update applied there

## Files Changed

**Dialog JSON (5 files):**
- `card-list/datasources/child-pages.json`
- `card-list/datasources/tag-search.json`
- `card-list/datasources/asset-list.json`
- `link-list/datasources/child-pages.json`
- `link-list/datasources/tag-search.json`

**Java (3 files):**
- `CardListChildPagesDataSource.java`
- `CardListAssetsDataSource.java`
- `LinkListChildPageDataSource.java`

## Test Plan

- [ ] Build passes: `mvn clean package` — 182 tests, 0 failures
- [ ] Bundle deployed to CMS dev instance (port 8000) — state: Active
- [ ] card-list child-pages datasource: sort by title/name/date, reverse, limit all function
- [ ] card-list asset-list datasource: sort by title/name, reverse, limit function
- [ ] link-list child-pages datasource: sort by title/name/date, reverse, limit function
- [ ] tag-search datasources: new dialog fields render correctly (Java deferred)