### PR TITLE
fix: pin maven-bundle-plugin to 5.1.9 to resolve ConcurrentModificationException (TASK-230)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,6 +56,20 @@
     <module>frontend</module>
   </modules>
 
+  <build>
+    <pluginManagement>
+      <plugins>
+        <!-- Upgrade from 4.1.0 (inherited from parent) to 5.1.9 to fix
+             ConcurrentModificationException in scr-metadata execution phase -->
+        <plugin>
+          <groupId>org.apache.felix</groupId>
+          <artifactId>maven-bundle-plugin</artifactId>
+          <version>5.1.9</version>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
+
   <dependencyManagement>
     <dependencies>
       <dependency>


### PR DESCRIPTION
## Summary

Pins maven-bundle-plugin from 4.1.0 to 5.1.9 via pluginManagement override in root pom.xml.

Resolves ConcurrentModificationException in scr-metadata phase caused by known race condition in maven-bundle-plugin 4.1.0.

## Change

- root pom.xml: adds 14-line pluginManagement block pinning maven-bundle-plugin to 5.1.9

## Verification

- BUILD SUCCESS confirmed locally with fix applied
- No ConcurrentModificationException in build output
- All modules and tests pass
- OSGi bundle manifest headers present and valid

Resolves: TASK-230