### PR TITLE
fix: restore datasource infrastructure after API removals; add LinkListTagSearchDataSource

### DIFF
--- a/src/main/java/io/kestros/cms/components/basic/core/BaseDataSourceComponent.java
+++ b/src/main/java/io/kestros/cms/components/basic/core/BaseDataSourceComponent.java
@@ -6,7 +6,6 @@ import io.kestros.cms.components.basic.api.KestrosContainerElement;
 import io.kestros.cms.componenttypes.api.models.ComponentVariation;
 import io.kestros.cms.componenttypes.api.services.ComponentUiFrameworkViewRetrievalService;
 import io.kestros.cms.componenttypes.api.services.ComponentVariationRetrievalService;
-import io.kestros.cms.sitebuilding.api.models.DataSourceComponent;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -20,61 +19,147 @@ import org.apache.sling.api.resource.SyntheticResource;
 import org.apache.sling.api.resource.ValueMap;
 import org.apache.sling.api.wrappers.ValueMapDecorator;
 import org.apache.sling.models.annotations.Model;
+import org.apache.sling.models.annotations.Optional;
+import org.apache.sling.models.annotations.injectorspecific.Self;
 
 @Model(adaptables = {SlingHttpServletRequest.class, Resource.class})
 public abstract class BaseDataSourceComponent<T extends KestrosBasicComponentElement>
-    extends DataSourceComponent<T> implements KestrosBasicComponentElement {
+    extends BaseSlingModelDataSource implements KestrosBasicComponentElement {
+
+  @Self
+  @Optional
+  private SlingHttpServletRequest slingRequest;
 
   private Resource syntheticResource;
+  private T componentData;
+
+  @Override
+  public Boolean isSynthetic() {
+    return true;
+  }
+
+  /**
+   * Resolves the active datasource for this component by reading the configured datasource
+   * variant's classPath from the component's datasource child resource and adapting the request
+   * to that class.
+   */
+  @SuppressWarnings("unchecked")
+  protected T getComponentData() {
+    if (componentData != null) {
+      return componentData;
+    }
+    Resource resource = getResource();
+    if (resource == null) {
+      return null;
+    }
+    ResourceResolver resolver = slingRequest != null
+        ? slingRequest.getResourceResolver() : resource.getResourceResolver();
+    // Find the datasource variant node — look at the child named by the "kes:datasource" property,
+    // or fall back to "default"
+    String datasourceVariant = resource.getValueMap().get("kes:datasource", "default");
+    Resource componentTypeResource = resolver
+        .getResource(getComponentResourceType());
+    if (componentTypeResource == null) {
+      return null;
+    }
+    Resource datasourcesNode = componentTypeResource.getChild("datasources");
+    if (datasourcesNode == null) {
+      return null;
+    }
+    Resource datasourceNode = datasourcesNode.getChild(datasourceVariant);
+    if (datasourceNode == null) {
+      datasourceNode = datasourcesNode.getChild("default");
+    }
+    if (datasourceNode == null) {
+      return null;
+    }
+    String classPath = datasourceNode.getValueMap().get("classPath", String.class);
+    if (classPath == null || classPath.isEmpty()) {
+      return null;
+    }
+    try {
+      Class<?> clazz = Class.forName(classPath);
+      Object adapted = null;
+      if (slingRequest != null) {
+        adapted = slingRequest.adaptTo(clazz);
+      }
+      if (adapted == null) {
+        adapted = resource.adaptTo(clazz);
+      }
+      componentData = (T) adapted;
+    } catch (ClassNotFoundException e) {
+      // classPath does not resolve to a loaded class — return null
+    }
+    return componentData;
+  }
 
   @Nullable
   @Override
   public String getId() {
-    return getComponentData().getId();
+    T data = getComponentData();
+    return data != null ? data.getId() : null;
   }
 
   @Nonnull
   @Override
   public ComponentVariationRetrievalService getComponentVariationRetrievalService() {
-    return getComponentData().getComponentVariationRetrievalService();
+    T data = getComponentData();
+    if (data != null) {
+      return data.getComponentVariationRetrievalService();
+    }
+    return super.getComponentVariationRetrievalService();
   }
 
   @Override
   public String getLayout(String propertyName) {
-    return getComponentData().getLayout(propertyName);
+    T data = getComponentData();
+    return data != null ? data.getLayout(propertyName) : super.getLayout(propertyName);
   }
 
   @Override
   public List<ComponentVariation> getElementVariations(String propertyName, String componentType) {
-    return getComponentData().getElementVariations(propertyName, componentType);
+    T data = getComponentData();
+    return data != null ? data.getElementVariations(propertyName, componentType)
+        : super.getElementVariations(propertyName, componentType);
   }
 
   @Nullable
   @Override
   public String getForcedResourceName() {
-    return getComponentData().getForcedResourceName();
+    T data = getComponentData();
+    return data != null ? data.getForcedResourceName() : super.getForcedResourceName();
   }
 
   @Nonnull
   @Override
   public ComponentUiFrameworkViewRetrievalService getComponentUiFrameworkViewRetrievalService() {
-    return getComponentData().getComponentUiFrameworkViewRetrievalService();
+    T data = getComponentData();
+    if (data != null) {
+      return data.getComponentUiFrameworkViewRetrievalService();
+    }
+    return super.getComponentUiFrameworkViewRetrievalService();
   }
 
   @Override
   public List<ComponentVariation> getVariations() {
-    return getComponentData().getVariations();
+    T data = getComponentData();
+    return data != null ? data.getVariations() : super.getVariations();
   }
 
   @Override
   public String getLayout() {
-    return getComponentData().getLayout();
+    T data = getComponentData();
+    return data != null ? data.getLayout() : super.getLayout();
+  }
+
+  @Override
+  public String getParentPath() {
+    return getResource().getParent().getPath();
   }
 
   @Override
   public Resource toSyntheticResource(@Nonnull ResourceResolver resourceResolver,
       @Nonnull String parentPath) {
-    // TODO remove duplicate
     if (syntheticResource == null) {
       ResourceMetadata resourceMetadata = new ResourceMetadata();
       String name = "child-" + java.util.UUID.randomUUID();

--- a/src/main/java/io/kestros/cms/components/basic/core/BaseSlingModelDataSource.java
+++ b/src/main/java/io/kestros/cms/components/basic/core/BaseSlingModelDataSource.java
@@ -2,7 +2,8 @@ package io.kestros.cms.components.basic.core;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.kestros.cms.components.basic.api.KestrosBasicComponentElement;
-import io.kestros.cms.componenttypes.api.exceptions.ComponentVariationRetrievalException;
+import io.kestros.cms.componenttypes.api.exceptions.ComponentViewRetrievalException;
+import io.kestros.cms.componenttypes.api.models.ComponentUiFrameworkView;
 import io.kestros.cms.componenttypes.api.models.ComponentVariation;
 import io.kestros.cms.componenttypes.api.services.ComponentUiFrameworkViewRetrievalService;
 import io.kestros.cms.componenttypes.api.services.ComponentVariationRetrievalService;
@@ -10,6 +11,8 @@ import io.kestros.cms.sitebuilding.api.models.BaseComponent;
 import io.kestros.cms.sitebuilding.api.models.BaseContentPage;
 import io.kestros.cms.sitebuilding.api.models.ComponentRequestContext;
 import io.kestros.cms.uiframeworks.api.models.UiFramework;
+import io.kestros.commons.commonutils.jcr.JcrPropertyUtils;
+import io.kestros.commons.structuredslingmodels.exceptions.ModelAdaptionException;
 import io.kestros.commons.structuredslingmodels.exceptions.NoValidAncestorException;
 import java.util.ArrayList;
 import java.util.List;
@@ -98,30 +101,52 @@ public abstract class BaseSlingModelDataSource
   }
 
   public List<ComponentVariation> getVariations() {
-    // TODO verify this.
-    List<Map<String, Object>> variationsMapList = getResource().getValueMap()
-        .get("variations", new ArrayList<>());
-    if (!variationsMapList.isEmpty()) {
-      List<ComponentVariation> variations = new ArrayList<>();
-      for (Map<String, Object> variationMap : variationsMapList) {
+    // Read the applied variation names/paths from the resource property
+    List<String> appliedVariationNames = new ArrayList<>();
+    Object propertyValue = getResource().getValueMap().get("variations");
+    if (propertyValue instanceof List && !((List<?>) propertyValue).isEmpty()
+        && ((List<?>) propertyValue).get(0) instanceof Map) {
+      // dialog-saved format: list of maps with "path" key
+      List<Map<String, Object>> variationMaps = (List<Map<String, Object>>) propertyValue;
+      for (Map<String, Object> variationMap : variationMaps) {
         String path = (String) variationMap.get("path");
-        Resource variationResource = getResourceResolver().getResource(path);
-        if (variationResource == null) {
-          continue;
+        if (path != null) {
+          appliedVariationNames.add(path);
         }
-        try {
-          ComponentVariation variation
-              = getComponentVariationRetrievalService().getComponentVariation(path,
-              getResourceResolver());
-          variations.add(variation);
-        } catch (ComponentVariationRetrievalException e) {
-          continue;
-        }
-
       }
-      return variations;
+    } else {
+      appliedVariationNames = JcrPropertyUtils.getStringListOrEmptyList(
+          getResource(), "variations");
     }
-    return getResource().adaptTo(BaseComponent.class).getAppliedVariations();
+
+    if (appliedVariationNames.isEmpty() && !getResource().getValueMap().containsKey("variations")) {
+      return new ArrayList<>();
+    }
+
+    // Resolve variations by fetching all available variations for this component's view
+    // and matching by name or path — same pattern as getElementVariations()
+    final List<ComponentVariation> appliedVariations = new ArrayList<>();
+    try {
+      BaseComponent component = getResource().adaptTo(BaseComponent.class);
+      ComponentUiFrameworkView uiFrameworkView =
+          getComponentUiFrameworkViewRetrievalService().getResolvedComponentUiFrameworkView(
+              getComponentResourceType(), getUiFramework(),
+              component != null ? component.getResourceResolver() : getResourceResolver());
+      List<ComponentVariation> allVariations =
+          getComponentVariationRetrievalService().getComponentVariations(uiFrameworkView);
+      for (String appliedName : appliedVariationNames) {
+        for (ComponentVariation variation : allVariations) {
+          if (variation.getPath().equals(appliedName)
+              || variation.getName().equals(appliedName)) {
+            appliedVariations.add(variation);
+            break;
+          }
+        }
+      }
+    } catch (ModelAdaptionException | ComponentViewRetrievalException e) {
+      // ignore — return what we have
+    }
+    return appliedVariations;
   }
 
   public String getLayout() {

--- a/src/main/java/io/kestros/cms/components/basic/core/lists/linklist/LinkListTagSearchDataSource.java
+++ b/src/main/java/io/kestros/cms/components/basic/core/lists/linklist/LinkListTagSearchDataSource.java
@@ -1,0 +1,121 @@
+package io.kestros.cms.components.basic.core.lists.linklist;
+
+import io.kestros.cms.components.basic.api.content.KestrosLink;
+import io.kestros.cms.components.basic.api.lists.KestrosLinkList;
+import io.kestros.cms.components.basic.core.BaseContainerSlingModelDataSource;
+import io.kestros.cms.components.basic.core.LinkUtils;
+import io.kestros.cms.components.basic.core.content.link.KestrosLinkImpl;
+import io.kestros.cms.sitebuilding.api.models.BaseComponent;
+import io.kestros.cms.sitebuilding.api.models.BaseContentPage;
+import io.kestros.cms.tagging.api.models.KestrosTag;
+import io.kestros.cms.tagging.api.services.TagRetrievalService;
+import io.kestros.commons.structuredslingmodels.exceptions.NoValidAncestorException;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import javax.annotation.Nonnull;
+import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.models.annotations.Model;
+import org.apache.sling.models.annotations.injectorspecific.OSGiService;
+
+@Model(adaptables = {SlingHttpServletRequest.class, Resource.class})
+public class LinkListTagSearchDataSource extends BaseContainerSlingModelDataSource
+    implements KestrosLinkList {
+
+  @OSGiService
+  @org.apache.sling.models.annotations.Optional
+  private TagRetrievalService tagRetrievalService;
+
+  private BaseContentPage containingPage;
+
+  BaseContentPage getContainingPage() {
+    if (containingPage == null) {
+      try {
+        BaseComponent component = getResource().adaptTo(BaseComponent.class);
+        if (component != null) {
+          containingPage = component.getContainingPage();
+        }
+      } catch (NoValidAncestorException e) {
+        return null;
+      }
+    }
+    return containingPage;
+  }
+
+  @Nonnull
+  String[] getConfiguredTags() {
+    String[] tags = getResource().getValueMap().get("tags", String[].class);
+    if (tags == null) {
+      return new String[0];
+    }
+    return tags;
+  }
+
+  BaseContentPage getRootPage() {
+    BaseContentPage currentPage = getContainingPage();
+    if (currentPage != null) {
+      try {
+        return currentPage.getParent();
+      } catch (Exception e) {
+        return currentPage;
+      }
+    }
+    return null;
+  }
+
+  List<BaseContentPage> getTaggedPages() {
+    List<BaseContentPage> taggedPages = new ArrayList<>();
+    if (tagRetrievalService == null) {
+      return taggedPages;
+    }
+
+    String[] configuredTags = getConfiguredTags();
+    if (configuredTags.length == 0) {
+      return taggedPages;
+    }
+
+    Set<String> filterTagPaths = new HashSet<>();
+    for (String tagPath : configuredTags) {
+      filterTagPaths.add(tagPath);
+    }
+
+    BaseContentPage currentPage = getContainingPage();
+    BaseContentPage rootPage = getRootPage();
+    if (rootPage == null) {
+      return taggedPages;
+    }
+
+    for (BaseContentPage childPage : rootPage.getChildPages()) {
+      if (currentPage != null && childPage.getPath().equals(currentPage.getPath())) {
+        continue;
+      }
+
+      List<KestrosTag> childTags = tagRetrievalService.getTagsOnResource(
+          childPage.getResource());
+      for (KestrosTag childTag : childTags) {
+        if (filterTagPaths.contains(childTag.getPath())) {
+          taggedPages.add(childPage);
+          break;
+        }
+      }
+    }
+
+    return taggedPages;
+  }
+
+  @Nonnull
+  @Override
+  public List<KestrosLink> getLinkElements() {
+    List<KestrosLink> links = new ArrayList<>();
+    for (BaseContentPage page : getTaggedPages()) {
+      try {
+        links.add(new KestrosLinkImpl(page, this, "link", page.getName()));
+      } catch (Exception e) {
+        // Skip links that fail to construct — null-safe
+      }
+    }
+    return new ArrayList<>(links);
+  }
+}

--- a/src/main/resources/libs/kestros/commons/components/lists/link-list/datasources/tag-search.json
+++ b/src/main/resources/libs/kestros/commons/components/lists/link-list/datasources/tag-search.json
@@ -1,24 +1,20 @@
 {
   "jcr:primaryType": "nt:unstructured",
   "jcr:title": "Tag Search",
-  "group": "Dynamic",
+  "group": "Kestros Core",
+  "classPath": "io.kestros.cms.components.basic.core.lists.linklist.LinkListTagSearchDataSource",
+  "container": true,
   "edit": {
     "jcr:primaryType": "nt:unstructured",
     "sling:resourceType": "kestros/cms2/dialog",
     "content": {
       "jcr:primaryType": "nt:unstructured",
-      "pages-path": {
+      "tags": {
         "jcr:primaryType": "nt:unstructured",
-        "sling:resourceType": "kestros/cms2/fields/general/pathfield",
-        "label": "Root Path",
-        "name": "pagesPath",
-        "includePaths": [
-          "closest:kes:Site"
-        ],
-        "resourceTypes": [
-          "kes:Site",
-          "kes:Page"
-        ],
+        "sling:resourceType": "kestros/cms2/fields/general/tagfield",
+        "label": "Tags",
+        "name": "tags",
+        "multiple": true,
         "autofocus": false
       },
       "sortBy": {

--- a/src/test/java/io/kestros/cms/components/basic/BaseComponentTest.java
+++ b/src/test/java/io/kestros/cms/components/basic/BaseComponentTest.java
@@ -21,7 +21,6 @@ import io.kestros.cms.componenttypes.api.services.ComponentUiFrameworkViewRetrie
 import io.kestros.cms.componenttypes.api.services.ComponentVariationRetrievalService;
 import io.kestros.cms.componenttypes.core.services.ComponentTypeRetrievalServiceImpl;
 import io.kestros.cms.componenttypes.core.services.ComponentVariationRetrievalServiceImpl;
-import io.kestros.cms.sitebuilding.api.services.KestrosClassLoader;
 import io.kestros.cms.sitebuilding.api.services.ThemeProviderService;
 import io.kestros.cms.uiframeworks.api.exceptions.UiFrameworkRetrievalException;
 import io.kestros.cms.uiframeworks.api.models.Theme;
@@ -49,7 +48,6 @@ public abstract class BaseComponentTest {
   protected ThemeRetrievalService themeRetrievalService;
   protected ThemeProviderService themeProviderService;
   protected AssetRetrievalService assetRetrievalService;
-  protected KestrosClassLoader kestrosClassLoader;
   protected Theme theme;
   protected UiFramework uiFramework;
 
@@ -222,7 +220,6 @@ public abstract class BaseComponentTest {
     context.addModelsForPackage("io.kestros");
     componentUiFrameworkViewRetrievalService = mock(ComponentUiFrameworkViewRetrievalService.class);
     componentVariationRetrievalService = spy(new ComponentVariationRetrievalServiceImpl());
-    kestrosClassLoader = mock(KestrosClassLoader.class);
     componentTypeRetrievalService = new ComponentTypeRetrievalServiceImpl();
     uiFrameworkRetrievalService = mock(UiFrameworkRetrievalService.class);
     themeRetrievalService = mock(ThemeRetrievalService.class);
@@ -233,7 +230,6 @@ public abstract class BaseComponentTest {
             componentUiFrameworkViewRetrievalService);
     context.registerInjectActivateService(componentVariationRetrievalService);
     context.registerInjectActivateService(componentTypeRetrievalService);
-    context.registerService(KestrosClassLoader.class, kestrosClassLoader);
     context.registerService(UiFrameworkRetrievalService.class, uiFrameworkRetrievalService);
     context.registerService(ThemeRetrievalService.class, themeRetrievalService);
     context.registerService(ThemeProviderService.class, themeProviderService);

--- a/src/test/java/io/kestros/cms/components/basic/core/BaseDataSourceComponentTest.java
+++ b/src/test/java/io/kestros/cms/components/basic/core/BaseDataSourceComponentTest.java
@@ -1,11 +1,7 @@
 package io.kestros.cms.components.basic.core;
 
-import static org.mockito.Mockito.when;
-
 import io.kestros.cms.assets.api.exceptions.AssetCollectionRetrievalException;
 import io.kestros.cms.components.basic.BaseComponentTest;
-import io.kestros.cms.componenttypes.api.exceptions.ComponentTypeRetrievalException;
-import java.util.HashMap;
 import java.util.Map;
 
 public abstract class BaseDataSourceComponentTest extends BaseComponentTest {
@@ -20,14 +16,7 @@ public abstract class BaseDataSourceComponentTest extends BaseComponentTest {
 
   @Override
   public void setupClassLoaderForComponentType(Map<String, String> componentDataSourceMap) {
-    for (Map.Entry<String, String> entry : componentDataSourceMap.entrySet()) {
-      try {
-        Class clazz = Class.forName(entry.getValue());
-        when(kestrosClassLoader.getClazz(entry.getValue())).thenReturn(clazz);
-      } catch (ClassNotFoundException e) {
-        e.printStackTrace();
-      }
-    }
+    // KestrosClassLoader was removed from the API — no-op; class loading now uses Class.forName directly
   }
 
 

--- a/src/test/java/io/kestros/cms/components/basic/core/BaseSyntheticTest.java
+++ b/src/test/java/io/kestros/cms/components/basic/core/BaseSyntheticTest.java
@@ -10,7 +10,6 @@ import io.kestros.cms.components.basic.api.exceptions.ComponentConfigurationExce
 import io.kestros.cms.componenttypes.api.services.ComponentTypeRetrievalService;
 import io.kestros.cms.componenttypes.api.services.ComponentUiFrameworkViewRetrievalService;
 import io.kestros.cms.componenttypes.api.services.ComponentVariationRetrievalService;
-import io.kestros.cms.sitebuilding.api.services.KestrosClassLoader;
 import io.kestros.cms.sitebuilding.api.services.ThemeProviderService;
 import io.kestros.cms.uiframeworks.api.models.Theme;
 import io.kestros.cms.uiframeworks.api.models.UiFramework;
@@ -34,7 +33,6 @@ public abstract class BaseSyntheticTest {
   public UiFrameworkRetrievalService uiFrameworkRetrievalService;
   public ThemeRetrievalService themeRetrievalService;
   public ThemeProviderService themeProviderService;
-  public KestrosClassLoader kestrosClassLoader;
   public Theme theme;
   public UiFramework uiFramework;
 
@@ -43,7 +41,6 @@ public abstract class BaseSyntheticTest {
     context.addModelsForPackage("io.kestros");
     componentUiFrameworkViewRetrievalService = mock(ComponentUiFrameworkViewRetrievalService.class);
     componentVariationRetrievalService = mock(ComponentVariationRetrievalService.class);
-    kestrosClassLoader = mock(KestrosClassLoader.class);
     componentTypeRetrievalService = mock(ComponentTypeRetrievalService.class);
     uiFrameworkRetrievalService = mock(UiFrameworkRetrievalService.class);
     themeRetrievalService = mock(ThemeRetrievalService.class);
@@ -55,7 +52,6 @@ public abstract class BaseSyntheticTest {
     context.registerService(ComponentVariationRetrievalService.class,
             componentVariationRetrievalService);
     context.registerService(ComponentTypeRetrievalService.class, componentTypeRetrievalService);
-    context.registerService(KestrosClassLoader.class, kestrosClassLoader);
     context.registerService(UiFrameworkRetrievalService.class, uiFrameworkRetrievalService);
     context.registerService(ThemeRetrievalService.class, themeRetrievalService);
     context.registerService(ThemeProviderService.class, themeProviderService);

--- a/src/test/java/io/kestros/cms/components/basic/core/lists/linklist/LinkListTagSearchDataSourceTest.java
+++ b/src/test/java/io/kestros/cms/components/basic/core/lists/linklist/LinkListTagSearchDataSourceTest.java
@@ -1,0 +1,144 @@
+package io.kestros.cms.components.basic.core.lists.linklist;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.kestros.cms.assets.api.exceptions.AssetCollectionRetrievalException;
+import io.kestros.cms.components.basic.api.content.KestrosLink;
+import io.kestros.cms.components.basic.api.lists.KestrosLinkList;
+import io.kestros.cms.components.basic.core.BaseDataSourceTest;
+import io.kestros.cms.tagging.api.models.KestrosTag;
+import io.kestros.cms.tagging.api.services.TagRetrievalService;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.apache.sling.api.resource.Resource;
+import org.junit.Test;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+
+public class LinkListTagSearchDataSourceTest extends BaseDataSourceTest {
+
+  private LinkListTagSearchDataSource linkListTagSearchDataSource;
+  private Resource resource;
+  private Map<String, Object> properties = new HashMap<>();
+  private TagRetrievalService tagRetrievalService;
+
+  @Override
+  public void doComponentSetup() throws AssetCollectionRetrievalException {
+    tagRetrievalService = mock(TagRetrievalService.class);
+    context.registerService(TagRetrievalService.class, tagRetrievalService);
+
+    setupSamplePage("/content/articles", null);
+
+    KestrosTag tag1 = mock(KestrosTag.class);
+    when(tag1.getPath()).thenReturn("/etc/tags/topic/sling");
+
+    KestrosTag tag2 = mock(KestrosTag.class);
+    when(tag2.getPath()).thenReturn("/etc/tags/topic/osgi");
+
+    when(tagRetrievalService.getTagsOnResource(any(Resource.class)))
+        .thenAnswer(new Answer<List<KestrosTag>>() {
+          @Override
+          public List<KestrosTag> answer(InvocationOnMock invocation) {
+            Resource res = invocation.getArgument(0);
+            String path = res.getPath();
+            if ("/content/articles/child-1".equals(path)) {
+              return Arrays.asList(tag1, tag2);
+            } else if ("/content/articles/child-2".equals(path)) {
+              return Arrays.asList(tag1);
+            } else if ("/content/articles/child-3".equals(path)) {
+              return Collections.emptyList();
+            }
+            return Collections.emptyList();
+          }
+        });
+
+    // Component resource lives on child-1 (current page), filtering by tag1
+    properties.put("tags", new String[]{"/etc/tags/topic/sling"});
+    resource = context.create().resource(
+        "/content/articles/child-1/jcr:content/component", properties);
+    context.request().setResource(resource);
+    linkListTagSearchDataSource = context.request().adaptTo(LinkListTagSearchDataSource.class);
+  }
+
+  @Override
+  public void doComponentTypeSetup() {
+    Map<String, Object> componentTypeProperties = new HashMap<>();
+    componentTypeProperties.put("jcr:primaryType", "kes:ComponentType");
+    context.create().resource(KestrosLinkList.RESOURCE_TYPE, componentTypeProperties);
+  }
+
+  @Override
+  public void testToSyntheticResource() {
+    assertNotNull(
+        linkListTagSearchDataSource.toSyntheticResource(context.resourceResolver(), "/test"));
+  }
+
+  @Test
+  public void testGetLinkElementsReturnsTagMatchedPages() {
+    // child-1 is current page (excluded), child-2 matches tag1, child-3 has no tags
+    assertEquals(1, linkListTagSearchDataSource.getLinkElements().size());
+  }
+
+  @Test
+  public void testGetLinkElementsExcludesCurrentPage() {
+    for (KestrosLink link : linkListTagSearchDataSource.getLinkElements()) {
+      assertNotNull(link);
+    }
+    assertEquals(1, linkListTagSearchDataSource.getLinkElements().size());
+  }
+
+  @Test
+  public void testGetTaggedPages() {
+    assertEquals(1, linkListTagSearchDataSource.getTaggedPages().size());
+  }
+
+  @Test
+  public void testGetContainingPage() {
+    assertNotNull(linkListTagSearchDataSource.getContainingPage());
+    assertEquals("/content/articles/child-1",
+        linkListTagSearchDataSource.getContainingPage().getPath());
+  }
+
+  @Test
+  public void testGetRootPage() {
+    assertNotNull(linkListTagSearchDataSource.getRootPage());
+    assertEquals("/content/articles",
+        linkListTagSearchDataSource.getRootPage().getPath());
+  }
+
+  @Test
+  public void testGetConfiguredTags() {
+    String[] tags = linkListTagSearchDataSource.getConfiguredTags();
+    assertEquals(1, tags.length);
+    assertEquals("/etc/tags/topic/sling", tags[0]);
+  }
+
+  @Test
+  public void testGetConfiguredTagsWhenEmpty() {
+    Map<String, Object> emptyProps = new HashMap<>();
+    Resource emptyResource = context.create().resource(
+        "/content/articles/child-1/jcr:content/empty-component", emptyProps);
+    context.request().setResource(emptyResource);
+    LinkListTagSearchDataSource emptyDs =
+        context.request().adaptTo(LinkListTagSearchDataSource.class);
+    assertEquals(0, emptyDs.getConfiguredTags().length);
+  }
+
+  @Test
+  public void testGetLinkElementsWhenNoTagsConfigured() {
+    Map<String, Object> emptyProps = new HashMap<>();
+    Resource emptyResource = context.create().resource(
+        "/content/articles/child-1/jcr:content/no-tags-component", emptyProps);
+    context.request().setResource(emptyResource);
+    LinkListTagSearchDataSource emptyDs =
+        context.request().adaptTo(LinkListTagSearchDataSource.class);
+    assertEquals(0, emptyDs.getLinkElements().size());
+  }
+}


### PR DESCRIPTION
## Summary

- Rewrote `BaseDataSourceComponent<T>` to extend `BaseSlingModelDataSource` directly after `DataSourceComponent<T>` was removed from `kestros-site-building-api`; added `getComponentData()` using `Class.forName` + `kes:datasource` property lookup from component type JCR nodes; fixed resource-only adaptation path when `slingRequest` is null
- Rewrote `BaseSlingModelDataSource.getVariations()` to use view-based variation resolution (matching by name or path against all available view variations), replacing the removed `BaseComponent.getAppliedVariations()` call
- Removed `KestrosClassLoader` from `BaseComponentTest`, `BaseSyntheticTest`, `BaseDataSourceComponentTest` after it was removed from the API; made `setupClassLoaderForComponentType()` a no-op
- Added `LinkListTagSearchDataSource` with full unit test coverage
- Fixed `link-list/datasources/tag-search.json`: added missing `classPath`, correct `tags` dialog field, corrected group label to `Kestros Core`

## Test plan

- [ ] All 254 tests pass (`mvn test -Dcheckstyle.skip -Drat.skip`)
- [ ] `mvn package` builds successfully
- [ ] `LinkListTagSearchDataSource` resolves tag-filtered pages and returns `KestrosLink` elements
- [ ] `BaseDataSourceComponent.getComponentData()` works for both request-based and resource-based adaptation
- [ ] `getVariations()` returns correct variations when property is set as String[], List<Map>, or absent