### PR TITLE
fix: add GPL3 license headers to enable mvn clean verify (TASK-097)

### DIFF
--- a/hold/KestrosTab.java
+++ b/hold/KestrosTab.java
@@ -1,3 +1,20 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package io.kestros.cms.components.basic.api.structure;
 
 import io.kestros.cms.components.basic.api.KestrosBasicComponentElement;

--- a/hold/KestrosTabContent.java
+++ b/hold/KestrosTabContent.java
@@ -1,3 +1,20 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package io.kestros.cms.components.basic.api.structure;
 
 import javax.annotation.Nonnull;

--- a/hold/KestrosTabHeader.java
+++ b/hold/KestrosTabHeader.java
@@ -1,3 +1,20 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package io.kestros.cms.components.basic.api.structure;
 
 import io.kestros.cms.components.basic.api.KestrosBasicComponentElement;

--- a/hold/KestrosTabs.java
+++ b/hold/KestrosTabs.java
@@ -1,3 +1,20 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package io.kestros.cms.components.basic.api.structure;
 
 import io.kestros.cms.components.basic.api.KestrosBasicComponentElement;

--- a/hold/tabs/KestrosTabContentDataSourceComponent.java
+++ b/hold/tabs/KestrosTabContentDataSourceComponent.java
@@ -1,3 +1,20 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package io.kestros.cms.components.basic.core.structure.tabs;
 
 public class KestrosTabContentDataSourceComponent {

--- a/hold/tabs/KestrosTabContentImpl.java
+++ b/hold/tabs/KestrosTabContentImpl.java
@@ -1,3 +1,20 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package io.kestros.cms.components.basic.core.structure.tabs;
 
 import io.kestros.cms.components.basic.api.KestrosBasicComponentElement;

--- a/hold/tabs/KestrosTabHeaderDataSourceComponent.java
+++ b/hold/tabs/KestrosTabHeaderDataSourceComponent.java
@@ -1,3 +1,20 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package io.kestros.cms.components.basic.core.structure.tabs;
 
 public class KestrosTabHeaderDataSourceComponent {

--- a/hold/tabs/KestrosTabHeaderImpl.java
+++ b/hold/tabs/KestrosTabHeaderImpl.java
@@ -1,3 +1,20 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package io.kestros.cms.components.basic.core.structure.tabs;
 
 import io.kestros.cms.components.basic.api.exceptions.ComponentConfigurationException;

--- a/hold/tabs/KestrosTabImpl.java
+++ b/hold/tabs/KestrosTabImpl.java
@@ -1,3 +1,20 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package io.kestros.cms.components.basic.core.structure.tabs;
 
 import io.kestros.cms.components.basic.api.exceptions.ComponentConfigurationException;

--- a/hold/tabs/KestrosTabsImpl.java
+++ b/hold/tabs/KestrosTabsImpl.java
@@ -1,3 +1,20 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package io.kestros.cms.components.basic.core.structure.tabs;
 
 import io.kestros.cms.components.basic.api.exceptions.ComponentConfigurationException;

--- a/hold/tabs/TabStaticDataSource.java
+++ b/hold/tabs/TabStaticDataSource.java
@@ -1,3 +1,20 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package io.kestros.cms.components.basic.core.structure.tabs;
 
 import io.kestros.cms.components.basic.api.exceptions.ComponentConfigurationException;

--- a/hold/tabs/TabsDataSourceComponent.java
+++ b/hold/tabs/TabsDataSourceComponent.java
@@ -1,3 +1,20 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package io.kestros.cms.components.basic.core.structure.tabs;
 
 import io.kestros.cms.components.basic.api.structure.KestrosTab;

--- a/hold/tabs/TabsStaticDataSource.java
+++ b/hold/tabs/TabsStaticDataSource.java
@@ -1,3 +1,20 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package io.kestros.cms.components.basic.core.structure.tabs;
 
 import io.kestros.cms.components.basic.api.structure.KestrosTab;

--- a/src/main/java/io/kestros/cms/components/basic/api/KestrosBasicComponentElement.java
+++ b/src/main/java/io/kestros/cms/components/basic/api/KestrosBasicComponentElement.java
@@ -1,3 +1,20 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package io.kestros.cms.components.basic.api;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;

--- a/src/main/java/io/kestros/cms/components/basic/api/KestrosContainerElement.java
+++ b/src/main/java/io/kestros/cms/components/basic/api/KestrosContainerElement.java
@@ -1,3 +1,20 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package io.kestros.cms.components.basic.api;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;

--- a/src/main/java/io/kestros/cms/components/basic/api/content/AnchorTarget.java
+++ b/src/main/java/io/kestros/cms/components/basic/api/content/AnchorTarget.java
@@ -1,3 +1,20 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package io.kestros.cms.components.basic.api.content;
 
 import javax.annotation.Nonnull;

--- a/src/main/java/io/kestros/cms/components/basic/api/content/HeadingLevels.java
+++ b/src/main/java/io/kestros/cms/components/basic/api/content/HeadingLevels.java
@@ -1,3 +1,20 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package io.kestros.cms.components.basic.api.content;
 
 import javax.annotation.Nonnull;

--- a/src/main/java/io/kestros/cms/components/basic/api/content/KestrosAlert.java
+++ b/src/main/java/io/kestros/cms/components/basic/api/content/KestrosAlert.java
@@ -1,3 +1,20 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package io.kestros.cms.components.basic.api.content;
 
 import io.kestros.cms.components.basic.api.KestrosBasicComponentElement;

--- a/src/main/java/io/kestros/cms/components/basic/api/content/KestrosButton.java
+++ b/src/main/java/io/kestros/cms/components/basic/api/content/KestrosButton.java
@@ -1,3 +1,20 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package io.kestros.cms.components.basic.api.content;
 
 /**

--- a/src/main/java/io/kestros/cms/components/basic/api/content/KestrosButtonGroup.java
+++ b/src/main/java/io/kestros/cms/components/basic/api/content/KestrosButtonGroup.java
@@ -1,3 +1,20 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package io.kestros.cms.components.basic.api.content;
 
 import io.kestros.cms.components.basic.api.KestrosBasicComponentElement;

--- a/src/main/java/io/kestros/cms/components/basic/api/content/KestrosCard.java
+++ b/src/main/java/io/kestros/cms/components/basic/api/content/KestrosCard.java
@@ -1,3 +1,20 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package io.kestros.cms.components.basic.api.content;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;

--- a/src/main/java/io/kestros/cms/components/basic/api/content/KestrosCode.java
+++ b/src/main/java/io/kestros/cms/components/basic/api/content/KestrosCode.java
@@ -1,3 +1,20 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package io.kestros.cms.components.basic.api.content;
 
 import io.kestros.cms.components.basic.api.KestrosBasicComponentElement;

--- a/src/main/java/io/kestros/cms/components/basic/api/content/KestrosHeading.java
+++ b/src/main/java/io/kestros/cms/components/basic/api/content/KestrosHeading.java
@@ -1,3 +1,20 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package io.kestros.cms.components.basic.api.content;
 
 import io.kestros.cms.components.basic.api.KestrosBasicComponentElement;

--- a/src/main/java/io/kestros/cms/components/basic/api/content/KestrosImage.java
+++ b/src/main/java/io/kestros/cms/components/basic/api/content/KestrosImage.java
@@ -1,3 +1,20 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package io.kestros.cms.components.basic.api.content;
 
 import io.kestros.cms.components.basic.api.KestrosBasicComponentElement;

--- a/src/main/java/io/kestros/cms/components/basic/api/content/KestrosLink.java
+++ b/src/main/java/io/kestros/cms/components/basic/api/content/KestrosLink.java
@@ -1,3 +1,20 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package io.kestros.cms.components.basic.api.content;
 
 import io.kestros.cms.components.basic.api.KestrosBasicComponentElement;

--- a/src/main/java/io/kestros/cms/components/basic/api/content/KestrosRichText.java
+++ b/src/main/java/io/kestros/cms/components/basic/api/content/KestrosRichText.java
@@ -1,3 +1,20 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package io.kestros.cms.components.basic.api.content;
 
 import io.kestros.cms.components.basic.api.KestrosBasicComponentElement;

--- a/src/main/java/io/kestros/cms/components/basic/api/content/KestrosText.java
+++ b/src/main/java/io/kestros/cms/components/basic/api/content/KestrosText.java
@@ -1,3 +1,20 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package io.kestros.cms.components.basic.api.content;
 
 import io.kestros.cms.components.basic.api.KestrosBasicComponentElement;

--- a/src/main/java/io/kestros/cms/components/basic/api/content/KestrosVideo.java
+++ b/src/main/java/io/kestros/cms/components/basic/api/content/KestrosVideo.java
@@ -1,3 +1,20 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package io.kestros.cms.components.basic.api.content;
 
 import io.kestros.cms.components.basic.api.KestrosBasicComponentElement;

--- a/src/main/java/io/kestros/cms/components/basic/api/content/KestrosVideoEmbed.java
+++ b/src/main/java/io/kestros/cms/components/basic/api/content/KestrosVideoEmbed.java
@@ -1,3 +1,20 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package io.kestros.cms.components.basic.api.content;
 
 import io.kestros.cms.components.basic.api.KestrosBasicComponentElement;

--- a/src/main/java/io/kestros/cms/components/basic/api/content/TextElementType.java
+++ b/src/main/java/io/kestros/cms/components/basic/api/content/TextElementType.java
@@ -1,3 +1,20 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package io.kestros.cms.components.basic.api.content;
 
 public enum TextElementType {

--- a/src/main/java/io/kestros/cms/components/basic/api/exceptions/ComponentConfigurationException.java
+++ b/src/main/java/io/kestros/cms/components/basic/api/exceptions/ComponentConfigurationException.java
@@ -1,3 +1,20 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package io.kestros.cms.components.basic.api.exceptions;
 
 public class ComponentConfigurationException extends Exception {

--- a/src/main/java/io/kestros/cms/components/basic/api/lists/KestrosCardList.java
+++ b/src/main/java/io/kestros/cms/components/basic/api/lists/KestrosCardList.java
@@ -1,3 +1,20 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package io.kestros.cms.components.basic.api.lists;
 
 import io.kestros.cms.components.basic.api.KestrosBasicComponentElement;

--- a/src/main/java/io/kestros/cms/components/basic/api/lists/KestrosLinkList.java
+++ b/src/main/java/io/kestros/cms/components/basic/api/lists/KestrosLinkList.java
@@ -1,3 +1,20 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package io.kestros.cms.components.basic.api.lists;
 
 import io.kestros.cms.components.basic.api.KestrosBasicComponentElement;

--- a/src/main/java/io/kestros/cms/components/basic/api/navigation/KestrosBreadCrumb.java
+++ b/src/main/java/io/kestros/cms/components/basic/api/navigation/KestrosBreadCrumb.java
@@ -1,3 +1,20 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package io.kestros.cms.components.basic.api.navigation;
 
 import io.kestros.cms.components.basic.api.content.KestrosLink;

--- a/src/main/java/io/kestros/cms/components/basic/api/navigation/KestrosBreadCrumbs.java
+++ b/src/main/java/io/kestros/cms/components/basic/api/navigation/KestrosBreadCrumbs.java
@@ -1,3 +1,20 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package io.kestros.cms.components.basic.api.navigation;
 
 import io.kestros.cms.components.basic.api.KestrosBasicComponentElement;

--- a/src/main/java/io/kestros/cms/components/basic/api/navigation/KestrosNavigation.java
+++ b/src/main/java/io/kestros/cms/components/basic/api/navigation/KestrosNavigation.java
@@ -1,3 +1,20 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package io.kestros.cms.components.basic.api.navigation;
 
 import io.kestros.cms.components.basic.api.KestrosBasicComponentElement;

--- a/src/main/java/io/kestros/cms/components/basic/api/navigation/KestrosNavigationItem.java
+++ b/src/main/java/io/kestros/cms/components/basic/api/navigation/KestrosNavigationItem.java
@@ -1,3 +1,20 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package io.kestros.cms.components.basic.api.navigation;
 
 import io.kestros.cms.components.basic.api.KestrosBasicComponentElement;

--- a/src/main/java/io/kestros/cms/components/basic/api/navigation/KestrosTopNavigation.java
+++ b/src/main/java/io/kestros/cms/components/basic/api/navigation/KestrosTopNavigation.java
@@ -1,3 +1,20 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package io.kestros.cms.components.basic.api.navigation;
 
 import io.kestros.cms.components.basic.api.KestrosBasicComponentElement;

--- a/src/main/java/io/kestros/cms/components/basic/api/navigation/KestrosTopNavigationItem.java
+++ b/src/main/java/io/kestros/cms/components/basic/api/navigation/KestrosTopNavigationItem.java
@@ -1,3 +1,20 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package io.kestros.cms.components.basic.api.navigation;
 
 import io.kestros.cms.components.basic.api.KestrosBasicComponentElement;

--- a/src/main/java/io/kestros/cms/components/basic/api/structure/KestrosAccordion.java
+++ b/src/main/java/io/kestros/cms/components/basic/api/structure/KestrosAccordion.java
@@ -1,3 +1,20 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package io.kestros.cms.components.basic.api.structure;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;

--- a/src/main/java/io/kestros/cms/components/basic/api/structure/KestrosAccordionPanel.java
+++ b/src/main/java/io/kestros/cms/components/basic/api/structure/KestrosAccordionPanel.java
@@ -1,3 +1,20 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package io.kestros.cms.components.basic.api.structure;
 
 import io.kestros.cms.components.basic.api.KestrosBasicComponentElement;

--- a/src/main/java/io/kestros/cms/components/basic/api/structure/KestrosContainer.java
+++ b/src/main/java/io/kestros/cms/components/basic/api/structure/KestrosContainer.java
@@ -1,3 +1,20 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package io.kestros.cms.components.basic.api.structure;
 
 import io.kestros.cms.components.basic.api.KestrosContainerElement;

--- a/src/main/java/io/kestros/cms/components/basic/api/structure/KestrosGrid.java
+++ b/src/main/java/io/kestros/cms/components/basic/api/structure/KestrosGrid.java
@@ -1,3 +1,20 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package io.kestros.cms.components.basic.api.structure;
 
 import io.kestros.cms.components.basic.api.KestrosBasicComponentElement;

--- a/src/main/java/io/kestros/cms/components/basic/api/structure/KestrosSection.java
+++ b/src/main/java/io/kestros/cms/components/basic/api/structure/KestrosSection.java
@@ -1,3 +1,20 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package io.kestros.cms.components.basic.api.structure;
 
 import javax.annotation.Nullable;

--- a/src/main/java/io/kestros/cms/components/basic/api/table/KestrosTable.java
+++ b/src/main/java/io/kestros/cms/components/basic/api/table/KestrosTable.java
@@ -1,3 +1,20 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package io.kestros.cms.components.basic.api.table;
 
 import io.kestros.cms.components.basic.api.KestrosBasicComponentElement;

--- a/src/main/java/io/kestros/cms/components/basic/api/table/KestrosTableCell.java
+++ b/src/main/java/io/kestros/cms/components/basic/api/table/KestrosTableCell.java
@@ -1,3 +1,20 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package io.kestros.cms.components.basic.api.table;
 
 import io.kestros.cms.components.basic.api.KestrosBasicComponentElement;

--- a/src/main/java/io/kestros/cms/components/basic/api/table/KestrosTableHeader.java
+++ b/src/main/java/io/kestros/cms/components/basic/api/table/KestrosTableHeader.java
@@ -1,3 +1,20 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package io.kestros.cms.components.basic.api.table;
 
 import io.kestros.cms.components.basic.api.KestrosBasicComponentElement;

--- a/src/main/java/io/kestros/cms/components/basic/api/table/KestrosTableRow.java
+++ b/src/main/java/io/kestros/cms/components/basic/api/table/KestrosTableRow.java
@@ -1,3 +1,20 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package io.kestros.cms.components.basic.api.table;
 
 import io.kestros.cms.components.basic.api.KestrosBasicComponentElement;

--- a/src/main/java/io/kestros/cms/components/basic/core/BaseComponentElement.java
+++ b/src/main/java/io/kestros/cms/components/basic/core/BaseComponentElement.java
@@ -1,3 +1,20 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package io.kestros.cms.components.basic.core;
 
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/src/main/java/io/kestros/cms/components/basic/core/BaseComponentSlingModel.java
+++ b/src/main/java/io/kestros/cms/components/basic/core/BaseComponentSlingModel.java
@@ -1,3 +1,20 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package io.kestros.cms.components.basic.core;
 
 import io.kestros.cms.components.basic.api.KestrosBasicComponentElement;

--- a/src/main/java/io/kestros/cms/components/basic/core/BaseContainerDataSourceComponent.java
+++ b/src/main/java/io/kestros/cms/components/basic/core/BaseContainerDataSourceComponent.java
@@ -1,3 +1,20 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package io.kestros.cms.components.basic.core;
 
 import io.kestros.cms.components.basic.api.KestrosBasicComponentElement;

--- a/src/main/java/io/kestros/cms/components/basic/core/BaseContainerSlingModelDataSource.java
+++ b/src/main/java/io/kestros/cms/components/basic/core/BaseContainerSlingModelDataSource.java
@@ -1,3 +1,20 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package io.kestros.cms.components.basic.core;
 
 import io.kestros.cms.components.basic.api.KestrosBasicComponentElement;

--- a/src/main/java/io/kestros/cms/components/basic/core/BaseContainerSyntheticResource.java
+++ b/src/main/java/io/kestros/cms/components/basic/core/BaseContainerSyntheticResource.java
@@ -1,3 +1,20 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package io.kestros.cms.components.basic.core;
 
 import io.kestros.cms.components.basic.api.KestrosBasicComponentElement;

--- a/src/main/java/io/kestros/cms/components/basic/core/BaseDataSourceComponent.java
+++ b/src/main/java/io/kestros/cms/components/basic/core/BaseDataSourceComponent.java
@@ -1,3 +1,20 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package io.kestros.cms.components.basic.core;
 
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/src/main/java/io/kestros/cms/components/basic/core/BaseSlingModelDataSource.java
+++ b/src/main/java/io/kestros/cms/components/basic/core/BaseSlingModelDataSource.java
@@ -1,3 +1,20 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package io.kestros.cms.components.basic.core;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;

--- a/src/main/java/io/kestros/cms/components/basic/core/BaseSyntheticResource.java
+++ b/src/main/java/io/kestros/cms/components/basic/core/BaseSyntheticResource.java
@@ -1,3 +1,20 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package io.kestros.cms.components.basic.core;
 
 import io.kestros.cms.components.basic.api.KestrosBasicComponentElement;

--- a/src/main/java/io/kestros/cms/components/basic/core/LinkUtils.java
+++ b/src/main/java/io/kestros/cms/components/basic/core/LinkUtils.java
@@ -1,3 +1,20 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package io.kestros.cms.components.basic.core;
 
 import javax.annotation.Nonnull;

--- a/src/main/java/io/kestros/cms/components/basic/core/SyntheticResourceWrapper.java
+++ b/src/main/java/io/kestros/cms/components/basic/core/SyntheticResourceWrapper.java
@@ -1,3 +1,20 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package io.kestros.cms.components.basic.core;
 
 import java.util.Iterator;

--- a/src/main/java/io/kestros/cms/components/basic/core/content/alert/AlertDataSourceComponent.java
+++ b/src/main/java/io/kestros/cms/components/basic/core/content/alert/AlertDataSourceComponent.java
@@ -1,3 +1,20 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package io.kestros.cms.components.basic.core.content.alert;
 
 import io.kestros.cms.components.basic.api.content.KestrosAlert;

--- a/src/main/java/io/kestros/cms/components/basic/core/content/alert/AlertStaticDataSource.java
+++ b/src/main/java/io/kestros/cms/components/basic/core/content/alert/AlertStaticDataSource.java
@@ -1,3 +1,20 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package io.kestros.cms.components.basic.core.content.alert;
 
 import io.kestros.cms.components.basic.api.content.KestrosAlert;

--- a/src/main/java/io/kestros/cms/components/basic/core/content/alert/KestrosAlertImpl.java
+++ b/src/main/java/io/kestros/cms/components/basic/core/content/alert/KestrosAlertImpl.java
@@ -1,3 +1,20 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package io.kestros.cms.components.basic.core.content.alert;
 
 import io.kestros.cms.components.basic.api.content.KestrosAlert;

--- a/src/main/java/io/kestros/cms/components/basic/core/content/alert/validation/AlertMessageValidatorBundle.java
+++ b/src/main/java/io/kestros/cms/components/basic/core/content/alert/validation/AlertMessageValidatorBundle.java
@@ -1,3 +1,20 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package io.kestros.cms.components.basic.core.content.alert.validation;
 
 @Deprecated

--- a/src/main/java/io/kestros/cms/components/basic/core/content/button/ButtonDataSourceComponent.java
+++ b/src/main/java/io/kestros/cms/components/basic/core/content/button/ButtonDataSourceComponent.java
@@ -1,3 +1,20 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package io.kestros.cms.components.basic.core.content.button;
 
 import io.kestros.cms.components.basic.api.content.AnchorTarget;

--- a/src/main/java/io/kestros/cms/components/basic/core/content/button/ButtonStaticDataSource.java
+++ b/src/main/java/io/kestros/cms/components/basic/core/content/button/ButtonStaticDataSource.java
@@ -1,3 +1,20 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package io.kestros.cms.components.basic.core.content.button;
 
 import io.kestros.cms.components.basic.api.content.AnchorTarget;

--- a/src/main/java/io/kestros/cms/components/basic/core/content/button/KestrosButtonImpl.java
+++ b/src/main/java/io/kestros/cms/components/basic/core/content/button/KestrosButtonImpl.java
@@ -1,3 +1,20 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package io.kestros.cms.components.basic.core.content.button;
 
 import io.kestros.cms.components.basic.api.content.AnchorTarget;

--- a/src/main/java/io/kestros/cms/components/basic/core/content/buttongroup/ButtonGroupDataSourceComponent.java
+++ b/src/main/java/io/kestros/cms/components/basic/core/content/buttongroup/ButtonGroupDataSourceComponent.java
@@ -1,3 +1,20 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package io.kestros.cms.components.basic.core.content.buttongroup;
 
 import io.kestros.cms.components.basic.api.content.KestrosButton;

--- a/src/main/java/io/kestros/cms/components/basic/core/content/buttongroup/ButtonGroupStaticDataSource.java
+++ b/src/main/java/io/kestros/cms/components/basic/core/content/buttongroup/ButtonGroupStaticDataSource.java
@@ -1,3 +1,20 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package io.kestros.cms.components.basic.core.content.buttongroup;
 
 import io.kestros.cms.components.basic.api.content.KestrosButton;

--- a/src/main/java/io/kestros/cms/components/basic/core/content/buttongroup/KestrosButtonGroupImpl.java
+++ b/src/main/java/io/kestros/cms/components/basic/core/content/buttongroup/KestrosButtonGroupImpl.java
@@ -1,3 +1,20 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package io.kestros.cms.components.basic.core.content.buttongroup;
 
 import io.kestros.cms.components.basic.api.content.KestrosButton;

--- a/src/main/java/io/kestros/cms/components/basic/core/content/card/CardAssetDataSource.java
+++ b/src/main/java/io/kestros/cms/components/basic/core/content/card/CardAssetDataSource.java
@@ -1,3 +1,20 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package io.kestros.cms.components.basic.core.content.card;
 
 import io.kestros.cms.assets.api.exceptions.AssetRetrievalException;

--- a/src/main/java/io/kestros/cms/components/basic/core/content/card/CardDataSourceComponent.java
+++ b/src/main/java/io/kestros/cms/components/basic/core/content/card/CardDataSourceComponent.java
@@ -1,3 +1,20 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package io.kestros.cms.components.basic.core.content.card;
 
 import io.kestros.cms.components.basic.api.KestrosBasicComponentElement;

--- a/src/main/java/io/kestros/cms/components/basic/core/content/card/CardPageDataSource.java
+++ b/src/main/java/io/kestros/cms/components/basic/core/content/card/CardPageDataSource.java
@@ -1,3 +1,20 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package io.kestros.cms.components.basic.core.content.card;
 
 import io.kestros.cms.assets.api.services.AssetRetrievalService;

--- a/src/main/java/io/kestros/cms/components/basic/core/content/card/CardStaticDataSource.java
+++ b/src/main/java/io/kestros/cms/components/basic/core/content/card/CardStaticDataSource.java
@@ -1,3 +1,20 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package io.kestros.cms.components.basic.core.content.card;
 
 import io.kestros.cms.assets.api.services.AssetRetrievalService;

--- a/src/main/java/io/kestros/cms/components/basic/core/content/card/KestrosCardImpl.java
+++ b/src/main/java/io/kestros/cms/components/basic/core/content/card/KestrosCardImpl.java
@@ -1,3 +1,20 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package io.kestros.cms.components.basic.core.content.card;
 
 import io.kestros.cms.assets.api.services.AssetRetrievalService;

--- a/src/main/java/io/kestros/cms/components/basic/core/content/code/CodeDataSourceComponent.java
+++ b/src/main/java/io/kestros/cms/components/basic/core/content/code/CodeDataSourceComponent.java
@@ -1,3 +1,20 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package io.kestros.cms.components.basic.core.content.code;
 
 import io.kestros.cms.components.basic.api.content.KestrosCode;

--- a/src/main/java/io/kestros/cms/components/basic/core/content/code/KestrosCodeImpl.java
+++ b/src/main/java/io/kestros/cms/components/basic/core/content/code/KestrosCodeImpl.java
@@ -1,3 +1,20 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package io.kestros.cms.components.basic.core.content.code;
 
 import io.kestros.cms.components.basic.api.content.KestrosCode;

--- a/src/main/java/io/kestros/cms/components/basic/core/content/code/KestrosCodeStaticDataSource.java
+++ b/src/main/java/io/kestros/cms/components/basic/core/content/code/KestrosCodeStaticDataSource.java
@@ -1,3 +1,20 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package io.kestros.cms.components.basic.core.content.code;
 
 import io.kestros.cms.components.basic.api.content.KestrosCode;

--- a/src/main/java/io/kestros/cms/components/basic/core/content/heading/HeadingDataSourceComponent.java
+++ b/src/main/java/io/kestros/cms/components/basic/core/content/heading/HeadingDataSourceComponent.java
@@ -1,3 +1,20 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package io.kestros.cms.components.basic.core.content.heading;
 
 import io.kestros.cms.components.basic.api.content.KestrosHeading;

--- a/src/main/java/io/kestros/cms/components/basic/core/content/heading/HeadingPageTitleDataSource.java
+++ b/src/main/java/io/kestros/cms/components/basic/core/content/heading/HeadingPageTitleDataSource.java
@@ -1,3 +1,20 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package io.kestros.cms.components.basic.core.content.heading;
 
 import io.kestros.cms.components.basic.api.content.KestrosHeading;

--- a/src/main/java/io/kestros/cms/components/basic/core/content/heading/HeadingStaticDataSource.java
+++ b/src/main/java/io/kestros/cms/components/basic/core/content/heading/HeadingStaticDataSource.java
@@ -1,3 +1,20 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package io.kestros.cms.components.basic.core.content.heading;
 
 import io.kestros.cms.components.basic.api.content.KestrosHeading;

--- a/src/main/java/io/kestros/cms/components/basic/core/content/heading/KestrosHeadingImpl.java
+++ b/src/main/java/io/kestros/cms/components/basic/core/content/heading/KestrosHeadingImpl.java
@@ -1,3 +1,20 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package io.kestros.cms.components.basic.core.content.heading;
 
 import io.kestros.cms.components.basic.api.content.KestrosHeading;

--- a/src/main/java/io/kestros/cms/components/basic/core/content/image/ImageAssetDataSource.java
+++ b/src/main/java/io/kestros/cms/components/basic/core/content/image/ImageAssetDataSource.java
@@ -1,3 +1,20 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package io.kestros.cms.components.basic.core.content.image;
 
 import io.kestros.cms.assets.api.exceptions.AssetRetrievalException;

--- a/src/main/java/io/kestros/cms/components/basic/core/content/image/ImageDataSourceComponent.java
+++ b/src/main/java/io/kestros/cms/components/basic/core/content/image/ImageDataSourceComponent.java
@@ -1,3 +1,20 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package io.kestros.cms.components.basic.core.content.image;
 
 import io.kestros.cms.components.basic.api.content.AnchorTarget;

--- a/src/main/java/io/kestros/cms/components/basic/core/content/image/ImageStaticDataSource.java
+++ b/src/main/java/io/kestros/cms/components/basic/core/content/image/ImageStaticDataSource.java
@@ -1,3 +1,20 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package io.kestros.cms.components.basic.core.content.image;
 
 import io.kestros.cms.assets.api.exceptions.AssetRetrievalException;

--- a/src/main/java/io/kestros/cms/components/basic/core/content/image/KestrosImageImpl.java
+++ b/src/main/java/io/kestros/cms/components/basic/core/content/image/KestrosImageImpl.java
@@ -1,3 +1,20 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package io.kestros.cms.components.basic.core.content.image;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;

--- a/src/main/java/io/kestros/cms/components/basic/core/content/link/KestrosLinkImpl.java
+++ b/src/main/java/io/kestros/cms/components/basic/core/content/link/KestrosLinkImpl.java
@@ -1,3 +1,20 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package io.kestros.cms.components.basic.core.content.link;
 
 import io.kestros.cms.components.basic.api.content.AnchorTarget;

--- a/src/main/java/io/kestros/cms/components/basic/core/content/link/LinkDataSourceComponent.java
+++ b/src/main/java/io/kestros/cms/components/basic/core/content/link/LinkDataSourceComponent.java
@@ -1,3 +1,20 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package io.kestros.cms.components.basic.core.content.link;
 
 import io.kestros.cms.components.basic.api.content.AnchorTarget;

--- a/src/main/java/io/kestros/cms/components/basic/core/content/link/LinkStaticDataSource.java
+++ b/src/main/java/io/kestros/cms/components/basic/core/content/link/LinkStaticDataSource.java
@@ -1,3 +1,20 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package io.kestros.cms.components.basic.core.content.link;
 
 import io.kestros.cms.components.basic.api.content.AnchorTarget;

--- a/src/main/java/io/kestros/cms/components/basic/core/content/richtext/KestrosRichTextImpl.java
+++ b/src/main/java/io/kestros/cms/components/basic/core/content/richtext/KestrosRichTextImpl.java
@@ -1,3 +1,20 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package io.kestros.cms.components.basic.core.content.richtext;
 
 import io.kestros.cms.components.basic.api.content.KestrosRichText;

--- a/src/main/java/io/kestros/cms/components/basic/core/content/richtext/KestrosRichTextStaticDataSource.java
+++ b/src/main/java/io/kestros/cms/components/basic/core/content/richtext/KestrosRichTextStaticDataSource.java
@@ -1,3 +1,20 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package io.kestros.cms.components.basic.core.content.richtext;
 
 import io.kestros.cms.components.basic.api.content.KestrosRichText;

--- a/src/main/java/io/kestros/cms/components/basic/core/content/richtext/RichTextDataSourceComponent.java
+++ b/src/main/java/io/kestros/cms/components/basic/core/content/richtext/RichTextDataSourceComponent.java
@@ -1,3 +1,20 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package io.kestros.cms.components.basic.core.content.richtext;
 
 import io.kestros.cms.components.basic.api.content.KestrosRichText;

--- a/src/main/java/io/kestros/cms/components/basic/core/content/table/TableCellDataSourceComponent.java
+++ b/src/main/java/io/kestros/cms/components/basic/core/content/table/TableCellDataSourceComponent.java
@@ -1,3 +1,20 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package io.kestros.cms.components.basic.core.content.table;
 
 import io.kestros.cms.components.basic.api.KestrosBasicComponentElement;

--- a/src/main/java/io/kestros/cms/components/basic/core/content/table/TableCellStaticDataSource.java
+++ b/src/main/java/io/kestros/cms/components/basic/core/content/table/TableCellStaticDataSource.java
@@ -1,3 +1,20 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package io.kestros.cms.components.basic.core.content.table;
 
 import io.kestros.cms.components.basic.api.KestrosBasicComponentElement;

--- a/src/main/java/io/kestros/cms/components/basic/core/content/table/TableDataSourceComponent.java
+++ b/src/main/java/io/kestros/cms/components/basic/core/content/table/TableDataSourceComponent.java
@@ -1,3 +1,20 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package io.kestros.cms.components.basic.core.content.table;
 
 import io.kestros.cms.components.basic.api.table.KestrosTable;

--- a/src/main/java/io/kestros/cms/components/basic/core/content/table/TableHeaderDataSourceComponent.java
+++ b/src/main/java/io/kestros/cms/components/basic/core/content/table/TableHeaderDataSourceComponent.java
@@ -1,3 +1,20 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package io.kestros.cms.components.basic.core.content.table;
 
 import io.kestros.cms.components.basic.api.table.KestrosTableHeader;

--- a/src/main/java/io/kestros/cms/components/basic/core/content/table/TableHeaderStaticDataSource.java
+++ b/src/main/java/io/kestros/cms/components/basic/core/content/table/TableHeaderStaticDataSource.java
@@ -1,3 +1,20 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package io.kestros.cms.components.basic.core.content.table;
 
 import io.kestros.cms.components.basic.api.table.KestrosTableHeader;

--- a/src/main/java/io/kestros/cms/components/basic/core/content/table/TableRowDataSourceComponent.java
+++ b/src/main/java/io/kestros/cms/components/basic/core/content/table/TableRowDataSourceComponent.java
@@ -1,3 +1,20 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package io.kestros.cms.components.basic.core.content.table;
 
 import io.kestros.cms.components.basic.api.table.KestrosTableCell;

--- a/src/main/java/io/kestros/cms/components/basic/core/content/table/TableRowStaticDataSource.java
+++ b/src/main/java/io/kestros/cms/components/basic/core/content/table/TableRowStaticDataSource.java
@@ -1,3 +1,20 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package io.kestros.cms.components.basic.core.content.table;
 
 import io.kestros.cms.components.basic.api.table.KestrosTableCell;

--- a/src/main/java/io/kestros/cms/components/basic/core/content/table/TableStaticDataSource.java
+++ b/src/main/java/io/kestros/cms/components/basic/core/content/table/TableStaticDataSource.java
@@ -1,3 +1,20 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package io.kestros.cms.components.basic.core.content.table;
 
 import io.kestros.cms.components.basic.api.table.KestrosTable;

--- a/src/main/java/io/kestros/cms/components/basic/core/content/text/KestrosTextImpl.java
+++ b/src/main/java/io/kestros/cms/components/basic/core/content/text/KestrosTextImpl.java
@@ -1,3 +1,20 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package io.kestros.cms.components.basic.core.content.text;
 
 import io.kestros.cms.components.basic.api.content.KestrosText;

--- a/src/main/java/io/kestros/cms/components/basic/core/content/text/KestrosTextStaticDataSource.java
+++ b/src/main/java/io/kestros/cms/components/basic/core/content/text/KestrosTextStaticDataSource.java
@@ -1,3 +1,20 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package io.kestros.cms.components.basic.core.content.text;
 
 import io.kestros.cms.components.basic.api.content.KestrosText;

--- a/src/main/java/io/kestros/cms/components/basic/core/content/text/TextDataSourceComponent.java
+++ b/src/main/java/io/kestros/cms/components/basic/core/content/text/TextDataSourceComponent.java
@@ -1,3 +1,20 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package io.kestros.cms.components.basic.core.content.text;
 
 import io.kestros.cms.components.basic.api.content.KestrosText;

--- a/src/main/java/io/kestros/cms/components/basic/core/content/text/TextStaticDataSource.java
+++ b/src/main/java/io/kestros/cms/components/basic/core/content/text/TextStaticDataSource.java
@@ -1,3 +1,20 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package io.kestros.cms.components.basic.core.content.text;
 
 import io.kestros.cms.components.basic.api.content.KestrosText;

--- a/src/main/java/io/kestros/cms/components/basic/core/content/video/KestrosVideoImpl.java
+++ b/src/main/java/io/kestros/cms/components/basic/core/content/video/KestrosVideoImpl.java
@@ -1,3 +1,20 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package io.kestros.cms.components.basic.core.content.video;
 
 import io.kestros.cms.components.basic.api.content.KestrosVideo;

--- a/src/main/java/io/kestros/cms/components/basic/core/content/video/VideoAssetDataSource.java
+++ b/src/main/java/io/kestros/cms/components/basic/core/content/video/VideoAssetDataSource.java
@@ -1,3 +1,20 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package io.kestros.cms.components.basic.core.content.video;
 
 import io.kestros.cms.assets.api.exceptions.AssetRetrievalException;

--- a/src/main/java/io/kestros/cms/components/basic/core/content/video/VideoDataSourceComponent.java
+++ b/src/main/java/io/kestros/cms/components/basic/core/content/video/VideoDataSourceComponent.java
@@ -1,3 +1,20 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package io.kestros.cms.components.basic.core.content.video;
 
 import io.kestros.cms.components.basic.api.content.KestrosVideo;

--- a/src/main/java/io/kestros/cms/components/basic/core/content/video/VideoStaticDataSource.java
+++ b/src/main/java/io/kestros/cms/components/basic/core/content/video/VideoStaticDataSource.java
@@ -1,3 +1,20 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package io.kestros.cms.components.basic.core.content.video;
 
 import io.kestros.cms.assets.api.exceptions.AssetRetrievalException;

--- a/src/main/java/io/kestros/cms/components/basic/core/content/videoembed/EmbedSanitizer.java
+++ b/src/main/java/io/kestros/cms/components/basic/core/content/videoembed/EmbedSanitizer.java
@@ -1,3 +1,20 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package io.kestros.cms.components.basic.core.content.videoembed;
 
 import java.util.Arrays;

--- a/src/main/java/io/kestros/cms/components/basic/core/content/videoembed/KestrosVideoEmbedImpl.java
+++ b/src/main/java/io/kestros/cms/components/basic/core/content/videoembed/KestrosVideoEmbedImpl.java
@@ -1,3 +1,20 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package io.kestros.cms.components.basic.core.content.videoembed;
 
 import io.kestros.cms.components.basic.api.content.KestrosVideoEmbed;

--- a/src/main/java/io/kestros/cms/components/basic/core/content/videoembed/VideoEmbedDataSourceComponent.java
+++ b/src/main/java/io/kestros/cms/components/basic/core/content/videoembed/VideoEmbedDataSourceComponent.java
@@ -1,3 +1,20 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package io.kestros.cms.components.basic.core.content.videoembed;
 
 import io.kestros.cms.components.basic.api.content.KestrosVideoEmbed;

--- a/src/main/java/io/kestros/cms/components/basic/core/content/videoembed/VideoEmbedYouTubeDataSource.java
+++ b/src/main/java/io/kestros/cms/components/basic/core/content/videoembed/VideoEmbedYouTubeDataSource.java
@@ -1,3 +1,20 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package io.kestros.cms.components.basic.core.content.videoembed;
 
 import io.kestros.cms.components.basic.api.content.KestrosVideoEmbed;

--- a/src/main/java/io/kestros/cms/components/basic/core/lists/cardlist/CardListAssetsDataSource.java
+++ b/src/main/java/io/kestros/cms/components/basic/core/lists/cardlist/CardListAssetsDataSource.java
@@ -1,3 +1,20 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package io.kestros.cms.components.basic.core.lists.cardlist;
 
 import io.kestros.cms.assets.api.exceptions.AssetCollectionRetrievalException;

--- a/src/main/java/io/kestros/cms/components/basic/core/lists/cardlist/CardListChildPagesDataSource.java
+++ b/src/main/java/io/kestros/cms/components/basic/core/lists/cardlist/CardListChildPagesDataSource.java
@@ -1,3 +1,20 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package io.kestros.cms.components.basic.core.lists.cardlist;
 
 import io.kestros.cms.components.basic.api.content.KestrosButton;

--- a/src/main/java/io/kestros/cms/components/basic/core/lists/cardlist/CardListDataSourceComponent.java
+++ b/src/main/java/io/kestros/cms/components/basic/core/lists/cardlist/CardListDataSourceComponent.java
@@ -1,3 +1,20 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package io.kestros.cms.components.basic.core.lists.cardlist;
 
 import io.kestros.cms.components.basic.api.content.KestrosCard;

--- a/src/main/java/io/kestros/cms/components/basic/core/lists/cardlist/CardListStaticDataSource.java
+++ b/src/main/java/io/kestros/cms/components/basic/core/lists/cardlist/CardListStaticDataSource.java
@@ -1,3 +1,20 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package io.kestros.cms.components.basic.core.lists.cardlist;
 
 import io.kestros.cms.components.basic.api.content.KestrosCard;

--- a/src/main/java/io/kestros/cms/components/basic/core/lists/cardlist/CardListTagSearchDataSource.java
+++ b/src/main/java/io/kestros/cms/components/basic/core/lists/cardlist/CardListTagSearchDataSource.java
@@ -1,3 +1,20 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package io.kestros.cms.components.basic.core.lists.cardlist;
 
 import io.kestros.cms.components.basic.api.content.KestrosCard;

--- a/src/main/java/io/kestros/cms/components/basic/core/lists/cardlist/KestrosCardListImpl.java
+++ b/src/main/java/io/kestros/cms/components/basic/core/lists/cardlist/KestrosCardListImpl.java
@@ -1,3 +1,20 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package io.kestros.cms.components.basic.core.lists.cardlist;
 
 import io.kestros.cms.components.basic.api.content.KestrosCard;

--- a/src/main/java/io/kestros/cms/components/basic/core/lists/linklist/KestrosLinkListImpl.java
+++ b/src/main/java/io/kestros/cms/components/basic/core/lists/linklist/KestrosLinkListImpl.java
@@ -1,3 +1,20 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package io.kestros.cms.components.basic.core.lists.linklist;
 
 import io.kestros.cms.components.basic.api.content.KestrosLink;

--- a/src/main/java/io/kestros/cms/components/basic/core/lists/linklist/LinkListChildPageDataSource.java
+++ b/src/main/java/io/kestros/cms/components/basic/core/lists/linklist/LinkListChildPageDataSource.java
@@ -1,3 +1,20 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package io.kestros.cms.components.basic.core.lists.linklist;
 
 import io.kestros.cms.components.basic.api.content.AnchorTarget;

--- a/src/main/java/io/kestros/cms/components/basic/core/lists/linklist/LinkListDataSourceComponent.java
+++ b/src/main/java/io/kestros/cms/components/basic/core/lists/linklist/LinkListDataSourceComponent.java
@@ -1,3 +1,20 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package io.kestros.cms.components.basic.core.lists.linklist;
 
 import io.kestros.cms.components.basic.api.content.KestrosLink;

--- a/src/main/java/io/kestros/cms/components/basic/core/lists/linklist/LinkListStaticDataSource.java
+++ b/src/main/java/io/kestros/cms/components/basic/core/lists/linklist/LinkListStaticDataSource.java
@@ -1,3 +1,20 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package io.kestros.cms.components.basic.core.lists.linklist;
 
 import io.kestros.cms.components.basic.api.content.KestrosLink;

--- a/src/main/java/io/kestros/cms/components/basic/core/navigation/breadcrumbs/BreadCrumbDataSourceComponent.java
+++ b/src/main/java/io/kestros/cms/components/basic/core/navigation/breadcrumbs/BreadCrumbDataSourceComponent.java
@@ -1,3 +1,20 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package io.kestros.cms.components.basic.core.navigation.breadcrumbs;
 
 import io.kestros.cms.components.basic.api.content.AnchorTarget;

--- a/src/main/java/io/kestros/cms/components/basic/core/navigation/breadcrumbs/BreadCrumbStaticDataSource.java
+++ b/src/main/java/io/kestros/cms/components/basic/core/navigation/breadcrumbs/BreadCrumbStaticDataSource.java
@@ -1,3 +1,20 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package io.kestros.cms.components.basic.core.navigation.breadcrumbs;
 
 import io.kestros.cms.components.basic.api.navigation.KestrosBreadCrumb;

--- a/src/main/java/io/kestros/cms/components/basic/core/navigation/breadcrumbs/BreadCrumbsDataSourceComponent.java
+++ b/src/main/java/io/kestros/cms/components/basic/core/navigation/breadcrumbs/BreadCrumbsDataSourceComponent.java
@@ -1,3 +1,20 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package io.kestros.cms.components.basic.core.navigation.breadcrumbs;
 
 import io.kestros.cms.components.basic.api.navigation.KestrosBreadCrumb;

--- a/src/main/java/io/kestros/cms/components/basic/core/navigation/breadcrumbs/BreadCrumbsPagePathDataSource.java
+++ b/src/main/java/io/kestros/cms/components/basic/core/navigation/breadcrumbs/BreadCrumbsPagePathDataSource.java
@@ -1,3 +1,20 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package io.kestros.cms.components.basic.core.navigation.breadcrumbs;
 
 import io.kestros.cms.components.basic.api.content.KestrosLink;

--- a/src/main/java/io/kestros/cms/components/basic/core/navigation/breadcrumbs/KestrosBreadCrumbImpl.java
+++ b/src/main/java/io/kestros/cms/components/basic/core/navigation/breadcrumbs/KestrosBreadCrumbImpl.java
@@ -1,3 +1,20 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package io.kestros.cms.components.basic.core.navigation.breadcrumbs;
 
 import io.kestros.cms.components.basic.api.content.AnchorTarget;

--- a/src/main/java/io/kestros/cms/components/basic/core/navigation/breadcrumbs/KestrosBreadCrumbsImpl.java
+++ b/src/main/java/io/kestros/cms/components/basic/core/navigation/breadcrumbs/KestrosBreadCrumbsImpl.java
@@ -1,3 +1,20 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package io.kestros.cms.components.basic.core.navigation.breadcrumbs;
 
 import io.kestros.cms.components.basic.api.exceptions.ComponentConfigurationException;

--- a/src/main/java/io/kestros/cms/components/basic/core/navigation/nav/KestrosNavigationImpl.java
+++ b/src/main/java/io/kestros/cms/components/basic/core/navigation/nav/KestrosNavigationImpl.java
@@ -1,3 +1,20 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package io.kestros.cms.components.basic.core.navigation.nav;
 
 import io.kestros.cms.components.basic.api.content.KestrosLink;

--- a/src/main/java/io/kestros/cms/components/basic/core/navigation/nav/NavigationDataSourceComponent.java
+++ b/src/main/java/io/kestros/cms/components/basic/core/navigation/nav/NavigationDataSourceComponent.java
@@ -1,3 +1,20 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package io.kestros.cms.components.basic.core.navigation.nav;
 
 import io.kestros.cms.components.basic.api.navigation.KestrosNavigation;

--- a/src/main/java/io/kestros/cms/components/basic/core/navigation/nav/NavigationItemDataSourceComponent.java
+++ b/src/main/java/io/kestros/cms/components/basic/core/navigation/nav/NavigationItemDataSourceComponent.java
@@ -1,3 +1,20 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package io.kestros.cms.components.basic.core.navigation.nav;
 
 import io.kestros.cms.components.basic.api.content.AnchorTarget;

--- a/src/main/java/io/kestros/cms/components/basic/core/navigation/nav/NavigationItemStaticDataSource.java
+++ b/src/main/java/io/kestros/cms/components/basic/core/navigation/nav/NavigationItemStaticDataSource.java
@@ -1,3 +1,20 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package io.kestros.cms.components.basic.core.navigation.nav;
 
 import io.kestros.cms.components.basic.api.content.AnchorTarget;

--- a/src/main/java/io/kestros/cms/components/basic/core/navigation/nav/NavigationStaticDataSource.java
+++ b/src/main/java/io/kestros/cms/components/basic/core/navigation/nav/NavigationStaticDataSource.java
@@ -1,3 +1,20 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package io.kestros.cms.components.basic.core.navigation.nav;
 
 import io.kestros.cms.components.basic.api.content.KestrosLink;

--- a/src/main/java/io/kestros/cms/components/basic/core/navigation/topnav/KestrosTopNavigationImpl.java
+++ b/src/main/java/io/kestros/cms/components/basic/core/navigation/topnav/KestrosTopNavigationImpl.java
@@ -1,3 +1,20 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package io.kestros.cms.components.basic.core.navigation.topnav;
 
 import io.kestros.cms.components.basic.api.content.KestrosImage;

--- a/src/main/java/io/kestros/cms/components/basic/core/navigation/topnav/KestrosTopNavigationItemImpl.java
+++ b/src/main/java/io/kestros/cms/components/basic/core/navigation/topnav/KestrosTopNavigationItemImpl.java
@@ -1,3 +1,20 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package io.kestros.cms.components.basic.core.navigation.topnav;
 
 import io.kestros.cms.components.basic.api.content.AnchorTarget;

--- a/src/main/java/io/kestros/cms/components/basic/core/navigation/topnav/TopNavigationDataSourceComponent.java
+++ b/src/main/java/io/kestros/cms/components/basic/core/navigation/topnav/TopNavigationDataSourceComponent.java
@@ -1,3 +1,20 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package io.kestros.cms.components.basic.core.navigation.topnav;
 
 import io.kestros.cms.components.basic.api.content.KestrosImage;

--- a/src/main/java/io/kestros/cms/components/basic/core/navigation/topnav/TopNavigationItemDataSourceComponent.java
+++ b/src/main/java/io/kestros/cms/components/basic/core/navigation/topnav/TopNavigationItemDataSourceComponent.java
@@ -1,3 +1,20 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package io.kestros.cms.components.basic.core.navigation.topnav;
 
 import io.kestros.cms.components.basic.api.content.AnchorTarget;

--- a/src/main/java/io/kestros/cms/components/basic/core/navigation/topnav/TopNavigationItemStaticDataSource.java
+++ b/src/main/java/io/kestros/cms/components/basic/core/navigation/topnav/TopNavigationItemStaticDataSource.java
@@ -1,3 +1,20 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package io.kestros.cms.components.basic.core.navigation.topnav;
 
 import io.kestros.cms.components.basic.api.content.AnchorTarget;

--- a/src/main/java/io/kestros/cms/components/basic/core/navigation/topnav/TopNavigationStaticDataSource.java
+++ b/src/main/java/io/kestros/cms/components/basic/core/navigation/topnav/TopNavigationStaticDataSource.java
@@ -1,3 +1,20 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package io.kestros.cms.components.basic.core.navigation.topnav;
 
 import io.kestros.cms.assets.api.services.AssetRetrievalService;

--- a/src/main/java/io/kestros/cms/components/basic/core/structure/accordion/AccordionDataSourceComponent.java
+++ b/src/main/java/io/kestros/cms/components/basic/core/structure/accordion/AccordionDataSourceComponent.java
@@ -1,3 +1,20 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package io.kestros.cms.components.basic.core.structure.accordion;
 
 import io.kestros.cms.components.basic.api.structure.KestrosAccordion;

--- a/src/main/java/io/kestros/cms/components/basic/core/structure/accordion/AccordionPanelDataSourceComponent.java
+++ b/src/main/java/io/kestros/cms/components/basic/core/structure/accordion/AccordionPanelDataSourceComponent.java
@@ -1,3 +1,20 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package io.kestros.cms.components.basic.core.structure.accordion;
 
 import io.kestros.cms.components.basic.api.structure.KestrosAccordionPanel;

--- a/src/main/java/io/kestros/cms/components/basic/core/structure/accordion/AccordionPanelStaticDataSource.java
+++ b/src/main/java/io/kestros/cms/components/basic/core/structure/accordion/AccordionPanelStaticDataSource.java
@@ -1,3 +1,20 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package io.kestros.cms.components.basic.core.structure.accordion;
 
 import io.kestros.cms.components.basic.api.structure.KestrosAccordionPanel;

--- a/src/main/java/io/kestros/cms/components/basic/core/structure/accordion/AccordionStaticDataSource.java
+++ b/src/main/java/io/kestros/cms/components/basic/core/structure/accordion/AccordionStaticDataSource.java
@@ -1,3 +1,20 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package io.kestros.cms.components.basic.core.structure.accordion;
 
 import io.kestros.cms.components.basic.api.structure.KestrosAccordion;

--- a/src/main/java/io/kestros/cms/components/basic/core/structure/accordion/KestrosAccordionImpl.java
+++ b/src/main/java/io/kestros/cms/components/basic/core/structure/accordion/KestrosAccordionImpl.java
@@ -1,3 +1,20 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package io.kestros.cms.components.basic.core.structure.accordion;
 
 import io.kestros.cms.components.basic.api.exceptions.ComponentConfigurationException;

--- a/src/main/java/io/kestros/cms/components/basic/core/structure/accordion/KestrosAccordionPanelImpl.java
+++ b/src/main/java/io/kestros/cms/components/basic/core/structure/accordion/KestrosAccordionPanelImpl.java
@@ -1,3 +1,20 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package io.kestros.cms.components.basic.core.structure.accordion;
 
 import io.kestros.cms.components.basic.api.exceptions.ComponentConfigurationException;

--- a/src/main/java/io/kestros/cms/components/basic/core/structure/container/ContainerDataSourceComponent.java
+++ b/src/main/java/io/kestros/cms/components/basic/core/structure/container/ContainerDataSourceComponent.java
@@ -1,3 +1,20 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package io.kestros.cms.components.basic.core.structure.container;
 
 import io.kestros.cms.components.basic.api.KestrosBasicComponentElement;

--- a/src/main/java/io/kestros/cms/components/basic/core/structure/container/ContainerStaticDataSource.java
+++ b/src/main/java/io/kestros/cms/components/basic/core/structure/container/ContainerStaticDataSource.java
@@ -1,3 +1,20 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package io.kestros.cms.components.basic.core.structure.container;
 
 import io.kestros.cms.components.basic.api.KestrosBasicComponentElement;

--- a/src/main/java/io/kestros/cms/components/basic/core/structure/container/KestrosContainerImpl.java
+++ b/src/main/java/io/kestros/cms/components/basic/core/structure/container/KestrosContainerImpl.java
@@ -1,3 +1,20 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package io.kestros.cms.components.basic.core.structure.container;
 
 import io.kestros.cms.components.basic.api.KestrosBasicComponentElement;

--- a/src/main/java/io/kestros/cms/components/basic/core/structure/grid/GridDataSourceComponent.java
+++ b/src/main/java/io/kestros/cms/components/basic/core/structure/grid/GridDataSourceComponent.java
@@ -1,3 +1,20 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package io.kestros.cms.components.basic.core.structure.grid;
 
 import io.kestros.cms.components.basic.api.structure.KestrosContainer;

--- a/src/main/java/io/kestros/cms/components/basic/core/structure/grid/GridStaticDataSource.java
+++ b/src/main/java/io/kestros/cms/components/basic/core/structure/grid/GridStaticDataSource.java
@@ -1,3 +1,20 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package io.kestros.cms.components.basic.core.structure.grid;
 
 import io.kestros.cms.components.basic.api.KestrosBasicComponentElement;

--- a/src/main/java/io/kestros/cms/components/basic/core/structure/grid/KestrosGridImpl.java
+++ b/src/main/java/io/kestros/cms/components/basic/core/structure/grid/KestrosGridImpl.java
@@ -1,3 +1,20 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package io.kestros.cms.components.basic.core.structure.grid;
 
 import io.kestros.cms.components.basic.api.exceptions.ComponentConfigurationException;

--- a/src/main/java/io/kestros/cms/components/basic/core/structure/section/KestrosSectionImpl.java
+++ b/src/main/java/io/kestros/cms/components/basic/core/structure/section/KestrosSectionImpl.java
@@ -1,3 +1,20 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package io.kestros.cms.components.basic.core.structure.section;
 
 import io.kestros.cms.components.basic.api.KestrosBasicComponentElement;

--- a/src/main/java/io/kestros/cms/components/basic/core/structure/section/SectionDataSourceComponent.java
+++ b/src/main/java/io/kestros/cms/components/basic/core/structure/section/SectionDataSourceComponent.java
@@ -1,3 +1,20 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package io.kestros.cms.components.basic.core.structure.section;
 
 import io.kestros.cms.components.basic.api.KestrosBasicComponentElement;

--- a/src/main/java/io/kestros/cms/components/basic/core/structure/section/SectionStaticDataSource.java
+++ b/src/main/java/io/kestros/cms/components/basic/core/structure/section/SectionStaticDataSource.java
@@ -1,3 +1,20 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package io.kestros.cms.components.basic.core.structure.section;
 
 import io.kestros.cms.components.basic.api.KestrosBasicComponentElement;

--- a/src/main/java/io/kestros/cms/components/basic/core/validation/ImageConfigurationValidatorBundle.java
+++ b/src/main/java/io/kestros/cms/components/basic/core/validation/ImageConfigurationValidatorBundle.java
@@ -1,3 +1,20 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package io.kestros.cms.components.basic.core.validation;
 
 public class ImageConfigurationValidatorBundle {

--- a/src/main/java/io/kestros/cms/components/basic/core/validation/ImageLinkAccessibilityPropertiesValidatorBundle.java
+++ b/src/main/java/io/kestros/cms/components/basic/core/validation/ImageLinkAccessibilityPropertiesValidatorBundle.java
@@ -1,3 +1,20 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package io.kestros.cms.components.basic.core.validation;
 
 public class ImageLinkAccessibilityPropertiesValidatorBundle {

--- a/src/main/java/io/kestros/cms/components/basic/core/validation/ImageLinkAccessibilityValidatorBundle.java
+++ b/src/main/java/io/kestros/cms/components/basic/core/validation/ImageLinkAccessibilityValidatorBundle.java
@@ -1,3 +1,20 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package io.kestros.cms.components.basic.core.validation;
 
 public class ImageLinkAccessibilityValidatorBundle {

--- a/src/main/java/io/kestros/cms/components/basic/core/validation/ImageLinkConfigurationValidatorBundle.java
+++ b/src/main/java/io/kestros/cms/components/basic/core/validation/ImageLinkConfigurationValidatorBundle.java
@@ -1,3 +1,20 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package io.kestros.cms.components.basic.core.validation;
 
 public class ImageLinkConfigurationValidatorBundle {

--- a/src/main/java/io/kestros/cms/components/basic/core/validation/ImageLinkPathValidatorBundle.java
+++ b/src/main/java/io/kestros/cms/components/basic/core/validation/ImageLinkPathValidatorBundle.java
@@ -1,3 +1,20 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package io.kestros.cms.components.basic.core.validation;
 
 public class ImageLinkPathValidatorBundle {

--- a/src/main/java/io/kestros/cms/components/basic/core/validation/ImagePathValidatorBundle.java
+++ b/src/main/java/io/kestros/cms/components/basic/core/validation/ImagePathValidatorBundle.java
@@ -1,3 +1,20 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package io.kestros.cms.components.basic.core.validation;
 
 public class ImagePathValidatorBundle {

--- a/src/main/resources/libs/kestros/commons/components/content/table-cell/common/content.html
+++ b/src/main/resources/libs/kestros/commons/components/content/table-cell/common/content.html
@@ -1,3 +1,20 @@
+<!--
+  ~      Copyright (C) 2020  Kestros, Inc.
+  ~
+  ~     This program is free software: you can redistribute it and/or modify
+  ~     it under the terms of the GNU General Public License as published by
+  ~     the Free Software Foundation, either version 3 of the License, or
+  ~     (at your option) any later version.
+  ~
+  ~     This program is distributed in the hope that it will be useful,
+  ~     but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  ~     GNU General Public License for more details.
+  ~
+  ~     You should have received a copy of the GNU General Public License
+  ~     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+  ~
+  -->
 <sly data-sly-use.tableCell="${'io.kestros.cms.components.basic.core.content.table.TableCellDataSourceComponent'}"/>
 <sly data-sly-use.includes="/libs/kestros/commons/components/includes.html"/>
 

--- a/src/main/resources/libs/kestros/commons/components/content/table-header/common/content.html
+++ b/src/main/resources/libs/kestros/commons/components/content/table-header/common/content.html
@@ -1,3 +1,20 @@
+<!--
+  ~      Copyright (C) 2020  Kestros, Inc.
+  ~
+  ~     This program is free software: you can redistribute it and/or modify
+  ~     it under the terms of the GNU General Public License as published by
+  ~     the Free Software Foundation, either version 3 of the License, or
+  ~     (at your option) any later version.
+  ~
+  ~     This program is distributed in the hope that it will be useful,
+  ~     but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  ~     GNU General Public License for more details.
+  ~
+  ~     You should have received a copy of the GNU General Public License
+  ~     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+  ~
+  -->
 <sly data-sly-use.tableHeader="${'io.kestros.cms.components.basic.core.content.table.TableHeaderDataSourceComponent'}"/>
 
 <th class="${tableHeader.inlineVariations}">${tableHeader.text}</th>

--- a/src/main/resources/libs/kestros/commons/components/content/table-row/common/content.html
+++ b/src/main/resources/libs/kestros/commons/components/content/table-row/common/content.html
@@ -1,3 +1,20 @@
+<!--
+  ~      Copyright (C) 2020  Kestros, Inc.
+  ~
+  ~     This program is free software: you can redistribute it and/or modify
+  ~     it under the terms of the GNU General Public License as published by
+  ~     the Free Software Foundation, either version 3 of the License, or
+  ~     (at your option) any later version.
+  ~
+  ~     This program is distributed in the hope that it will be useful,
+  ~     but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  ~     GNU General Public License for more details.
+  ~
+  ~     You should have received a copy of the GNU General Public License
+  ~     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+  ~
+  -->
 <sly data-sly-use.tableRow="${'io.kestros.cms.components.basic.core.content.table.TableRowDataSourceComponent'}"/>
 
 <tr class="${tableRow.inlineVariations}" data-sly-list.cell="${tableRow.cells}">

--- a/src/main/resources/libs/kestros/commons/components/content/table/common/content.html
+++ b/src/main/resources/libs/kestros/commons/components/content/table/common/content.html
@@ -1,3 +1,20 @@
+<!--
+  ~      Copyright (C) 2020  Kestros, Inc.
+  ~
+  ~     This program is free software: you can redistribute it and/or modify
+  ~     it under the terms of the GNU General Public License as published by
+  ~     the Free Software Foundation, either version 3 of the License, or
+  ~     (at your option) any later version.
+  ~
+  ~     This program is distributed in the hope that it will be useful,
+  ~     but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  ~     GNU General Public License for more details.
+  ~
+  ~     You should have received a copy of the GNU General Public License
+  ~     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+  ~
+  -->
 <sly data-sly-use.table="${'io.kestros.cms.components.basic.core.content.table.TableDataSourceComponent'}"/>
 
 <table class="${table.inlineVariations}">

--- a/src/main/resources/libs/kestros/commons/components/lists/card-list/common/content.html
+++ b/src/main/resources/libs/kestros/commons/components/lists/card-list/common/content.html
@@ -1,3 +1,20 @@
+<!--
+  ~      Copyright (C) 2020  Kestros, Inc.
+  ~
+  ~     This program is free software: you can redistribute it and/or modify
+  ~     it under the terms of the GNU General Public License as published by
+  ~     the Free Software Foundation, either version 3 of the License, or
+  ~     (at your option) any later version.
+  ~
+  ~     This program is distributed in the hope that it will be useful,
+  ~     but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  ~     GNU General Public License for more details.
+  ~
+  ~     You should have received a copy of the GNU General Public License
+  ~     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+  ~
+  -->
 <sly data-sly-use.cardList="${'io.kestros.cms.components.basic.core.lists.cardlist.CardListDataSourceComponent'}"/>
 
 <div class="card-list" data-sly-list.card="${cardList.cards}">

--- a/src/test/java/io/kestros/cms/components/basic/BaseComponentTest.java
+++ b/src/test/java/io/kestros/cms/components/basic/BaseComponentTest.java
@@ -1,3 +1,20 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package io.kestros.cms.components.basic;
 
 import static org.junit.Assert.assertEquals;

--- a/src/test/java/io/kestros/cms/components/basic/api/KestrosBasicComponentElementTest.java
+++ b/src/test/java/io/kestros/cms/components/basic/api/KestrosBasicComponentElementTest.java
@@ -1,3 +1,20 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package io.kestros.cms.components.basic.api;
 
 import static org.junit.Assert.assertEquals;

--- a/src/test/java/io/kestros/cms/components/basic/api/content/HeadingLevelsTest.java
+++ b/src/test/java/io/kestros/cms/components/basic/api/content/HeadingLevelsTest.java
@@ -1,3 +1,20 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package io.kestros.cms.components.basic.api.content;
 
 import static org.junit.Assert.assertEquals;

--- a/src/test/java/io/kestros/cms/components/basic/api/exceptions/ComponentConfigurationExceptionTest.java
+++ b/src/test/java/io/kestros/cms/components/basic/api/exceptions/ComponentConfigurationExceptionTest.java
@@ -1,3 +1,20 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package io.kestros.cms.components.basic.api.exceptions;
 
 import static org.junit.Assert.assertEquals;

--- a/src/test/java/io/kestros/cms/components/basic/core/BaseDataSourceComponentTest.java
+++ b/src/test/java/io/kestros/cms/components/basic/core/BaseDataSourceComponentTest.java
@@ -1,3 +1,20 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package io.kestros.cms.components.basic.core;
 
 import static org.mockito.Mockito.when;

--- a/src/test/java/io/kestros/cms/components/basic/core/BaseDataSourceTest.java
+++ b/src/test/java/io/kestros/cms/components/basic/core/BaseDataSourceTest.java
@@ -1,3 +1,20 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package io.kestros.cms.components.basic.core;
 
 import static org.mockito.Mockito.mock;

--- a/src/test/java/io/kestros/cms/components/basic/core/BaseSlingModelDataSourceTest.java
+++ b/src/test/java/io/kestros/cms/components/basic/core/BaseSlingModelDataSourceTest.java
@@ -1,3 +1,20 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package io.kestros.cms.components.basic.core;
 
 import static org.junit.Assert.assertEquals;

--- a/src/test/java/io/kestros/cms/components/basic/core/BaseSyntheticResourceTest.java
+++ b/src/test/java/io/kestros/cms/components/basic/core/BaseSyntheticResourceTest.java
@@ -1,3 +1,20 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package io.kestros.cms.components.basic.core;
 
 import static org.junit.Assert.assertEquals;

--- a/src/test/java/io/kestros/cms/components/basic/core/BaseSyntheticTest.java
+++ b/src/test/java/io/kestros/cms/components/basic/core/BaseSyntheticTest.java
@@ -1,3 +1,20 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package io.kestros.cms.components.basic.core;
 
 import static org.mockito.ArgumentMatchers.any;

--- a/src/test/java/io/kestros/cms/components/basic/core/content/alert/AlertDataSourceComponentTest.java
+++ b/src/test/java/io/kestros/cms/components/basic/core/content/alert/AlertDataSourceComponentTest.java
@@ -1,3 +1,20 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package io.kestros.cms.components.basic.core.content.alert;
 
 import static org.junit.Assert.assertEquals;

--- a/src/test/java/io/kestros/cms/components/basic/core/content/alert/AlertStaticDataSourceTest.java
+++ b/src/test/java/io/kestros/cms/components/basic/core/content/alert/AlertStaticDataSourceTest.java
@@ -1,3 +1,20 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package io.kestros.cms.components.basic.core.content.alert;
 
 import static org.junit.Assert.assertEquals;

--- a/src/test/java/io/kestros/cms/components/basic/core/content/alert/KestrosAlertImplTest.java
+++ b/src/test/java/io/kestros/cms/components/basic/core/content/alert/KestrosAlertImplTest.java
@@ -1,3 +1,20 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package io.kestros.cms.components.basic.core.content.alert;
 
 import static org.junit.Assert.assertEquals;

--- a/src/test/java/io/kestros/cms/components/basic/core/content/card/CardAssetDataSourceTest.java
+++ b/src/test/java/io/kestros/cms/components/basic/core/content/card/CardAssetDataSourceTest.java
@@ -1,3 +1,20 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package io.kestros.cms.components.basic.core.content.card;
 
 import static org.junit.Assert.assertEquals;

--- a/src/test/java/io/kestros/cms/components/basic/core/content/card/CardDataSourceComponentTest.java
+++ b/src/test/java/io/kestros/cms/components/basic/core/content/card/CardDataSourceComponentTest.java
@@ -1,3 +1,20 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package io.kestros.cms.components.basic.core.content.card;
 
 import static org.junit.Assert.assertEquals;

--- a/src/test/java/io/kestros/cms/components/basic/core/content/card/CardPageDataSourceTest.java
+++ b/src/test/java/io/kestros/cms/components/basic/core/content/card/CardPageDataSourceTest.java
@@ -1,3 +1,20 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package io.kestros.cms.components.basic.core.content.card;
 
 import static org.junit.Assert.assertEquals;

--- a/src/test/java/io/kestros/cms/components/basic/core/content/card/CardStaticDataSourceTest.java
+++ b/src/test/java/io/kestros/cms/components/basic/core/content/card/CardStaticDataSourceTest.java
@@ -1,3 +1,20 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package io.kestros.cms.components.basic.core.content.card;
 
 import static org.junit.Assert.assertEquals;

--- a/src/test/java/io/kestros/cms/components/basic/core/content/card/KestrosCardImplTest.java
+++ b/src/test/java/io/kestros/cms/components/basic/core/content/card/KestrosCardImplTest.java
@@ -1,3 +1,20 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package io.kestros.cms.components.basic.core.content.card;
 
 import static org.junit.Assert.assertEquals;

--- a/src/test/java/io/kestros/cms/components/basic/core/content/heading/HeadingDataSourceComponentTest.java
+++ b/src/test/java/io/kestros/cms/components/basic/core/content/heading/HeadingDataSourceComponentTest.java
@@ -1,3 +1,20 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package io.kestros.cms.components.basic.core.content.heading;
 
 import static org.junit.Assert.assertEquals;

--- a/src/test/java/io/kestros/cms/components/basic/core/content/image/ImageStaticDataSourceTest.java
+++ b/src/test/java/io/kestros/cms/components/basic/core/content/image/ImageStaticDataSourceTest.java
@@ -1,3 +1,20 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package io.kestros.cms.components.basic.core.content.image;
 
 import static org.junit.Assert.assertEquals;

--- a/src/test/java/io/kestros/cms/components/basic/core/content/video/VideoDataSourceComponentTest.java
+++ b/src/test/java/io/kestros/cms/components/basic/core/content/video/VideoDataSourceComponentTest.java
@@ -1,3 +1,20 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package io.kestros.cms.components.basic.core.content.video;
 
 import static org.junit.Assert.assertEquals;

--- a/src/test/java/io/kestros/cms/components/basic/core/content/video/VideoStaticDataSourceTest.java
+++ b/src/test/java/io/kestros/cms/components/basic/core/content/video/VideoStaticDataSourceTest.java
@@ -1,3 +1,20 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package io.kestros.cms.components.basic.core.content.video;
 
 import static org.junit.Assert.assertEquals;

--- a/src/test/java/io/kestros/cms/components/basic/core/content/videoembed/EmbedSanitizerTest.java
+++ b/src/test/java/io/kestros/cms/components/basic/core/content/videoembed/EmbedSanitizerTest.java
@@ -1,3 +1,20 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package io.kestros.cms.components.basic.core.content.videoembed;
 
 import static org.junit.Assert.assertEquals;

--- a/src/test/java/io/kestros/cms/components/basic/core/content/videoembed/VideoEmbedDataSourceComponentTest.java
+++ b/src/test/java/io/kestros/cms/components/basic/core/content/videoembed/VideoEmbedDataSourceComponentTest.java
@@ -1,3 +1,20 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package io.kestros.cms.components.basic.core.content.videoembed;
 
 import static org.junit.Assert.assertEquals;

--- a/src/test/java/io/kestros/cms/components/basic/core/content/videoembed/VideoEmbedYouTubeDataSourceTest.java
+++ b/src/test/java/io/kestros/cms/components/basic/core/content/videoembed/VideoEmbedYouTubeDataSourceTest.java
@@ -1,3 +1,20 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package io.kestros.cms.components.basic.core.content.videoembed;
 
 import static org.junit.Assert.assertFalse;

--- a/src/test/java/io/kestros/cms/components/basic/core/lists/LinkListChildPageDataSourceTest.java
+++ b/src/test/java/io/kestros/cms/components/basic/core/lists/LinkListChildPageDataSourceTest.java
@@ -1,3 +1,20 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package io.kestros.cms.components.basic.core.lists;
 
 import static org.junit.Assert.assertEquals;

--- a/src/test/java/io/kestros/cms/components/basic/core/lists/cardlist/CardListAssetsDataSourceTest.java
+++ b/src/test/java/io/kestros/cms/components/basic/core/lists/cardlist/CardListAssetsDataSourceTest.java
@@ -1,3 +1,20 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package io.kestros.cms.components.basic.core.lists.cardlist;
 
 import static org.junit.Assert.assertEquals;

--- a/src/test/java/io/kestros/cms/components/basic/core/lists/cardlist/CardListChildPagesDataSourceTest.java
+++ b/src/test/java/io/kestros/cms/components/basic/core/lists/cardlist/CardListChildPagesDataSourceTest.java
@@ -1,3 +1,20 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package io.kestros.cms.components.basic.core.lists.cardlist;
 
 import static org.junit.Assert.assertEquals;

--- a/src/test/java/io/kestros/cms/components/basic/core/lists/cardlist/CardListDataSourceComponentTest.java
+++ b/src/test/java/io/kestros/cms/components/basic/core/lists/cardlist/CardListDataSourceComponentTest.java
@@ -1,3 +1,20 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package io.kestros.cms.components.basic.core.lists.cardlist;
 
 import static org.junit.Assert.assertEquals;

--- a/src/test/java/io/kestros/cms/components/basic/core/lists/cardlist/CardListTagSearchDataSourceTest.java
+++ b/src/test/java/io/kestros/cms/components/basic/core/lists/cardlist/CardListTagSearchDataSourceTest.java
@@ -1,3 +1,20 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package io.kestros.cms.components.basic.core.lists.cardlist;
 
 import static org.junit.Assert.assertEquals;

--- a/src/test/java/io/kestros/cms/components/basic/core/navigation/breadcrumbs/BreadCrumbsDataSourceComponentTest.java
+++ b/src/test/java/io/kestros/cms/components/basic/core/navigation/breadcrumbs/BreadCrumbsDataSourceComponentTest.java
@@ -1,3 +1,20 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package io.kestros.cms.components.basic.core.navigation.breadcrumbs;
 
 import static org.junit.Assert.assertEquals;

--- a/src/test/java/io/kestros/cms/components/basic/core/navigation/nav/NavigationDataSourceComponentTest.java
+++ b/src/test/java/io/kestros/cms/components/basic/core/navigation/nav/NavigationDataSourceComponentTest.java
@@ -1,3 +1,20 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package io.kestros.cms.components.basic.core.navigation.nav;
 
 import static org.junit.Assert.assertEquals;

--- a/src/test/java/io/kestros/cms/components/basic/core/navigation/topnav/TopNavigationDataSourceComponentTest.java
+++ b/src/test/java/io/kestros/cms/components/basic/core/navigation/topnav/TopNavigationDataSourceComponentTest.java
@@ -1,3 +1,20 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package io.kestros.cms.components.basic.core.navigation.topnav;
 
 import static org.junit.Assert.assertEquals;

--- a/src/test/java/io/kestros/cms/components/basic/core/structure/accordion/AccordionDataSourceComponentTest.java
+++ b/src/test/java/io/kestros/cms/components/basic/core/structure/accordion/AccordionDataSourceComponentTest.java
@@ -1,3 +1,20 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package io.kestros.cms.components.basic.core.structure.accordion;
 
 import static org.junit.Assert.assertEquals;


### PR DESCRIPTION
## Summary

- 196 Java and HTML source files were missing GPL3 license headers, causing `apache-rat-plugin` to fail during `mvn clean verify`
- This was a pre-existing issue — the RAT failure existed before the test fixes in PR #57
- Added GPL3 license headers matching the existing project license to all affected files in `src/main/`, `src/test/`, and `hold/`

## Test Results

`mvn clean verify` now passes cleanly:
- **245 tests run, 0 failures, 0 errors, 1 skipped**
- RAT check: 0 unapproved files
- BUILD SUCCESS

## Relationship to PR #57

PR #57 (commit 339255c) fixed the actual test failures (card off-by-one counts and nav datasource NPE/IllegalArgument). This PR fixes the remaining RAT license check that also blocked `mvn clean verify`.

## AC Status (TASK-097)

1. All tests pass with 0 failures, 0 errors on develop ✓
2. Card component tests pass — off-by-one resolved (in PR #57) ✓
3. Nav datasource tests pass — NPE/IllegalArgument resolved (in PR #57) ✓
4. Root cause was stale test expectations, not component logic ✓
5. `mvn clean verify` passes locally ✓