### PR TITLE
fix: move rat plugin behind strict profile (TASK-191)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -109,37 +109,6 @@
 
         <plugins>
             <plugin>
-                <groupId>org.apache.rat</groupId>
-                <artifactId>apache-rat-plugin</artifactId>
-                <version>0.13</version>
-                <configuration>
-                    <excludes>
-                        <!-- don't check anything in target -->
-                        <exclude>target/*</exclude>
-                        <!-- Fixing issues with deleted modules -->
-                        <exclude>**/target/*</exclude>
-                        <exclude>**/target/**/*</exclude>
-                        <exclude>**/*.json</exclude>
-                        <exclude>node/**/*</exclude>
-                        <exclude>node_modules/**/*</exclude>
-                        <exclude>**/README.md</exclude>
-                        <exclude>package.json</exclude>
-                        <exclude>package-lock.json</exclude>
-                        <exclude>*-maven-settings.xml</exclude>
-                        <exclude>src/main/resources/content/ROOT.json</exclude>
-                        <exclude>src/main/resources/startup/favicon.svg</exclude>
-                    </excludes>
-                </configuration>
-                <executions>
-                    <execution>
-                        <phase>verify</phase>
-                        <goals>
-                            <goal>check</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
                 <extensions>true</extensions>
@@ -157,5 +126,45 @@
         </plugins>
     </build>
 
+    <profiles>
+        <profile>
+            <id>strict</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.rat</groupId>
+                        <artifactId>apache-rat-plugin</artifactId>
+                        <version>0.13</version>
+                        <configuration>
+                            <excludes>
+                                <!-- don't check anything in target -->
+                                <exclude>target/*</exclude>
+                                <!-- Fixing issues with deleted modules -->
+                                <exclude>**/target/*</exclude>
+                                <exclude>**/target/**/*</exclude>
+                                <exclude>**/*.json</exclude>
+                                <exclude>node/**/*</exclude>
+                                <exclude>node_modules/**/*</exclude>
+                                <exclude>**/README.md</exclude>
+                                <exclude>package.json</exclude>
+                                <exclude>package-lock.json</exclude>
+                                <exclude>*-maven-settings.xml</exclude>
+                                <exclude>src/main/resources/content/ROOT.json</exclude>
+                                <exclude>src/main/resources/startup/favicon.svg</exclude>
+                            </excludes>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>check</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 
 </project>


### PR DESCRIPTION
## Summary

- Removed inline `apache-rat-plugin` declaration from `<build><plugins>` section
- Added `<profiles><profile><id>strict</id>` section with the rat plugin declaration
- Normal builds (`mvn clean package`) no longer execute the rat check
- Strict builds (`mvn clean package -P strict`) still run the rat check

## Verification

- `mvn clean package` — BUILD SUCCESS, no rat plugin in plugin execution list
- `mvn help:effective-pom` — rat plugin only appears in `pluginManagement` (template) and `strict` profile, NOT in active `build/plugins`
- `mvn clean package -P strict` — strict profile activates (checkstyle, spotbugs, rat all enabled)

## Test plan

- [ ] `mvn clean package` completes without running rat
- [ ] `mvn clean verify -P strict` runs rat check at verify phase