### PR TITLE
feat: TASK-007 unit tests for all Impl classes + fix 3 constructor bugs

### DIFF
--- a/src/main/java/io/kestros/cms/components/basic/core/content/text/KestrosTextImpl.java
+++ b/src/main/java/io/kestros/cms/components/basic/core/content/text/KestrosTextImpl.java
@@ -16,6 +16,7 @@ public class KestrosTextImpl extends BaseSyntheticResource implements KestrosTex
       @Nonnull String resourcePrefix, @Nullable String forcedResourceName)
       throws ComponentConfigurationException {
     super(dataSource, resourcePrefix, forcedResourceName);
+    this.text = text;
   }
 
   @Nullable

--- a/src/main/java/io/kestros/cms/components/basic/core/structure/accordion/KestrosAccordionImpl.java
+++ b/src/main/java/io/kestros/cms/components/basic/core/structure/accordion/KestrosAccordionImpl.java
@@ -20,6 +20,7 @@ public class KestrosAccordionImpl extends BaseContainerSyntheticResource
       @Nonnull String resourcePrefix, String forcedResourceName)
       throws ComponentConfigurationException {
     super(dataSource, resourcePrefix, forcedResourceName);
+    this.panels = panels;
   }
 
 

--- a/src/main/java/io/kestros/cms/components/basic/core/structure/section/KestrosSectionImpl.java
+++ b/src/main/java/io/kestros/cms/components/basic/core/structure/section/KestrosSectionImpl.java
@@ -20,6 +20,7 @@ public class KestrosSectionImpl extends KestrosContainerImpl implements KestrosS
       @Nonnull String resourcePrefix, String forcedResourceName)
       throws ComponentConfigurationException {
     super(childElements, dataSource, resourcePrefix, forcedResourceName);
+    this.backgroundImage = backgroundImage;
   }
 
   @Nullable

--- a/src/test/java/io/kestros/cms/components/basic/core/content/button/KestrosButtonImplTest.java
+++ b/src/test/java/io/kestros/cms/components/basic/core/content/button/KestrosButtonImplTest.java
@@ -1,0 +1,109 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+package io.kestros.cms.components.basic.core.content.button;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+
+import io.kestros.cms.components.basic.api.content.AnchorTarget;
+import io.kestros.cms.components.basic.api.exceptions.ComponentConfigurationException;
+import io.kestros.cms.components.basic.core.BaseSyntheticTest;
+import io.kestros.cms.components.basic.core.lists.cardlist.CardListStaticDataSource;
+import org.apache.sling.api.resource.Resource;
+import org.junit.Test;
+
+public class KestrosButtonImplTest extends BaseSyntheticTest {
+
+  private KestrosButtonImpl button;
+
+  @Override
+  public void setupElement() throws ComponentConfigurationException {
+    Resource resource = context.create().resource("/content/parent");
+    context.currentResource(resource);
+    CardListStaticDataSource dataSource = context.request().adaptTo(
+        CardListStaticDataSource.class);
+
+    button = new KestrosButtonImpl(
+        "Click Me",
+        "/content/page.html",
+        "Button Title",
+        AnchorTarget.SAME_WINDOW,
+        "nofollow",
+        "aria-button",
+        "describedby-id",
+        "en",
+        false,
+        dataSource,
+        "button",
+        "buttonElement"
+    );
+  }
+
+  @Override
+  public void testToSyntheticResource() {
+    Resource syntheticResource = button.toSyntheticResource(getResourceResolver(), "/parent");
+    assertNotNull(syntheticResource);
+    assertEquals("/synthetics/parent/buttonElement", syntheticResource.getPath());
+  }
+
+  @Test
+  public void testGetText() {
+    assertEquals("Click Me", button.getText());
+  }
+
+  @Test
+  public void testGetHref() {
+    assertEquals("/content/page.html", button.getHref());
+  }
+
+  @Test
+  public void testGetTitle() {
+    assertEquals("Button Title", button.getTitle());
+  }
+
+  @Test
+  public void testGetTarget() {
+    assertEquals(AnchorTarget.SAME_WINDOW, button.getTarget());
+  }
+
+  @Test
+  public void testGetRel() {
+    assertEquals("nofollow", button.getRel());
+  }
+
+  @Test
+  public void testGetAriaLabel() {
+    assertEquals("aria-button", button.getAriaLabel());
+  }
+
+  @Test
+  public void testGetAriaDescribedBy() {
+    assertEquals("describedby-id", button.getAriaDescribedBy());
+  }
+
+  @Test
+  public void testGetLang() {
+    assertEquals("en", button.getLang());
+  }
+
+  @Test
+  public void testIsDisabled() {
+    assertFalse(button.isDisabled());
+  }
+}

--- a/src/test/java/io/kestros/cms/components/basic/core/content/buttongroup/KestrosButtonGroupImplTest.java
+++ b/src/test/java/io/kestros/cms/components/basic/core/content/buttongroup/KestrosButtonGroupImplTest.java
@@ -1,0 +1,75 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+package io.kestros.cms.components.basic.core.content.buttongroup;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import io.kestros.cms.components.basic.api.content.AnchorTarget;
+import io.kestros.cms.components.basic.api.content.KestrosButton;
+import io.kestros.cms.components.basic.api.exceptions.ComponentConfigurationException;
+import io.kestros.cms.components.basic.core.BaseSyntheticTest;
+import io.kestros.cms.components.basic.core.content.button.KestrosButtonImpl;
+import io.kestros.cms.components.basic.core.lists.cardlist.CardListStaticDataSource;
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.sling.api.resource.Resource;
+import org.junit.Test;
+
+public class KestrosButtonGroupImplTest extends BaseSyntheticTest {
+
+  private KestrosButtonGroupImpl buttonGroup;
+
+  @Override
+  public void setupElement() throws ComponentConfigurationException {
+    Resource resource = context.create().resource("/content/parent");
+    context.currentResource(resource);
+    CardListStaticDataSource dataSource = context.request().adaptTo(
+        CardListStaticDataSource.class);
+
+    List<KestrosButton> buttons = new ArrayList<>();
+    buttons.add(new KestrosButtonImpl(
+        "Button 1", "/content/page1.html",
+        null, AnchorTarget.SAME_WINDOW, null, null, null, null, false,
+        dataSource, "button", "button1"));
+    buttons.add(new KestrosButtonImpl(
+        "Button 2", "/content/page2.html",
+        null, AnchorTarget.SAME_WINDOW, null, null, null, null, false,
+        dataSource, "button", "button2"));
+
+    buttonGroup = new KestrosButtonGroupImpl(buttons, dataSource, "buttonGroup",
+        "buttonGroupElement");
+  }
+
+  @Override
+  public void testToSyntheticResource() {
+    Resource syntheticResource = buttonGroup.toSyntheticResource(getResourceResolver(), "/parent");
+    assertNotNull(syntheticResource);
+    assertEquals("/synthetics/parent/buttonGroupElement", syntheticResource.getPath());
+  }
+
+  @Test
+  public void testGetButtonsElements() {
+    assertEquals(2, buttonGroup.getButtonsElements().size());
+  }
+
+  @Test
+  public void testGetButtonVariations() {
+    assertNotNull(buttonGroup.getButtonVariations());
+  }
+}

--- a/src/test/java/io/kestros/cms/components/basic/core/content/code/KestrosCodeImplTest.java
+++ b/src/test/java/io/kestros/cms/components/basic/core/content/code/KestrosCodeImplTest.java
@@ -1,0 +1,55 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+package io.kestros.cms.components.basic.core.content.code;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import io.kestros.cms.components.basic.api.exceptions.ComponentConfigurationException;
+import io.kestros.cms.components.basic.core.BaseSyntheticTest;
+import io.kestros.cms.components.basic.core.lists.cardlist.CardListStaticDataSource;
+import org.apache.sling.api.resource.Resource;
+import org.junit.Test;
+
+public class KestrosCodeImplTest extends BaseSyntheticTest {
+
+  private KestrosCodeImpl code;
+
+  @Override
+  public void setupElement() throws ComponentConfigurationException {
+    Resource resource = context.create().resource("/content/parent");
+    context.currentResource(resource);
+    CardListStaticDataSource dataSource = context.request().adaptTo(
+        CardListStaticDataSource.class);
+
+    code = new KestrosCodeImpl("System.out.println(\"Hello\");", dataSource, "code",
+        "codeElement");
+  }
+
+  @Override
+  public void testToSyntheticResource() {
+    Resource syntheticResource = code.toSyntheticResource(getResourceResolver(), "/parent");
+    assertNotNull(syntheticResource);
+    assertEquals("/synthetics/parent/codeElement", syntheticResource.getPath());
+  }
+
+  @Test
+  public void testGetCode() {
+    assertEquals("System.out.println(\"Hello\");", code.getCode());
+  }
+}

--- a/src/test/java/io/kestros/cms/components/basic/core/content/heading/KestrosHeadingImplTest.java
+++ b/src/test/java/io/kestros/cms/components/basic/core/content/heading/KestrosHeadingImplTest.java
@@ -1,0 +1,63 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+package io.kestros.cms.components.basic.core.content.heading;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import io.kestros.cms.components.basic.api.exceptions.ComponentConfigurationException;
+import io.kestros.cms.components.basic.core.BaseSyntheticTest;
+import io.kestros.cms.components.basic.core.lists.cardlist.CardListStaticDataSource;
+import org.apache.sling.api.resource.Resource;
+import org.junit.Test;
+
+public class KestrosHeadingImplTest extends BaseSyntheticTest {
+
+  private KestrosHeadingImpl heading;
+
+  @Override
+  public void setupElement() throws ComponentConfigurationException {
+    Resource resource = context.create().resource("/content/parent");
+    context.currentResource(resource);
+    CardListStaticDataSource dataSource = context.request().adaptTo(
+        CardListStaticDataSource.class);
+
+    heading = new KestrosHeadingImpl("Hello World", "h2", dataSource, "heading", "headingElement");
+  }
+
+  @Override
+  public void testToSyntheticResource() {
+    Resource syntheticResource = heading.toSyntheticResource(getResourceResolver(), "/parent");
+    assertNotNull(syntheticResource);
+    assertEquals("/synthetics/parent/headingElement", syntheticResource.getPath());
+    assertEquals("Hello World",
+        syntheticResource.getValueMap().get("headingText", String.class));
+    assertEquals("h2",
+        syntheticResource.getValueMap().get("headingType", String.class));
+  }
+
+  @Test
+  public void testGetHeadingText() {
+    assertEquals("Hello World", heading.getHeadingText());
+  }
+
+  @Test
+  public void testGetHeadingType() {
+    assertEquals("h2", heading.getHeadingType());
+  }
+}

--- a/src/test/java/io/kestros/cms/components/basic/core/content/image/KestrosImageImplTest.java
+++ b/src/test/java/io/kestros/cms/components/basic/core/content/image/KestrosImageImplTest.java
@@ -1,0 +1,112 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+package io.kestros.cms.components.basic.core.content.image;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import io.kestros.cms.components.basic.api.content.AnchorTarget;
+import io.kestros.cms.components.basic.api.exceptions.ComponentConfigurationException;
+import io.kestros.cms.components.basic.core.BaseSyntheticTest;
+import io.kestros.cms.components.basic.core.lists.cardlist.CardListStaticDataSource;
+import org.apache.sling.api.resource.Resource;
+import org.junit.Test;
+
+public class KestrosImageImplTest extends BaseSyntheticTest {
+
+  private KestrosImageImpl image;
+
+  @Override
+  public void setupElement() throws ComponentConfigurationException {
+    Resource resource = context.create().resource("/content/parent");
+    context.currentResource(resource);
+    CardListStaticDataSource dataSource = context.request().adaptTo(CardListStaticDataSource.class);
+
+    image = new KestrosImageImpl(
+        "/content/assets/image.jpg",
+        "Alt text",
+        "Caption text",
+        "Image Title",
+        "/content/page.html",
+        "Aria Label",
+        "Anchor Title",
+        AnchorTarget.SAME_WINDOW,
+        dataSource,
+        "image",
+        "imageElement",
+        assetRetrievalService
+    );
+  }
+
+  @Override
+  public void testToSyntheticResource() {
+    Resource syntheticResource = image.toSyntheticResource(getResourceResolver(), "/parent");
+    assertNotNull(syntheticResource);
+    assertEquals("/synthetics/parent/imageElement", syntheticResource.getPath());
+  }
+
+  @Test
+  public void testGetImagePath() {
+    assertEquals("/content/assets/image.jpg", image.getImagePath());
+  }
+
+  @Test
+  public void testGetAltText() {
+    assertEquals("Alt text", image.getAltText());
+  }
+
+  @Test
+  public void testGetCaption() {
+    assertEquals("Caption text", image.getCaption());
+  }
+
+  @Test
+  public void testGetImageTitle() {
+    assertEquals("Image Title", image.getImageTitle());
+  }
+
+  @Test
+  public void testGetHref() {
+    assertEquals("/content/page.html", image.getHref());
+  }
+
+  @Test
+  public void testGetAriaLabel() {
+    assertEquals("Aria Label", image.getAriaLabel());
+  }
+
+  @Test
+  public void testGetAnchorTitle() {
+    assertEquals("Anchor Title", image.getAnchorTitle());
+  }
+
+  @Test
+  public void testGetTarget() {
+    assertEquals(AnchorTarget.SAME_WINDOW, image.getTarget());
+  }
+
+  @Test(expected = ComponentConfigurationException.class)
+  public void testConstructorThrowsWhenImagePathEmpty() throws ComponentConfigurationException {
+    Resource resource = context.create().resource("/content/parent2");
+    context.currentResource(resource);
+    CardListStaticDataSource dataSource = context.request().adaptTo(CardListStaticDataSource.class);
+
+    new KestrosImageImpl("", "Alt text", null, null, null, null, null,
+        AnchorTarget.SAME_WINDOW, dataSource, "image", "failElement", assetRetrievalService);
+  }
+}

--- a/src/test/java/io/kestros/cms/components/basic/core/content/link/KestrosLinkImplTest.java
+++ b/src/test/java/io/kestros/cms/components/basic/core/content/link/KestrosLinkImplTest.java
@@ -1,0 +1,92 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+package io.kestros.cms.components.basic.core.content.link;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+import io.kestros.cms.components.basic.api.content.AnchorTarget;
+import io.kestros.cms.components.basic.api.exceptions.ComponentConfigurationException;
+import io.kestros.cms.components.basic.core.BaseSyntheticTest;
+import io.kestros.cms.components.basic.core.lists.cardlist.CardListStaticDataSource;
+import org.apache.sling.api.resource.Resource;
+import org.junit.Test;
+
+public class KestrosLinkImplTest extends BaseSyntheticTest {
+
+  private KestrosLinkImpl link;
+
+  @Override
+  public void setupElement() throws ComponentConfigurationException {
+    Resource resource = context.create().resource("/content/parent");
+    context.currentResource(resource);
+    CardListStaticDataSource dataSource = context.request().adaptTo(CardListStaticDataSource.class);
+
+    link = new KestrosLinkImpl("Link Text", "/content/page.html", "Link Title",
+        AnchorTarget.SAME_WINDOW, "noopener", "Aria Label", "aria-describedby", "en",
+        dataSource, "link", "linkElement");
+  }
+
+  @Override
+  public void testToSyntheticResource() {
+    Resource syntheticResource = link.toSyntheticResource(getResourceResolver(), "/parent");
+    assertNotNull(syntheticResource);
+    assertEquals("/synthetics/parent/linkElement", syntheticResource.getPath());
+  }
+
+  @Test
+  public void testGetText() {
+    assertEquals("Link Text", link.getText());
+  }
+
+  @Test
+  public void testGetHref() {
+    assertEquals("/content/page.html", link.getHref());
+  }
+
+  @Test
+  public void testGetTitle() {
+    assertEquals("Link Title", link.getTitle());
+  }
+
+  @Test
+  public void testGetTarget() {
+    assertEquals(AnchorTarget.SAME_WINDOW, link.getTarget());
+  }
+
+  @Test
+  public void testGetRel() {
+    assertEquals("noopener", link.getRel());
+  }
+
+  @Test
+  public void testGetAriaLabel() {
+    assertEquals("Aria Label", link.getAriaLabel());
+  }
+
+  @Test
+  public void testGetAriaDescribedBy() {
+    assertEquals("aria-describedby", link.getAriaDescribedBy());
+  }
+
+  @Test
+  public void testGetLang() {
+    assertEquals("en", link.getLang());
+  }
+}

--- a/src/test/java/io/kestros/cms/components/basic/core/content/richtext/KestrosRichTextImplTest.java
+++ b/src/test/java/io/kestros/cms/components/basic/core/content/richtext/KestrosRichTextImplTest.java
@@ -1,0 +1,54 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+package io.kestros.cms.components.basic.core.content.richtext;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import io.kestros.cms.components.basic.api.exceptions.ComponentConfigurationException;
+import io.kestros.cms.components.basic.core.BaseSyntheticTest;
+import io.kestros.cms.components.basic.core.lists.cardlist.CardListStaticDataSource;
+import org.apache.sling.api.resource.Resource;
+import org.junit.Test;
+
+public class KestrosRichTextImplTest extends BaseSyntheticTest {
+
+  private KestrosRichTextImpl richText;
+
+  @Override
+  public void setupElement() throws ComponentConfigurationException {
+    Resource resource = context.create().resource("/content/parent");
+    context.currentResource(resource);
+    CardListStaticDataSource dataSource = context.request().adaptTo(CardListStaticDataSource.class);
+
+    richText = new KestrosRichTextImpl("<p>Hello World</p>", dataSource, "richtext",
+        "richtextElement");
+  }
+
+  @Override
+  public void testToSyntheticResource() {
+    Resource syntheticResource = richText.toSyntheticResource(getResourceResolver(), "/parent");
+    assertNotNull(syntheticResource);
+    assertEquals("/synthetics/parent/richtextElement", syntheticResource.getPath());
+  }
+
+  @Test
+  public void testGetText() {
+    assertEquals("<p>Hello World</p>", richText.getText());
+  }
+}

--- a/src/test/java/io/kestros/cms/components/basic/core/content/text/KestrosTextImplTest.java
+++ b/src/test/java/io/kestros/cms/components/basic/core/content/text/KestrosTextImplTest.java
@@ -1,0 +1,54 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+package io.kestros.cms.components.basic.core.content.text;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import io.kestros.cms.components.basic.api.exceptions.ComponentConfigurationException;
+import io.kestros.cms.components.basic.core.BaseSyntheticTest;
+import io.kestros.cms.components.basic.core.lists.cardlist.CardListStaticDataSource;
+import org.apache.sling.api.resource.Resource;
+import org.junit.Test;
+
+public class KestrosTextImplTest extends BaseSyntheticTest {
+
+  private KestrosTextImpl text;
+
+  @Override
+  public void setupElement() throws ComponentConfigurationException {
+    Resource resource = context.create().resource("/content/parent");
+    context.currentResource(resource);
+    CardListStaticDataSource dataSource = context.request().adaptTo(
+        CardListStaticDataSource.class);
+
+    text = new KestrosTextImpl("Sample text", dataSource, "text", "textElement");
+  }
+
+  @Override
+  public void testToSyntheticResource() {
+    Resource syntheticResource = text.toSyntheticResource(getResourceResolver(), "/parent");
+    assertNotNull(syntheticResource);
+    assertEquals("/synthetics/parent/textElement", syntheticResource.getPath());
+  }
+
+  @Test
+  public void testGetText() {
+    assertEquals("Sample text", text.getText());
+  }
+}

--- a/src/test/java/io/kestros/cms/components/basic/core/content/video/KestrosVideoImplTest.java
+++ b/src/test/java/io/kestros/cms/components/basic/core/content/video/KestrosVideoImplTest.java
@@ -1,0 +1,60 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+package io.kestros.cms.components.basic.core.content.video;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import io.kestros.cms.components.basic.api.exceptions.ComponentConfigurationException;
+import io.kestros.cms.components.basic.core.BaseSyntheticTest;
+import io.kestros.cms.components.basic.core.lists.cardlist.CardListStaticDataSource;
+import org.apache.sling.api.resource.Resource;
+import org.junit.Test;
+
+public class KestrosVideoImplTest extends BaseSyntheticTest {
+
+  private KestrosVideoImpl video;
+
+  @Override
+  public void setupElement() throws ComponentConfigurationException {
+    Resource resource = context.create().resource("/content/parent");
+    context.currentResource(resource);
+    CardListStaticDataSource dataSource = context.request().adaptTo(
+        CardListStaticDataSource.class);
+
+    video = new KestrosVideoImpl("/content/dam/video.mp4", "Video fallback text", dataSource,
+        "video", "videoElement");
+  }
+
+  @Override
+  public void testToSyntheticResource() {
+    Resource syntheticResource = video.toSyntheticResource(getResourceResolver(), "/parent");
+    assertNotNull(syntheticResource);
+    assertEquals("/synthetics/parent/videoElement", syntheticResource.getPath());
+  }
+
+  @Test
+  public void testGetVideoSource() {
+    assertEquals("/content/dam/video.mp4", video.getVideoSource());
+  }
+
+  @Test
+  public void testGetFallbackText() {
+    assertEquals("Video fallback text", video.getFallbackText());
+  }
+}

--- a/src/test/java/io/kestros/cms/components/basic/core/content/videoembed/KestrosVideoEmbedImplTest.java
+++ b/src/test/java/io/kestros/cms/components/basic/core/content/videoembed/KestrosVideoEmbedImplTest.java
@@ -1,0 +1,57 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+package io.kestros.cms.components.basic.core.content.videoembed;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import io.kestros.cms.components.basic.api.exceptions.ComponentConfigurationException;
+import io.kestros.cms.components.basic.core.BaseSyntheticTest;
+import io.kestros.cms.components.basic.core.lists.cardlist.CardListStaticDataSource;
+import org.apache.sling.api.resource.Resource;
+import org.junit.Test;
+
+public class KestrosVideoEmbedImplTest extends BaseSyntheticTest {
+
+  private KestrosVideoEmbedImpl videoEmbed;
+
+  @Override
+  public void setupElement() throws ComponentConfigurationException {
+    Resource resource = context.create().resource("/content/parent");
+    context.currentResource(resource);
+    CardListStaticDataSource dataSource = context.request().adaptTo(
+        CardListStaticDataSource.class);
+
+    videoEmbed = new KestrosVideoEmbedImpl(
+        "<iframe src='https://www.youtube.com/embed/abc123'></iframe>",
+        dataSource, "videoembed", "videoEmbedElement");
+  }
+
+  @Override
+  public void testToSyntheticResource() {
+    Resource syntheticResource = videoEmbed.toSyntheticResource(getResourceResolver(), "/parent");
+    assertNotNull(syntheticResource);
+    assertEquals("/synthetics/parent/videoEmbedElement", syntheticResource.getPath());
+  }
+
+  @Test
+  public void testGetVideoEmbedCode() {
+    assertEquals("<iframe src='https://www.youtube.com/embed/abc123'></iframe>",
+        videoEmbed.getVideoEmbedCode());
+  }
+}

--- a/src/test/java/io/kestros/cms/components/basic/core/lists/cardlist/KestrosCardListImplTest.java
+++ b/src/test/java/io/kestros/cms/components/basic/core/lists/cardlist/KestrosCardListImplTest.java
@@ -1,0 +1,72 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+package io.kestros.cms.components.basic.core.lists.cardlist;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import io.kestros.cms.components.basic.api.content.AnchorTarget;
+import io.kestros.cms.components.basic.api.content.KestrosCard;
+import io.kestros.cms.components.basic.api.exceptions.ComponentConfigurationException;
+import io.kestros.cms.components.basic.core.BaseSyntheticTest;
+import io.kestros.cms.components.basic.core.content.buttongroup.KestrosButtonGroupImpl;
+import io.kestros.cms.components.basic.core.content.card.KestrosCardImpl;
+import io.kestros.cms.components.basic.core.content.heading.KestrosHeadingImpl;
+import io.kestros.cms.components.basic.core.content.image.KestrosImageImpl;
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.sling.api.resource.Resource;
+import org.junit.Test;
+
+public class KestrosCardListImplTest extends BaseSyntheticTest {
+
+  private KestrosCardListImpl cardList;
+
+  @Override
+  public void setupElement() throws ComponentConfigurationException {
+    Resource resource = context.create().resource("/content/parent");
+    context.currentResource(resource);
+    CardListStaticDataSource dataSource = context.request().adaptTo(
+        CardListStaticDataSource.class);
+
+    List<KestrosCard> cards = new ArrayList<>();
+    cards.add(new KestrosCardImpl(
+        "Card 1 description",
+        new KestrosHeadingImpl("Card 1", "h3", dataSource, "title", "title1"),
+        new KestrosImageImpl("/content/dam/img1.jpg", "Alt 1", null, null, null, null, null,
+            AnchorTarget.SAME_WINDOW, dataSource, "image", "img1", assetRetrievalService),
+        new KestrosButtonGroupImpl(new ArrayList<>(), dataSource, "bg", "bg1"),
+        dataSource, "card", "card1"
+    ));
+
+    cardList = new KestrosCardListImpl(cards, dataSource, "cardlist", "cardListElement");
+  }
+
+  @Override
+  public void testToSyntheticResource() {
+    Resource syntheticResource = cardList.toSyntheticResource(getResourceResolver(), "/parent");
+    assertNotNull(syntheticResource);
+    assertEquals("/synthetics/parent/cardListElement", syntheticResource.getPath());
+  }
+
+  @Test
+  public void testGetCardElements() {
+    assertNotNull(cardList.getCardElements());
+    assertEquals(1, cardList.getCardElements().size());
+  }
+}

--- a/src/test/java/io/kestros/cms/components/basic/core/lists/linklist/KestrosLinkListImplTest.java
+++ b/src/test/java/io/kestros/cms/components/basic/core/lists/linklist/KestrosLinkListImplTest.java
@@ -1,0 +1,71 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+package io.kestros.cms.components.basic.core.lists.linklist;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import io.kestros.cms.components.basic.api.content.KestrosLink;
+import io.kestros.cms.components.basic.api.exceptions.ComponentConfigurationException;
+import io.kestros.cms.components.basic.core.BaseSyntheticTest;
+import io.kestros.cms.components.basic.core.content.link.KestrosLinkImpl;
+import io.kestros.cms.components.basic.core.lists.cardlist.CardListStaticDataSource;
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.sling.api.resource.Resource;
+import org.junit.Test;
+
+public class KestrosLinkListImplTest extends BaseSyntheticTest {
+
+  private KestrosLinkListImpl linkList;
+
+  @Override
+  public void setupElement() throws ComponentConfigurationException {
+    Resource resource = context.create().resource("/content/parent");
+    context.currentResource(resource);
+    CardListStaticDataSource dataSource = context.request().adaptTo(CardListStaticDataSource.class);
+
+    List<KestrosLink> links = new ArrayList<>();
+    links.add(new KestrosLinkImpl("Link 1", "/content/page1.html", null, null, null, null, null,
+        null, dataSource, "link", "link1"));
+    links.add(new KestrosLinkImpl("Link 2", "/content/page2.html", null, null, null, null, null,
+        null, dataSource, "link", "link2"));
+
+    linkList = new KestrosLinkListImpl(links, dataSource, "linkList", "linkListElement");
+  }
+
+  @Override
+  public void testToSyntheticResource() {
+    Resource syntheticResource = linkList.toSyntheticResource(getResourceResolver(), "/parent");
+    assertNotNull(syntheticResource);
+    assertEquals("/synthetics/parent/linkListElement", syntheticResource.getPath());
+  }
+
+  @Test
+  public void testGetLinkElements() {
+    assertNotNull(linkList.getLinkElements());
+    assertEquals(2, linkList.getLinkElements().size());
+  }
+
+  @Test
+  public void testGetLinkElementsIsDefensiveCopy() {
+    List<KestrosLink> links = linkList.getLinkElements();
+    links.clear();
+    assertEquals(2, linkList.getLinkElements().size());
+  }
+}

--- a/src/test/java/io/kestros/cms/components/basic/core/navigation/breadcrumbs/KestrosBreadCrumbImplTest.java
+++ b/src/test/java/io/kestros/cms/components/basic/core/navigation/breadcrumbs/KestrosBreadCrumbImplTest.java
@@ -1,0 +1,97 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+package io.kestros.cms.components.basic.core.navigation.breadcrumbs;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
+
+import io.kestros.cms.components.basic.api.content.AnchorTarget;
+import io.kestros.cms.components.basic.api.exceptions.ComponentConfigurationException;
+import io.kestros.cms.components.basic.core.BaseSyntheticTest;
+import io.kestros.cms.components.basic.core.content.link.KestrosLinkImpl;
+import io.kestros.cms.components.basic.core.lists.cardlist.CardListStaticDataSource;
+import org.apache.sling.api.resource.Resource;
+import org.junit.Test;
+
+public class KestrosBreadCrumbImplTest extends BaseSyntheticTest {
+
+  private KestrosBreadCrumbImpl breadCrumb;
+
+  @Override
+  public void setupElement() throws ComponentConfigurationException {
+    Resource resource = context.create().resource("/content/parent");
+    context.currentResource(resource);
+    CardListStaticDataSource dataSource = context.request().adaptTo(CardListStaticDataSource.class);
+
+    KestrosLinkImpl link = new KestrosLinkImpl("Home", "/content/home.html", "Home Page",
+        AnchorTarget.SAME_WINDOW, null, "Home Label", null, "en",
+        dataSource, "breadcrumb", "homeLink");
+
+    breadCrumb = new KestrosBreadCrumbImpl(link, true, false, dataSource, "breadcrumb",
+        "breadCrumbElement");
+  }
+
+  @Override
+  public void testToSyntheticResource() {
+    Resource syntheticResource = breadCrumb.toSyntheticResource(getResourceResolver(), "/parent");
+    assertNotNull(syntheticResource);
+    assertEquals("/synthetics/parent/breadCrumbElement", syntheticResource.getPath());
+  }
+
+  @Test
+  public void testIsFirstItem() {
+    assertTrue(breadCrumb.isFirstItem());
+  }
+
+  @Test
+  public void testIsLastItem() {
+    assertFalse(breadCrumb.isLastItem());
+  }
+
+  @Test
+  public void testGetText() {
+    assertEquals("Home", breadCrumb.getText());
+  }
+
+  @Test
+  public void testGetHref() {
+    assertEquals("/content/home.html", breadCrumb.getHref());
+  }
+
+  @Test
+  public void testGetTitle() {
+    assertEquals("Home Page", breadCrumb.getTitle());
+  }
+
+  @Test
+  public void testGetAriaLabel() {
+    assertEquals("Home Label", breadCrumb.getAriaLabel());
+  }
+
+  @Test
+  public void testGetTarget() {
+    assertEquals(AnchorTarget.SAME_WINDOW, breadCrumb.getTarget());
+  }
+
+  @Test
+  public void testGetLang() {
+    assertEquals("en", breadCrumb.getLang());
+  }
+}

--- a/src/test/java/io/kestros/cms/components/basic/core/navigation/breadcrumbs/KestrosBreadCrumbsImplTest.java
+++ b/src/test/java/io/kestros/cms/components/basic/core/navigation/breadcrumbs/KestrosBreadCrumbsImplTest.java
@@ -1,0 +1,76 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+package io.kestros.cms.components.basic.core.navigation.breadcrumbs;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import io.kestros.cms.components.basic.api.content.AnchorTarget;
+import io.kestros.cms.components.basic.api.exceptions.ComponentConfigurationException;
+import io.kestros.cms.components.basic.api.navigation.KestrosBreadCrumb;
+import io.kestros.cms.components.basic.core.BaseSyntheticTest;
+import io.kestros.cms.components.basic.core.content.link.KestrosLinkImpl;
+import io.kestros.cms.components.basic.core.lists.cardlist.CardListStaticDataSource;
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.sling.api.resource.Resource;
+import org.junit.Test;
+
+public class KestrosBreadCrumbsImplTest extends BaseSyntheticTest {
+
+  private KestrosBreadCrumbsImpl breadCrumbs;
+
+  @Override
+  public void setupElement() throws ComponentConfigurationException {
+    Resource resource = context.create().resource("/content/parent");
+    context.currentResource(resource);
+    CardListStaticDataSource dataSource = context.request().adaptTo(CardListStaticDataSource.class);
+
+    KestrosLinkImpl homeLink = new KestrosLinkImpl("Home", "/content/home.html", null,
+        AnchorTarget.SAME_WINDOW, null, null, null, null, dataSource, "breadcrumb", "homeLink");
+    KestrosLinkImpl pageLink = new KestrosLinkImpl("Page", "/content/page.html", null,
+        AnchorTarget.SAME_WINDOW, null, null, null, null, dataSource, "breadcrumb", "pageLink");
+
+    List<KestrosBreadCrumb> crumbs = new ArrayList<>();
+    crumbs.add(new KestrosBreadCrumbImpl(homeLink, true, false, dataSource, "breadcrumb", "home"));
+    crumbs.add(new KestrosBreadCrumbImpl(pageLink, false, true, dataSource, "breadcrumb", "page"));
+
+    breadCrumbs = new KestrosBreadCrumbsImpl(crumbs, dataSource, "breadcrumbs",
+        "breadCrumbsElement");
+  }
+
+  @Override
+  public void testToSyntheticResource() {
+    Resource syntheticResource = breadCrumbs.toSyntheticResource(getResourceResolver(), "/parent");
+    assertNotNull(syntheticResource);
+    assertEquals("/synthetics/parent/breadCrumbsElement", syntheticResource.getPath());
+  }
+
+  @Test
+  public void testGetLinkElements() {
+    assertNotNull(breadCrumbs.getLinkElements());
+    assertEquals(2, breadCrumbs.getLinkElements().size());
+  }
+
+  @Test
+  public void testGetLinkElementsIsDefensiveCopy() {
+    List<KestrosBreadCrumb> crumbs = breadCrumbs.getLinkElements();
+    crumbs.clear();
+    assertEquals(2, breadCrumbs.getLinkElements().size());
+  }
+}

--- a/src/test/java/io/kestros/cms/components/basic/core/navigation/nav/KestrosNavigationImplTest.java
+++ b/src/test/java/io/kestros/cms/components/basic/core/navigation/nav/KestrosNavigationImplTest.java
@@ -1,0 +1,67 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+package io.kestros.cms.components.basic.core.navigation.nav;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import io.kestros.cms.components.basic.api.content.AnchorTarget;
+import io.kestros.cms.components.basic.api.exceptions.ComponentConfigurationException;
+import io.kestros.cms.components.basic.api.navigation.KestrosNavigationItem;
+import io.kestros.cms.components.basic.core.BaseSyntheticTest;
+import io.kestros.cms.components.basic.core.content.link.KestrosLinkImpl;
+import io.kestros.cms.components.basic.core.lists.cardlist.CardListStaticDataSource;
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.sling.api.resource.Resource;
+import org.junit.Test;
+
+public class KestrosNavigationImplTest extends BaseSyntheticTest {
+
+  private KestrosNavigationImpl navigation;
+
+  @Override
+  public void setupElement() throws ComponentConfigurationException {
+    Resource resource = context.create().resource("/content/parent");
+    context.currentResource(resource);
+    CardListStaticDataSource dataSource = context.request().adaptTo(CardListStaticDataSource.class);
+
+    List<KestrosNavigationItem> items = new ArrayList<>();
+    navigation = new KestrosNavigationImpl(items, dataSource, "navigation", "navigationElement");
+  }
+
+  @Override
+  public void testToSyntheticResource() {
+    Resource syntheticResource = navigation.toSyntheticResource(getResourceResolver(), "/parent");
+    assertNotNull(syntheticResource);
+    assertEquals("/synthetics/parent/navigationElement", syntheticResource.getPath());
+  }
+
+  @Test
+  public void testGetNavigationLinkElements() {
+    assertNotNull(navigation.getNavigationLinkElements());
+    assertEquals(0, navigation.getNavigationLinkElements().size());
+  }
+
+  @Test
+  public void testGetNavigationLinkElementsIsDefensiveCopy() {
+    List<KestrosNavigationItem> items = navigation.getNavigationLinkElements();
+    items.clear();
+    assertEquals(0, navigation.getNavigationLinkElements().size());
+  }
+}

--- a/src/test/java/io/kestros/cms/components/basic/core/navigation/topnav/KestrosTopNavigationImplTest.java
+++ b/src/test/java/io/kestros/cms/components/basic/core/navigation/topnav/KestrosTopNavigationImplTest.java
@@ -1,0 +1,71 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+package io.kestros.cms.components.basic.core.navigation.topnav;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+import io.kestros.cms.components.basic.api.exceptions.ComponentConfigurationException;
+import io.kestros.cms.components.basic.api.navigation.KestrosTopNavigationItem;
+import io.kestros.cms.components.basic.core.BaseSyntheticTest;
+import io.kestros.cms.components.basic.core.lists.cardlist.CardListStaticDataSource;
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.sling.api.resource.Resource;
+import org.junit.Test;
+
+public class KestrosTopNavigationImplTest extends BaseSyntheticTest {
+
+  private KestrosTopNavigationImpl topNavigation;
+
+  @Override
+  public void setupElement() throws ComponentConfigurationException {
+    Resource resource = context.create().resource("/content/parent");
+    context.currentResource(resource);
+    CardListStaticDataSource dataSource = context.request().adaptTo(CardListStaticDataSource.class);
+
+    List<KestrosTopNavigationItem> items = new ArrayList<>();
+    topNavigation = new KestrosTopNavigationImpl("Brand Name", null, items, dataSource,
+        "topNavigation", "topNavigationElement");
+  }
+
+  @Override
+  public void testToSyntheticResource() {
+    Resource syntheticResource = topNavigation.toSyntheticResource(getResourceResolver(),
+        "/parent");
+    assertNotNull(syntheticResource);
+    assertEquals("/synthetics/parent/topNavigationElement", syntheticResource.getPath());
+  }
+
+  @Test
+  public void testGetNavigationLinkElements() {
+    assertNotNull(topNavigation.getNavigationLinkElements());
+    assertEquals(0, topNavigation.getNavigationLinkElements().size());
+  }
+
+  @Test
+  public void testGetBrandName() {
+    assertEquals("Brand Name", topNavigation.getBrandName());
+  }
+
+  @Test
+  public void testGetImageElement() {
+    assertNull(topNavigation.getImageElement());
+  }
+}

--- a/src/test/java/io/kestros/cms/components/basic/core/navigation/topnav/KestrosTopNavigationItemImplTest.java
+++ b/src/test/java/io/kestros/cms/components/basic/core/navigation/topnav/KestrosTopNavigationItemImplTest.java
@@ -1,0 +1,95 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+package io.kestros.cms.components.basic.core.navigation.topnav;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import io.kestros.cms.components.basic.api.content.AnchorTarget;
+import io.kestros.cms.components.basic.api.exceptions.ComponentConfigurationException;
+import io.kestros.cms.components.basic.api.navigation.KestrosTopNavigationItem;
+import io.kestros.cms.components.basic.core.BaseSyntheticTest;
+import io.kestros.cms.components.basic.core.content.link.KestrosLinkImpl;
+import io.kestros.cms.components.basic.core.lists.cardlist.CardListStaticDataSource;
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.sling.api.resource.Resource;
+import org.junit.Test;
+
+public class KestrosTopNavigationItemImplTest extends BaseSyntheticTest {
+
+  private KestrosTopNavigationItemImpl topNavItem;
+
+  @Override
+  public void setupElement() throws ComponentConfigurationException {
+    Resource resource = context.create().resource("/content/parent");
+    context.currentResource(resource);
+    CardListStaticDataSource dataSource = context.request().adaptTo(CardListStaticDataSource.class);
+
+    KestrosLinkImpl link = new KestrosLinkImpl("Products", "/content/products.html", "Products",
+        AnchorTarget.SAME_WINDOW, null, "Products aria", null, "en",
+        dataSource, "topNavItem", "topNavItemLink");
+
+    List<KestrosTopNavigationItem> children = new ArrayList<>();
+    topNavItem = new KestrosTopNavigationItemImpl(link, children, dataSource, "topNavItem",
+        "topNavItemElement");
+  }
+
+  @Override
+  public void testToSyntheticResource() {
+    Resource syntheticResource = topNavItem.toSyntheticResource(getResourceResolver(), "/parent");
+    assertNotNull(syntheticResource);
+    assertEquals("/synthetics/parent/topNavItemElement", syntheticResource.getPath());
+  }
+
+  @Test
+  public void testGetNavigationItems() {
+    assertNotNull(topNavItem.getNavigationItems());
+    assertEquals(0, topNavItem.getNavigationItems().size());
+  }
+
+  @Test
+  public void testGetText() {
+    assertEquals("Products", topNavItem.getText());
+  }
+
+  @Test
+  public void testGetHref() {
+    assertEquals("/content/products.html", topNavItem.getHref());
+  }
+
+  @Test
+  public void testGetTarget() {
+    assertEquals(AnchorTarget.SAME_WINDOW, topNavItem.getTarget());
+  }
+
+  @Test
+  public void testGetAriaLabel() {
+    assertEquals("Products aria", topNavItem.getAriaLabel());
+  }
+
+  @Test
+  public void testGetTitle() {
+    assertEquals("Products", topNavItem.getTitle());
+  }
+
+  @Test
+  public void testGetLang() {
+    assertEquals("en", topNavItem.getLang());
+  }
+}

--- a/src/test/java/io/kestros/cms/components/basic/core/structure/accordion/KestrosAccordionImplTest.java
+++ b/src/test/java/io/kestros/cms/components/basic/core/structure/accordion/KestrosAccordionImplTest.java
@@ -1,0 +1,70 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+package io.kestros.cms.components.basic.core.structure.accordion;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import io.kestros.cms.components.basic.api.exceptions.ComponentConfigurationException;
+import io.kestros.cms.components.basic.api.structure.KestrosAccordionPanel;
+import io.kestros.cms.components.basic.core.BaseSyntheticTest;
+import io.kestros.cms.components.basic.core.lists.cardlist.CardListStaticDataSource;
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.sling.api.resource.Resource;
+import org.junit.Test;
+
+public class KestrosAccordionImplTest extends BaseSyntheticTest {
+
+  private KestrosAccordionImpl accordion;
+
+  @Override
+  public void setupElement() throws ComponentConfigurationException {
+    Resource resource = context.create().resource("/content/parent");
+    context.currentResource(resource);
+    CardListStaticDataSource dataSource = context.request().adaptTo(CardListStaticDataSource.class);
+
+    List<KestrosAccordionPanel> panels = new ArrayList<>();
+    panels.add(new KestrosAccordionPanelImpl("Panel 1", true, false, "Panel 1 Aria", dataSource,
+        "accordionPanel", "panel1"));
+    panels.add(new KestrosAccordionPanelImpl("Panel 2", false, false, "Panel 2 Aria", dataSource,
+        "accordionPanel", "panel2"));
+
+    accordion = new KestrosAccordionImpl(panels, dataSource, "accordion", "accordionElement");
+  }
+
+  @Override
+  public void testToSyntheticResource() {
+    Resource syntheticResource = accordion.toSyntheticResource(getResourceResolver(), "/parent");
+    assertNotNull(syntheticResource);
+    assertEquals("/synthetics/parent/accordionElement", syntheticResource.getPath());
+  }
+
+  @Test
+  public void testGetPanelElements() {
+    assertNotNull(accordion.getPanelElements());
+    assertEquals(2, accordion.getPanelElements().size());
+  }
+
+  @Test
+  public void testGetPanelElementsIsDefensiveCopy() {
+    List<KestrosAccordionPanel> panels = accordion.getPanelElements();
+    panels.clear();
+    assertEquals(2, accordion.getPanelElements().size());
+  }
+}

--- a/src/test/java/io/kestros/cms/components/basic/core/structure/accordion/KestrosAccordionPanelImplTest.java
+++ b/src/test/java/io/kestros/cms/components/basic/core/structure/accordion/KestrosAccordionPanelImplTest.java
@@ -1,0 +1,71 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+package io.kestros.cms.components.basic.core.structure.accordion;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import io.kestros.cms.components.basic.api.exceptions.ComponentConfigurationException;
+import io.kestros.cms.components.basic.core.BaseSyntheticTest;
+import io.kestros.cms.components.basic.core.lists.cardlist.CardListStaticDataSource;
+import org.apache.sling.api.resource.Resource;
+import org.junit.Test;
+
+public class KestrosAccordionPanelImplTest extends BaseSyntheticTest {
+
+  private KestrosAccordionPanelImpl panel;
+
+  @Override
+  public void setupElement() throws ComponentConfigurationException {
+    Resource resource = context.create().resource("/content/parent");
+    context.currentResource(resource);
+    CardListStaticDataSource dataSource = context.request().adaptTo(CardListStaticDataSource.class);
+
+    panel = new KestrosAccordionPanelImpl("Panel Title", true, false, "Panel Aria Label",
+        dataSource, "accordionPanel", "panelElement");
+  }
+
+  @Override
+  public void testToSyntheticResource() {
+    Resource syntheticResource = panel.toSyntheticResource(getResourceResolver(), "/parent");
+    assertNotNull(syntheticResource);
+    assertEquals("/synthetics/parent/panelElement", syntheticResource.getPath());
+  }
+
+  @Test
+  public void testGetTitle() {
+    assertEquals("Panel Title", panel.getTitle());
+  }
+
+  @Test
+  public void testIsExpanded() {
+    assertTrue(panel.isExpanded());
+  }
+
+  @Test
+  public void testIsDisabled() {
+    assertFalse(panel.isDisabled());
+  }
+
+  @Test
+  public void testGetAriaLabel() {
+    assertEquals("Panel Aria Label", panel.getAriaLabel());
+  }
+}

--- a/src/test/java/io/kestros/cms/components/basic/core/structure/container/KestrosContainerImplTest.java
+++ b/src/test/java/io/kestros/cms/components/basic/core/structure/container/KestrosContainerImplTest.java
@@ -1,0 +1,69 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+package io.kestros.cms.components.basic.core.structure.container;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import io.kestros.cms.components.basic.api.KestrosBasicComponentElement;
+import io.kestros.cms.components.basic.api.exceptions.ComponentConfigurationException;
+import io.kestros.cms.components.basic.core.BaseSyntheticTest;
+import io.kestros.cms.components.basic.core.content.richtext.KestrosRichTextImpl;
+import io.kestros.cms.components.basic.core.lists.cardlist.CardListStaticDataSource;
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.sling.api.resource.Resource;
+import org.junit.Test;
+
+public class KestrosContainerImplTest extends BaseSyntheticTest {
+
+  private KestrosContainerImpl container;
+
+  @Override
+  public void setupElement() throws ComponentConfigurationException {
+    Resource resource = context.create().resource("/content/parent");
+    context.currentResource(resource);
+    CardListStaticDataSource dataSource = context.request().adaptTo(CardListStaticDataSource.class);
+
+    List<KestrosBasicComponentElement> elements = new ArrayList<>();
+    elements.add(new KestrosRichTextImpl("<p>Child 1</p>", dataSource, "richtext", "child1"));
+    elements.add(new KestrosRichTextImpl("<p>Child 2</p>", dataSource, "richtext", "child2"));
+
+    container = new KestrosContainerImpl(elements, dataSource, "container", "containerElement");
+  }
+
+  @Override
+  public void testToSyntheticResource() {
+    Resource syntheticResource = container.toSyntheticResource(getResourceResolver(), "/parent");
+    assertNotNull(syntheticResource);
+    assertEquals("/synthetics/parent/containerElement", syntheticResource.getPath());
+  }
+
+  @Test
+  public void testGetChildElements() {
+    assertNotNull(container.getChildElements());
+    assertEquals(2, container.getChildElements().size());
+  }
+
+  @Test
+  public void testGetChildElementsIsDefensiveCopy() {
+    List<KestrosBasicComponentElement> elements = container.getChildElements();
+    elements.clear();
+    assertEquals(2, container.getChildElements().size());
+  }
+}

--- a/src/test/java/io/kestros/cms/components/basic/core/structure/grid/KestrosGridImplTest.java
+++ b/src/test/java/io/kestros/cms/components/basic/core/structure/grid/KestrosGridImplTest.java
@@ -1,0 +1,60 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+package io.kestros.cms.components.basic.core.structure.grid;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import io.kestros.cms.components.basic.api.KestrosBasicComponentElement;
+import io.kestros.cms.components.basic.api.exceptions.ComponentConfigurationException;
+import io.kestros.cms.components.basic.api.structure.KestrosContainer;
+import io.kestros.cms.components.basic.core.BaseSyntheticTest;
+import io.kestros.cms.components.basic.core.lists.cardlist.CardListStaticDataSource;
+import io.kestros.cms.components.basic.core.structure.container.KestrosContainerImpl;
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.sling.api.resource.Resource;
+import org.junit.Test;
+
+public class KestrosGridImplTest extends BaseSyntheticTest {
+
+  private KestrosGridImpl grid;
+
+  @Override
+  public void setupElement() throws ComponentConfigurationException {
+    Resource resource = context.create().resource("/content/parent");
+    context.currentResource(resource);
+    CardListStaticDataSource dataSource = context.request().adaptTo(
+        CardListStaticDataSource.class);
+
+    List<KestrosContainer> columns = new ArrayList<>();
+    columns.add(new KestrosContainerImpl(
+        new ArrayList<KestrosBasicComponentElement>(), dataSource, "column", "col1"));
+    columns.add(new KestrosContainerImpl(
+        new ArrayList<KestrosBasicComponentElement>(), dataSource, "column", "col2"));
+
+    grid = new KestrosGridImpl(columns, dataSource, "grid", "gridElement");
+  }
+
+  @Override
+  public void testToSyntheticResource() {
+    Resource syntheticResource = grid.toSyntheticResource(getResourceResolver(), "/parent");
+    assertNotNull(syntheticResource);
+    assertEquals("/synthetics/parent/gridElement", syntheticResource.getPath());
+  }
+}

--- a/src/test/java/io/kestros/cms/components/basic/core/structure/section/KestrosSectionImplTest.java
+++ b/src/test/java/io/kestros/cms/components/basic/core/structure/section/KestrosSectionImplTest.java
@@ -1,0 +1,75 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+package io.kestros.cms.components.basic.core.structure.section;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+import io.kestros.cms.components.basic.api.KestrosBasicComponentElement;
+import io.kestros.cms.components.basic.api.exceptions.ComponentConfigurationException;
+import io.kestros.cms.components.basic.core.BaseSyntheticTest;
+import io.kestros.cms.components.basic.core.content.richtext.KestrosRichTextImpl;
+import io.kestros.cms.components.basic.core.lists.cardlist.CardListStaticDataSource;
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.sling.api.resource.Resource;
+import org.junit.Test;
+
+public class KestrosSectionImplTest extends BaseSyntheticTest {
+
+  private KestrosSectionImpl section;
+  private KestrosSectionImpl sectionWithBackground;
+
+  @Override
+  public void setupElement() throws ComponentConfigurationException {
+    Resource resource = context.create().resource("/content/parent");
+    context.currentResource(resource);
+    CardListStaticDataSource dataSource = context.request().adaptTo(CardListStaticDataSource.class);
+
+    List<KestrosBasicComponentElement> elements = new ArrayList<>();
+    elements.add(new KestrosRichTextImpl("<p>Child</p>", dataSource, "richtext", "child1"));
+
+    section = new KestrosSectionImpl(null, elements, dataSource, "section", "sectionElement");
+    sectionWithBackground = new KestrosSectionImpl("/content/assets/bg.jpg", elements, dataSource,
+        "section", "sectionWithBg");
+  }
+
+  @Override
+  public void testToSyntheticResource() {
+    Resource syntheticResource = section.toSyntheticResource(getResourceResolver(), "/parent");
+    assertNotNull(syntheticResource);
+    assertEquals("/synthetics/parent/sectionElement", syntheticResource.getPath());
+  }
+
+  @Test
+  public void testGetBackgroundImageWhenNull() {
+    assertNull(section.getBackgroundImage());
+  }
+
+  @Test
+  public void testGetBackgroundImage() {
+    assertEquals("/content/assets/bg.jpg", sectionWithBackground.getBackgroundImage());
+  }
+
+  @Test
+  public void testGetChildElements() {
+    assertNotNull(section.getChildElements());
+    assertEquals(1, section.getChildElements().size());
+  }
+}


### PR DESCRIPTION
## Summary

- Adds 22 unit test classes covering every Impl class in kestros-basic-components
- Fixes 3 bugs where constructor parameters were accepted but never assigned to instance fields: `KestrosTextImpl.text`, `KestrosAccordionImpl.panels`, `KestrosSectionImpl.backgroundImage`

## Test coverage added

Content: `KestrosButtonImplTest`, `KestrosButtonGroupImplTest`, `KestrosCodeImplTest`, `KestrosHeadingImplTest`, `KestrosImageImplTest`, `KestrosLinkImplTest`, `KestrosRichTextImplTest`, `KestrosTextImplTest`, `KestrosVideoImplTest`, `KestrosVideoEmbedImplTest`

Lists: `KestrosCardListImplTest`, `KestrosLinkListImplTest`

Navigation: `KestrosBreadCrumbImplTest`, `KestrosBreadCrumbsImplTest`, `KestrosNavigationImplTest`, `KestrosTopNavigationImplTest`, `KestrosTopNavigationItemImplTest`

Structure: `KestrosAccordionImplTest`, `KestrosAccordionPanelImplTest`, `KestrosContainerImplTest`, `KestrosGridImplTest`, `KestrosSectionImplTest`

## Test results

339 tests, 0 failures, 0 errors, 1 skipped (pre-existing @Ignore)

Closes TASK-007