### PR TITLE
fix: convert selectfield options to JCR child nodes (TASK-197)

### DIFF
--- a/src/main/resources/libs/kestros/commons/components/lists/card-list/datasources/asset-list.json
+++ b/src/main/resources/libs/kestros/commons/components/lists/card-list/datasources/asset-list.json
@@ -27,11 +27,25 @@
         "sling:resourceType": "kestros/cms2/fields/general/selectfield",
         "label": "Sort By",
         "name": "sortBy",
-        "options": [
-          { "value": "", "text": "None (natural order)", "selected": true },
-          { "value": "title", "text": "Title" },
-          { "value": "name", "text": "Name" }
-        ]
+        "options": {
+          "jcr:primaryType": "nt:unstructured",
+          "none": {
+            "jcr:primaryType": "nt:unstructured",
+            "text": "None (natural order)",
+            "value": "",
+            "selected": true
+          },
+          "title": {
+            "jcr:primaryType": "nt:unstructured",
+            "text": "Title",
+            "value": "title"
+          },
+          "name": {
+            "jcr:primaryType": "nt:unstructured",
+            "text": "Name",
+            "value": "name"
+          }
+        }
       },
       "reverse": {
         "jcr:primaryType": "nt:unstructured",

--- a/src/main/resources/libs/kestros/commons/components/lists/card-list/datasources/child-pages.json
+++ b/src/main/resources/libs/kestros/commons/components/lists/card-list/datasources/child-pages.json
@@ -35,11 +35,25 @@
         "sling:resourceType": "kestros/cms2/fields/general/selectfield",
         "label": "Sort By",
         "name": "sortBy",
-        "options": [
-          { "value": "", "text": "None (natural order)", "selected": true },
-          { "value": "title", "text": "Title" },
-          { "value": "name", "text": "Name" }
-        ]
+        "options": {
+          "jcr:primaryType": "nt:unstructured",
+          "none": {
+            "jcr:primaryType": "nt:unstructured",
+            "text": "None (natural order)",
+            "value": "",
+            "selected": true
+          },
+          "title": {
+            "jcr:primaryType": "nt:unstructured",
+            "text": "Title",
+            "value": "title"
+          },
+          "name": {
+            "jcr:primaryType": "nt:unstructured",
+            "text": "Name",
+            "value": "name"
+          }
+        }
       },
       "reverse": {
         "jcr:primaryType": "nt:unstructured",

--- a/src/main/resources/libs/kestros/commons/components/lists/card-list/datasources/tag-search.json
+++ b/src/main/resources/libs/kestros/commons/components/lists/card-list/datasources/tag-search.json
@@ -29,11 +29,25 @@
         "sling:resourceType": "kestros/cms2/fields/general/selectfield",
         "label": "Sort By",
         "name": "sortBy",
-        "options": [
-          { "value": "", "text": "None (natural order)", "selected": true },
-          { "value": "title", "text": "Title" },
-          { "value": "name", "text": "Name" }
-        ]
+        "options": {
+          "jcr:primaryType": "nt:unstructured",
+          "none": {
+            "jcr:primaryType": "nt:unstructured",
+            "text": "None (natural order)",
+            "value": "",
+            "selected": true
+          },
+          "title": {
+            "jcr:primaryType": "nt:unstructured",
+            "text": "Title",
+            "value": "title"
+          },
+          "name": {
+            "jcr:primaryType": "nt:unstructured",
+            "text": "Name",
+            "value": "name"
+          }
+        }
       },
       "reverse": {
         "jcr:primaryType": "nt:unstructured",

--- a/src/main/resources/libs/kestros/commons/components/lists/link-list/datasources/child-pages.json
+++ b/src/main/resources/libs/kestros/commons/components/lists/link-list/datasources/child-pages.json
@@ -27,11 +27,25 @@
         "sling:resourceType": "kestros/cms2/fields/general/selectfield",
         "label": "Sort By",
         "name": "sortBy",
-        "options": [
-          { "value": "", "text": "None (natural order)", "selected": true },
-          { "value": "title", "text": "Title" },
-          { "value": "name", "text": "Name" }
-        ]
+        "options": {
+          "jcr:primaryType": "nt:unstructured",
+          "none": {
+            "jcr:primaryType": "nt:unstructured",
+            "text": "None (natural order)",
+            "value": "",
+            "selected": true
+          },
+          "title": {
+            "jcr:primaryType": "nt:unstructured",
+            "text": "Title",
+            "value": "title"
+          },
+          "name": {
+            "jcr:primaryType": "nt:unstructured",
+            "text": "Name",
+            "value": "name"
+          }
+        }
       },
       "reverse": {
         "jcr:primaryType": "nt:unstructured",

--- a/src/main/resources/libs/kestros/commons/components/lists/link-list/datasources/tag-search.json
+++ b/src/main/resources/libs/kestros/commons/components/lists/link-list/datasources/tag-search.json
@@ -26,11 +26,25 @@
         "sling:resourceType": "kestros/cms2/fields/general/selectfield",
         "label": "Sort By",
         "name": "sortBy",
-        "options": [
-          { "value": "", "text": "None (natural order)", "selected": true },
-          { "value": "title", "text": "Title" },
-          { "value": "name", "text": "Name" }
-        ]
+        "options": {
+          "jcr:primaryType": "nt:unstructured",
+          "none": {
+            "jcr:primaryType": "nt:unstructured",
+            "text": "None (natural order)",
+            "value": "",
+            "selected": true
+          },
+          "title": {
+            "jcr:primaryType": "nt:unstructured",
+            "text": "Title",
+            "value": "title"
+          },
+          "name": {
+            "jcr:primaryType": "nt:unstructured",
+            "text": "Name",
+            "value": "name"
+          }
+        }
       },
       "reverse": {
         "jcr:primaryType": "nt:unstructured",


### PR DESCRIPTION
## Summary
- Sort By dropdown was rendering empty in all 5 list datasource dialogs
- Root cause: options stored as JSON array properties, but `SelectFieldDialogContext` uses `@ChildResource` injection which requires JCR child nodes
- Converted options in all 5 files to child-node format matching the heading dialog pattern

## Files changed
- card-list/datasources/tag-search.json
- card-list/datasources/child-pages.json
- card-list/datasources/asset-list.json
- link-list/datasources/child-pages.json
- link-list/datasources/tag-search.json

## Verified
- Deployed to port 8000 and 8001, bundle Active
- Sort By dropdown now shows: None (natural order), Title, Name