### PR TITLE
feat: complete TASK-197 list datasource sort/reverse/limit

### DIFF
--- a/src/main/java/io/kestros/cms/components/basic/core/lists/cardlist/CardListAssetsDataSource.java
+++ b/src/main/java/io/kestros/cms/components/basic/core/lists/cardlist/CardListAssetsDataSource.java
@@ -19,6 +19,7 @@ import io.kestros.cms.componenttypes.api.models.ComponentVariation;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.Date;
 import java.util.List;
 import javax.annotation.Nonnull;
 import org.apache.sling.api.SlingHttpServletRequest;
@@ -64,14 +65,21 @@ public class CardListAssetsDataSource extends BaseContainerSlingModelDataSource 
     }
 
     if (!sortBy.isEmpty()) {
-      assets.sort(Comparator.comparing(a -> {
-        switch (sortBy) {
-          case "name":
-            return a.getName() != null ? a.getName() : "";
-          default:
-            return a.getTitle() != null ? a.getTitle() : a.getName();
-        }
-      }));
+      if ("created".equals(sortBy) || "modified".equals(sortBy)) {
+        assets.sort(Comparator.comparing(a -> {
+          Date date = "created".equals(sortBy) ? a.getCreatedDate() : a.getModifiedDate();
+          return date != null ? date.getTime() : 0L;
+        }));
+      } else {
+        assets.sort(Comparator.comparing(a -> {
+          switch (sortBy) {
+            case "name":
+              return a.getName() != null ? a.getName() : "";
+            default:
+              return a.getTitle() != null ? a.getTitle() : a.getName();
+          }
+        }));
+      }
     }
 
     if (reverse) {

--- a/src/main/java/io/kestros/cms/components/basic/core/lists/cardlist/CardListChildPagesDataSource.java
+++ b/src/main/java/io/kestros/cms/components/basic/core/lists/cardlist/CardListChildPagesDataSource.java
@@ -11,6 +11,7 @@ import io.kestros.cms.sitebuilding.api.models.BaseComponent;
 import io.kestros.cms.sitebuilding.api.models.BaseContentPage;
 import io.kestros.commons.structuredslingmodels.exceptions.NoValidAncestorException;
 import java.util.ArrayList;
+import java.util.Calendar;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
@@ -68,14 +69,28 @@ public class CardListChildPagesDataSource extends BaseContainerSlingModelDataSou
     }
 
     if (!sortBy.isEmpty()) {
-      pages.sort(Comparator.comparing(p -> {
-        switch (sortBy) {
-          case "name":
-            return p.getName() != null ? p.getName() : "";
-          default:
-            return p.getDisplayTitle() != null ? p.getDisplayTitle() : p.getName();
-        }
-      }));
+      if ("created".equals(sortBy) || "modified".equals(sortBy)) {
+        String jcrProperty = "created".equals(sortBy) ? "jcr:created" : "jcr:lastModified";
+        pages.sort(Comparator.comparing(p -> {
+          Resource content = p.getResource().getChild("jcr:content");
+          if (content != null) {
+            Calendar cal = content.getValueMap().get(jcrProperty, Calendar.class);
+            if (cal != null) {
+              return cal.getTimeInMillis();
+            }
+          }
+          return 0L;
+        }));
+      } else {
+        pages.sort(Comparator.comparing(p -> {
+          switch (sortBy) {
+            case "name":
+              return p.getName() != null ? p.getName() : "";
+            default:
+              return p.getDisplayTitle() != null ? p.getDisplayTitle() : p.getName();
+          }
+        }));
+      }
     }
 
     if (reverse) {

--- a/src/main/java/io/kestros/cms/components/basic/core/lists/cardlist/CardListTagSearchDataSource.java
+++ b/src/main/java/io/kestros/cms/components/basic/core/lists/cardlist/CardListTagSearchDataSource.java
@@ -10,6 +10,7 @@ import io.kestros.cms.tagging.api.models.KestrosTag;
 import io.kestros.cms.tagging.api.services.TagRetrievalService;
 import io.kestros.commons.structuredslingmodels.exceptions.NoValidAncestorException;
 import java.util.ArrayList;
+import java.util.Calendar;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashSet;
@@ -136,14 +137,28 @@ public class CardListTagSearchDataSource extends BaseContainerSlingModelDataSour
 
     String sortBy = getSortBy();
     if (!sortBy.isEmpty()) {
-      pages.sort(Comparator.comparing(p -> {
-        switch (sortBy) {
-          case "name":
-            return p.getName() != null ? p.getName() : "";
-          default:
-            return p.getDisplayTitle() != null ? p.getDisplayTitle() : p.getName();
-        }
-      }));
+      if ("created".equals(sortBy) || "modified".equals(sortBy)) {
+        String jcrProperty = "created".equals(sortBy) ? "jcr:created" : "jcr:lastModified";
+        pages.sort(Comparator.comparing(p -> {
+          Resource content = p.getResource().getChild("jcr:content");
+          if (content != null) {
+            Calendar cal = content.getValueMap().get(jcrProperty, Calendar.class);
+            if (cal != null) {
+              return cal.getTimeInMillis();
+            }
+          }
+          return 0L;
+        }));
+      } else {
+        pages.sort(Comparator.comparing(p -> {
+          switch (sortBy) {
+            case "name":
+              return p.getName() != null ? p.getName() : "";
+            default:
+              return p.getDisplayTitle() != null ? p.getDisplayTitle() : p.getName();
+          }
+        }));
+      }
     }
 
     if (isReverseOrder()) {

--- a/src/main/java/io/kestros/cms/components/basic/core/lists/cardlist/CardListTagSearchDataSource.java
+++ b/src/main/java/io/kestros/cms/components/basic/core/lists/cardlist/CardListTagSearchDataSource.java
@@ -10,6 +10,8 @@ import io.kestros.cms.tagging.api.models.KestrosTag;
 import io.kestros.cms.tagging.api.services.TagRetrievalService;
 import io.kestros.commons.structuredslingmodels.exceptions.NoValidAncestorException;
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -110,11 +112,51 @@ public class CardListTagSearchDataSource extends BaseContainerSlingModelDataSour
     return taggedPages;
   }
 
+  String getSortBy() {
+    return getResource().getValueMap().get("sortBy", "");
+  }
+
+  boolean isReverseOrder() {
+    return getResource().getValueMap().get("reverse", false);
+  }
+
+  int getLimit() {
+    try {
+      return Math.max(0, Integer.parseInt(
+          getResource().getValueMap().get("limit", "0").trim()));
+    } catch (NumberFormatException e) {
+      return 0;
+    }
+  }
+
   @Nonnull
   @Override
   public List<KestrosCard> getCardElements() {
+    List<BaseContentPage> pages = new ArrayList<>(getTaggedPages());
+
+    String sortBy = getSortBy();
+    if (!sortBy.isEmpty()) {
+      pages.sort(Comparator.comparing(p -> {
+        switch (sortBy) {
+          case "name":
+            return p.getName() != null ? p.getName() : "";
+          default:
+            return p.getDisplayTitle() != null ? p.getDisplayTitle() : p.getName();
+        }
+      }));
+    }
+
+    if (isReverseOrder()) {
+      Collections.reverse(pages);
+    }
+
+    int limit = getLimit();
+    if (limit > 0 && pages.size() > limit) {
+      pages = new ArrayList<>(pages.subList(0, limit));
+    }
+
     List<KestrosCard> cards = new ArrayList<>();
-    for (BaseContentPage page : getTaggedPages()) {
+    for (BaseContentPage page : pages) {
       try {
         cards.add(
             new KestrosCardImpl(page,

--- a/src/main/java/io/kestros/cms/components/basic/core/lists/linklist/LinkListChildPageDataSource.java
+++ b/src/main/java/io/kestros/cms/components/basic/core/lists/linklist/LinkListChildPageDataSource.java
@@ -10,6 +10,7 @@ import io.kestros.cms.componenttypes.api.services.ComponentUiFrameworkViewRetrie
 import io.kestros.cms.componenttypes.api.services.ComponentVariationRetrievalService;
 import io.kestros.cms.sitebuilding.api.models.BaseContentPage;
 import java.util.ArrayList;
+import java.util.Calendar;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
@@ -59,14 +60,28 @@ public class LinkListChildPageDataSource extends BaseContainerSlingModelDataSour
     }
 
     if (!sortBy.isEmpty()) {
-      pages.sort(Comparator.comparing(p -> {
-        switch (sortBy) {
-          case "name":
-            return p.getName() != null ? p.getName() : "";
-          default:
-            return p.getDisplayTitle() != null ? p.getDisplayTitle() : p.getName();
-        }
-      }));
+      if ("created".equals(sortBy) || "modified".equals(sortBy)) {
+        String jcrProperty = "created".equals(sortBy) ? "jcr:created" : "jcr:lastModified";
+        pages.sort(Comparator.comparing(p -> {
+          Resource content = p.getResource().getChild("jcr:content");
+          if (content != null) {
+            Calendar cal = content.getValueMap().get(jcrProperty, Calendar.class);
+            if (cal != null) {
+              return cal.getTimeInMillis();
+            }
+          }
+          return 0L;
+        }));
+      } else {
+        pages.sort(Comparator.comparing(p -> {
+          switch (sortBy) {
+            case "name":
+              return p.getName() != null ? p.getName() : "";
+            default:
+              return p.getDisplayTitle() != null ? p.getDisplayTitle() : p.getName();
+          }
+        }));
+      }
     }
 
     if (reverse) {

--- a/src/main/resources/libs/kestros/commons/components/lists/card-list/datasources/asset-list.json
+++ b/src/main/resources/libs/kestros/commons/components/lists/card-list/datasources/asset-list.json
@@ -44,6 +44,16 @@
             "jcr:primaryType": "nt:unstructured",
             "text": "Name",
             "value": "name"
+          },
+          "created": {
+            "jcr:primaryType": "nt:unstructured",
+            "text": "Created Date",
+            "value": "created"
+          },
+          "modified": {
+            "jcr:primaryType": "nt:unstructured",
+            "text": "Last Modified",
+            "value": "modified"
           }
         }
       },

--- a/src/main/resources/libs/kestros/commons/components/lists/card-list/datasources/asset-list.json
+++ b/src/main/resources/libs/kestros/commons/components/lists/card-list/datasources/asset-list.json
@@ -27,11 +27,25 @@
         "sling:resourceType": "kestros/cms2/fields/general/selectfield",
         "label": "Sort By",
         "name": "sortBy",
-        "options": [
-          { "value": "", "text": "None (natural order)", "selected": true },
-          { "value": "title", "text": "Title" },
-          { "value": "name", "text": "Name" }
-        ]
+        "options": {
+          "jcr:primaryType": "nt:unstructured",
+          "none": {
+            "jcr:primaryType": "nt:unstructured",
+            "text": "None (natural order)",
+            "value": "",
+            "selected": true
+          },
+          "title": {
+            "jcr:primaryType": "nt:unstructured",
+            "text": "Title",
+            "value": "title"
+          },
+          "name": {
+            "jcr:primaryType": "nt:unstructured",
+            "text": "Name",
+            "value": "name"
+          }
+        }
       },
       "reverse": {
         "jcr:primaryType": "nt:unstructured",

--- a/src/main/resources/libs/kestros/commons/components/lists/card-list/datasources/child-pages.json
+++ b/src/main/resources/libs/kestros/commons/components/lists/card-list/datasources/child-pages.json
@@ -52,6 +52,16 @@
             "jcr:primaryType": "nt:unstructured",
             "text": "Name",
             "value": "name"
+          },
+          "created": {
+            "jcr:primaryType": "nt:unstructured",
+            "text": "Created Date",
+            "value": "created"
+          },
+          "modified": {
+            "jcr:primaryType": "nt:unstructured",
+            "text": "Last Modified",
+            "value": "modified"
           }
         }
       },

--- a/src/main/resources/libs/kestros/commons/components/lists/card-list/datasources/child-pages.json
+++ b/src/main/resources/libs/kestros/commons/components/lists/card-list/datasources/child-pages.json
@@ -35,11 +35,25 @@
         "sling:resourceType": "kestros/cms2/fields/general/selectfield",
         "label": "Sort By",
         "name": "sortBy",
-        "options": [
-          { "value": "", "text": "None (natural order)", "selected": true },
-          { "value": "title", "text": "Title" },
-          { "value": "name", "text": "Name" }
-        ]
+        "options": {
+          "jcr:primaryType": "nt:unstructured",
+          "none": {
+            "jcr:primaryType": "nt:unstructured",
+            "text": "None (natural order)",
+            "value": "",
+            "selected": true
+          },
+          "title": {
+            "jcr:primaryType": "nt:unstructured",
+            "text": "Title",
+            "value": "title"
+          },
+          "name": {
+            "jcr:primaryType": "nt:unstructured",
+            "text": "Name",
+            "value": "name"
+          }
+        }
       },
       "reverse": {
         "jcr:primaryType": "nt:unstructured",

--- a/src/main/resources/libs/kestros/commons/components/lists/card-list/datasources/tag-search.json
+++ b/src/main/resources/libs/kestros/commons/components/lists/card-list/datasources/tag-search.json
@@ -46,6 +46,16 @@
             "jcr:primaryType": "nt:unstructured",
             "text": "Name",
             "value": "name"
+          },
+          "created": {
+            "jcr:primaryType": "nt:unstructured",
+            "text": "Created Date",
+            "value": "created"
+          },
+          "modified": {
+            "jcr:primaryType": "nt:unstructured",
+            "text": "Last Modified",
+            "value": "modified"
           }
         }
       },

--- a/src/main/resources/libs/kestros/commons/components/lists/card-list/datasources/tag-search.json
+++ b/src/main/resources/libs/kestros/commons/components/lists/card-list/datasources/tag-search.json
@@ -29,11 +29,25 @@
         "sling:resourceType": "kestros/cms2/fields/general/selectfield",
         "label": "Sort By",
         "name": "sortBy",
-        "options": [
-          { "value": "", "text": "None (natural order)", "selected": true },
-          { "value": "title", "text": "Title" },
-          { "value": "name", "text": "Name" }
-        ]
+        "options": {
+          "jcr:primaryType": "nt:unstructured",
+          "none": {
+            "jcr:primaryType": "nt:unstructured",
+            "text": "None (natural order)",
+            "value": "",
+            "selected": true
+          },
+          "title": {
+            "jcr:primaryType": "nt:unstructured",
+            "text": "Title",
+            "value": "title"
+          },
+          "name": {
+            "jcr:primaryType": "nt:unstructured",
+            "text": "Name",
+            "value": "name"
+          }
+        }
       },
       "reverse": {
         "jcr:primaryType": "nt:unstructured",

--- a/src/main/resources/libs/kestros/commons/components/lists/link-list/datasources/child-pages.json
+++ b/src/main/resources/libs/kestros/commons/components/lists/link-list/datasources/child-pages.json
@@ -44,6 +44,16 @@
             "jcr:primaryType": "nt:unstructured",
             "text": "Name",
             "value": "name"
+          },
+          "created": {
+            "jcr:primaryType": "nt:unstructured",
+            "text": "Created Date",
+            "value": "created"
+          },
+          "modified": {
+            "jcr:primaryType": "nt:unstructured",
+            "text": "Last Modified",
+            "value": "modified"
           }
         }
       },

--- a/src/main/resources/libs/kestros/commons/components/lists/link-list/datasources/child-pages.json
+++ b/src/main/resources/libs/kestros/commons/components/lists/link-list/datasources/child-pages.json
@@ -27,11 +27,25 @@
         "sling:resourceType": "kestros/cms2/fields/general/selectfield",
         "label": "Sort By",
         "name": "sortBy",
-        "options": [
-          { "value": "", "text": "None (natural order)", "selected": true },
-          { "value": "title", "text": "Title" },
-          { "value": "name", "text": "Name" }
-        ]
+        "options": {
+          "jcr:primaryType": "nt:unstructured",
+          "none": {
+            "jcr:primaryType": "nt:unstructured",
+            "text": "None (natural order)",
+            "value": "",
+            "selected": true
+          },
+          "title": {
+            "jcr:primaryType": "nt:unstructured",
+            "text": "Title",
+            "value": "title"
+          },
+          "name": {
+            "jcr:primaryType": "nt:unstructured",
+            "text": "Name",
+            "value": "name"
+          }
+        }
       },
       "reverse": {
         "jcr:primaryType": "nt:unstructured",

--- a/src/main/resources/libs/kestros/commons/components/lists/link-list/datasources/tag-search.json
+++ b/src/main/resources/libs/kestros/commons/components/lists/link-list/datasources/tag-search.json
@@ -26,11 +26,25 @@
         "sling:resourceType": "kestros/cms2/fields/general/selectfield",
         "label": "Sort By",
         "name": "sortBy",
-        "options": [
-          { "value": "", "text": "None (natural order)", "selected": true },
-          { "value": "title", "text": "Title" },
-          { "value": "name", "text": "Name" }
-        ]
+        "options": {
+          "jcr:primaryType": "nt:unstructured",
+          "none": {
+            "jcr:primaryType": "nt:unstructured",
+            "text": "None (natural order)",
+            "value": "",
+            "selected": true
+          },
+          "title": {
+            "jcr:primaryType": "nt:unstructured",
+            "text": "Title",
+            "value": "title"
+          },
+          "name": {
+            "jcr:primaryType": "nt:unstructured",
+            "text": "Name",
+            "value": "name"
+          }
+        }
       },
       "reverse": {
         "jcr:primaryType": "nt:unstructured",

--- a/src/main/resources/libs/kestros/commons/components/lists/link-list/datasources/tag-search.json
+++ b/src/main/resources/libs/kestros/commons/components/lists/link-list/datasources/tag-search.json
@@ -43,6 +43,16 @@
             "jcr:primaryType": "nt:unstructured",
             "text": "Name",
             "value": "name"
+          },
+          "created": {
+            "jcr:primaryType": "nt:unstructured",
+            "text": "Created Date",
+            "value": "created"
+          },
+          "modified": {
+            "jcr:primaryType": "nt:unstructured",
+            "text": "Last Modified",
+            "value": "modified"
           }
         }
       },

--- a/src/test/java/io/kestros/cms/components/basic/core/lists/LinkListChildPageDataSourceTest.java
+++ b/src/test/java/io/kestros/cms/components/basic/core/lists/LinkListChildPageDataSourceTest.java
@@ -175,4 +175,46 @@ public class LinkListChildPageDataSourceTest extends BaseDataSourceTest {
     assertEquals(1, linkListChildPageDataSource.getLinkElements().size());
   }
 
+  @Test
+  public void testGetLinkElements_sortByCreated_doesNotCrash() {
+    properties.put("sortBy", "created");
+    resource = context.create().resource("/content/linklist/childpages/ds-sortby-created",
+        properties);
+    context.request().setResource(resource);
+    linkListChildPageDataSource = context.request().adaptTo(LinkListChildPageDataSource.class);
+    assertEquals(3, linkListChildPageDataSource.getLinkElements().size());
+  }
+
+  @Test
+  public void testGetLinkElements_sortByModified_doesNotCrash() {
+    properties.put("sortBy", "modified");
+    resource = context.create().resource("/content/linklist/childpages/ds-sortby-modified",
+        properties);
+    context.request().setResource(resource);
+    linkListChildPageDataSource = context.request().adaptTo(LinkListChildPageDataSource.class);
+    assertEquals(3, linkListChildPageDataSource.getLinkElements().size());
+  }
+
+  @Test
+  public void testGetLinkElements_sortByCreatedReversed() {
+    properties.put("sortBy", "created");
+    properties.put("reverse", true);
+    resource = context.create().resource("/content/linklist/childpages/ds-created-reverse",
+        properties);
+    context.request().setResource(resource);
+    linkListChildPageDataSource = context.request().adaptTo(LinkListChildPageDataSource.class);
+    assertEquals(3, linkListChildPageDataSource.getLinkElements().size());
+  }
+
+  @Test
+  public void testGetLinkElements_sortByModifiedWithLimit() {
+    properties.put("sortBy", "modified");
+    properties.put("limit", "2");
+    resource = context.create().resource("/content/linklist/childpages/ds-modified-limit",
+        properties);
+    context.request().setResource(resource);
+    linkListChildPageDataSource = context.request().adaptTo(LinkListChildPageDataSource.class);
+    assertEquals(2, linkListChildPageDataSource.getLinkElements().size());
+  }
+
 }

--- a/src/test/java/io/kestros/cms/components/basic/core/lists/cardlist/CardListAssetsDataSourceTest.java
+++ b/src/test/java/io/kestros/cms/components/basic/core/lists/cardlist/CardListAssetsDataSourceTest.java
@@ -169,4 +169,46 @@ public class CardListAssetsDataSourceTest extends BaseDataSourceTest {
     cardListAssetsDataSource = context.request().adaptTo(CardListAssetsDataSource.class);
     assertEquals(1, cardListAssetsDataSource.getCardElements().size());
   }
+
+  @Test
+  public void testGetCardElements_sortByCreated_doesNotCrash() {
+    registerAssetRetrievalService();
+    properties.put("sortBy", "created");
+    resource = context.create().resource("/content/page/cardlist/assets-sortby-created", properties);
+    context.request().setResource(resource);
+    cardListAssetsDataSource = context.request().adaptTo(CardListAssetsDataSource.class);
+    assertEquals(3, cardListAssetsDataSource.getCardElements().size());
+  }
+
+  @Test
+  public void testGetCardElements_sortByModified_doesNotCrash() {
+    registerAssetRetrievalService();
+    properties.put("sortBy", "modified");
+    resource = context.create().resource("/content/page/cardlist/assets-sortby-modified", properties);
+    context.request().setResource(resource);
+    cardListAssetsDataSource = context.request().adaptTo(CardListAssetsDataSource.class);
+    assertEquals(3, cardListAssetsDataSource.getCardElements().size());
+  }
+
+  @Test
+  public void testGetCardElements_sortByCreatedReversed() {
+    registerAssetRetrievalService();
+    properties.put("sortBy", "created");
+    properties.put("reverse", true);
+    resource = context.create().resource("/content/page/cardlist/assets-created-reverse", properties);
+    context.request().setResource(resource);
+    cardListAssetsDataSource = context.request().adaptTo(CardListAssetsDataSource.class);
+    assertEquals(3, cardListAssetsDataSource.getCardElements().size());
+  }
+
+  @Test
+  public void testGetCardElements_sortByModifiedWithLimit() {
+    registerAssetRetrievalService();
+    properties.put("sortBy", "modified");
+    properties.put("limit", "2");
+    resource = context.create().resource("/content/page/cardlist/assets-modified-limit", properties);
+    context.request().setResource(resource);
+    cardListAssetsDataSource = context.request().adaptTo(CardListAssetsDataSource.class);
+    assertEquals(2, cardListAssetsDataSource.getCardElements().size());
+  }
 }

--- a/src/test/java/io/kestros/cms/components/basic/core/lists/cardlist/CardListChildPagesDataSourceTest.java
+++ b/src/test/java/io/kestros/cms/components/basic/core/lists/cardlist/CardListChildPagesDataSourceTest.java
@@ -234,4 +234,130 @@ public class CardListChildPagesDataSourceTest extends BaseDataSourceTest {
     cardListChildPagesDataSource = context.request().adaptTo(CardListChildPagesDataSource.class);
     assertEquals(1, cardListChildPagesDataSource.getCardElements().size());
   }
+
+  @Test
+  public void testGetCardElements_sortByCreated_noDateProperties_doesNotCrash() {
+    properties.put("sortBy", "created");
+    resource = context.create().resource("/content/page/jcr:content/comp-sortby-created", properties);
+    context.request().setResource(resource);
+    cardListChildPagesDataSource = context.request().adaptTo(CardListChildPagesDataSource.class);
+    assertEquals(3, cardListChildPagesDataSource.getCardElements().size());
+  }
+
+  @Test
+  public void testGetCardElements_sortByModified_noDateProperties_doesNotCrash() {
+    properties.put("sortBy", "modified");
+    resource = context.create().resource("/content/page/jcr:content/comp-sortby-modified", properties);
+    context.request().setResource(resource);
+    cardListChildPagesDataSource = context.request().adaptTo(CardListChildPagesDataSource.class);
+    assertEquals(3, cardListChildPagesDataSource.getCardElements().size());
+  }
+
+  @Test
+  public void testGetCardElements_sortByCreatedWithDates() {
+    // Create pages with different jcr:created dates
+    Map<String, Object> pageProps = new HashMap<>();
+    pageProps.put("jcr:primaryType", "kes:Page");
+    context.create().resource("/content/dated-page", pageProps);
+    Map<String, Object> jcrContentProps = new HashMap<>();
+    jcrContentProps.put("jcr:primaryType", "nt:unstructured");
+    jcrContentProps.put("jcr:title", "Parent");
+    context.create().resource("/content/dated-page/jcr:content", jcrContentProps);
+
+    java.util.Calendar cal1 = java.util.Calendar.getInstance();
+    cal1.set(2025, 0, 1);
+    java.util.Calendar cal2 = java.util.Calendar.getInstance();
+    cal2.set(2025, 6, 1);
+    java.util.Calendar cal3 = java.util.Calendar.getInstance();
+    cal3.set(2025, 3, 1);
+
+    context.create().resource("/content/dated-page/page-a", pageProps);
+    Map<String, Object> jcr1 = new HashMap<>();
+    jcr1.put("jcr:primaryType", "nt:unstructured");
+    jcr1.put("jcr:title", "Page A");
+    jcr1.put("jcr:created", cal1);
+    context.create().resource("/content/dated-page/page-a/jcr:content", jcr1);
+
+    context.create().resource("/content/dated-page/page-b", pageProps);
+    Map<String, Object> jcr2 = new HashMap<>();
+    jcr2.put("jcr:primaryType", "nt:unstructured");
+    jcr2.put("jcr:title", "Page B");
+    jcr2.put("jcr:created", cal2);
+    context.create().resource("/content/dated-page/page-b/jcr:content", jcr2);
+
+    context.create().resource("/content/dated-page/page-c", pageProps);
+    Map<String, Object> jcr3 = new HashMap<>();
+    jcr3.put("jcr:primaryType", "nt:unstructured");
+    jcr3.put("jcr:title", "Page C");
+    jcr3.put("jcr:created", cal3);
+    context.create().resource("/content/dated-page/page-c/jcr:content", jcr3);
+
+    Map<String, Object> compProps = new HashMap<>();
+    compProps.put("pagesPath", "/content/dated-page");
+    compProps.put("sortBy", "created");
+    Resource compResource = context.create().resource("/content/dated-page/jcr:content/comp-created-sort", compProps);
+    context.request().setResource(compResource);
+    CardListChildPagesDataSource ds = context.request().adaptTo(CardListChildPagesDataSource.class);
+    List<KestrosCard> cards = ds.getCardElements();
+    assertEquals(3, cards.size());
+  }
+
+  @Test
+  public void testGetCardElements_sortByModifiedWithDates() {
+    Map<String, Object> pageProps = new HashMap<>();
+    pageProps.put("jcr:primaryType", "kes:Page");
+    context.create().resource("/content/mod-page", pageProps);
+    Map<String, Object> jcrContentProps = new HashMap<>();
+    jcrContentProps.put("jcr:primaryType", "nt:unstructured");
+    jcrContentProps.put("jcr:title", "Parent");
+    context.create().resource("/content/mod-page/jcr:content", jcrContentProps);
+
+    java.util.Calendar cal1 = java.util.Calendar.getInstance();
+    cal1.set(2025, 0, 15);
+    java.util.Calendar cal2 = java.util.Calendar.getInstance();
+    cal2.set(2025, 5, 15);
+
+    context.create().resource("/content/mod-page/page-x", pageProps);
+    Map<String, Object> jcr1 = new HashMap<>();
+    jcr1.put("jcr:primaryType", "nt:unstructured");
+    jcr1.put("jcr:title", "Page X");
+    jcr1.put("jcr:lastModified", cal1);
+    context.create().resource("/content/mod-page/page-x/jcr:content", jcr1);
+
+    context.create().resource("/content/mod-page/page-y", pageProps);
+    Map<String, Object> jcr2 = new HashMap<>();
+    jcr2.put("jcr:primaryType", "nt:unstructured");
+    jcr2.put("jcr:title", "Page Y");
+    jcr2.put("jcr:lastModified", cal2);
+    context.create().resource("/content/mod-page/page-y/jcr:content", jcr2);
+
+    Map<String, Object> compProps = new HashMap<>();
+    compProps.put("pagesPath", "/content/mod-page");
+    compProps.put("sortBy", "modified");
+    Resource compResource = context.create().resource("/content/mod-page/jcr:content/comp-mod-sort", compProps);
+    context.request().setResource(compResource);
+    CardListChildPagesDataSource ds = context.request().adaptTo(CardListChildPagesDataSource.class);
+    List<KestrosCard> cards = ds.getCardElements();
+    assertEquals(2, cards.size());
+  }
+
+  @Test
+  public void testGetCardElements_sortByCreatedReversed() {
+    properties.put("sortBy", "created");
+    properties.put("reverse", true);
+    resource = context.create().resource("/content/page/jcr:content/comp-created-reverse", properties);
+    context.request().setResource(resource);
+    cardListChildPagesDataSource = context.request().adaptTo(CardListChildPagesDataSource.class);
+    assertEquals(3, cardListChildPagesDataSource.getCardElements().size());
+  }
+
+  @Test
+  public void testGetCardElements_sortByModifiedWithLimit() {
+    properties.put("sortBy", "modified");
+    properties.put("limit", "1");
+    resource = context.create().resource("/content/page/jcr:content/comp-modified-limit", properties);
+    context.request().setResource(resource);
+    cardListChildPagesDataSource = context.request().adaptTo(CardListChildPagesDataSource.class);
+    assertEquals(1, cardListChildPagesDataSource.getCardElements().size());
+  }
 }

--- a/src/test/java/io/kestros/cms/components/basic/core/lists/cardlist/CardListTagSearchDataSourceTest.java
+++ b/src/test/java/io/kestros/cms/components/basic/core/lists/cardlist/CardListTagSearchDataSourceTest.java
@@ -147,4 +147,227 @@ public class CardListTagSearchDataSourceTest extends BaseDataSourceTest {
         context.request().adaptTo(CardListTagSearchDataSource.class);
     assertEquals(0, emptyDs.getConfiguredTags().length);
   }
+
+  @Test
+  public void testGetSortByDefault() {
+    assertEquals("", cardListTagSearchDataSource.getSortBy());
+  }
+
+  @Test
+  public void testGetSortByTitle() {
+    Map<String, Object> sortProps = new HashMap<>();
+    sortProps.put("tags", new String[]{"/etc/tags/topic/java"});
+    sortProps.put("readMoreText", "View Session");
+    sortProps.put("sortBy", "title");
+    Resource sortResource = context.create().resource(
+        "/content/sessions/child-1/jcr:content/sort-title-component", sortProps);
+    context.request().setResource(sortResource);
+    CardListTagSearchDataSource ds =
+        context.request().adaptTo(CardListTagSearchDataSource.class);
+    assertEquals("title", ds.getSortBy());
+  }
+
+  @Test
+  public void testGetSortByName() {
+    Map<String, Object> sortProps = new HashMap<>();
+    sortProps.put("tags", new String[]{"/etc/tags/topic/java"});
+    sortProps.put("readMoreText", "View Session");
+    sortProps.put("sortBy", "name");
+    Resource sortResource = context.create().resource(
+        "/content/sessions/child-1/jcr:content/sort-name-component", sortProps);
+    context.request().setResource(sortResource);
+    CardListTagSearchDataSource ds =
+        context.request().adaptTo(CardListTagSearchDataSource.class);
+    assertEquals("name", ds.getSortBy());
+  }
+
+  @Test
+  public void testIsReverseOrderDefault() {
+    assertEquals(false, cardListTagSearchDataSource.isReverseOrder());
+  }
+
+  @Test
+  public void testIsReverseOrderTrue() {
+    Map<String, Object> reverseProps = new HashMap<>();
+    reverseProps.put("tags", new String[]{"/etc/tags/topic/java"});
+    reverseProps.put("readMoreText", "View Session");
+    reverseProps.put("reverse", true);
+    Resource reverseResource = context.create().resource(
+        "/content/sessions/child-1/jcr:content/reverse-component", reverseProps);
+    context.request().setResource(reverseResource);
+    CardListTagSearchDataSource ds =
+        context.request().adaptTo(CardListTagSearchDataSource.class);
+    assertEquals(true, ds.isReverseOrder());
+  }
+
+  @Test
+  public void testGetLimitDefault() {
+    assertEquals(0, cardListTagSearchDataSource.getLimit());
+  }
+
+  @Test
+  public void testGetLimitSet() {
+    Map<String, Object> limitProps = new HashMap<>();
+    limitProps.put("tags", new String[]{"/etc/tags/topic/java"});
+    limitProps.put("readMoreText", "View Session");
+    limitProps.put("limit", "5");
+    Resource limitResource = context.create().resource(
+        "/content/sessions/child-1/jcr:content/limit-component", limitProps);
+    context.request().setResource(limitResource);
+    CardListTagSearchDataSource ds =
+        context.request().adaptTo(CardListTagSearchDataSource.class);
+    assertEquals(5, ds.getLimit());
+  }
+
+  @Test
+  public void testGetLimitInvalidString() {
+    Map<String, Object> limitProps = new HashMap<>();
+    limitProps.put("tags", new String[]{"/etc/tags/topic/java"});
+    limitProps.put("readMoreText", "View Session");
+    limitProps.put("limit", "invalid");
+    Resource limitResource = context.create().resource(
+        "/content/sessions/child-1/jcr:content/limit-invalid-component", limitProps);
+    context.request().setResource(limitResource);
+    CardListTagSearchDataSource ds =
+        context.request().adaptTo(CardListTagSearchDataSource.class);
+    assertEquals(0, ds.getLimit());
+  }
+
+  @Test
+  public void testGetLimitZero() {
+    Map<String, Object> limitProps = new HashMap<>();
+    limitProps.put("tags", new String[]{"/etc/tags/topic/java"});
+    limitProps.put("readMoreText", "View Session");
+    limitProps.put("limit", "0");
+    Resource limitResource = context.create().resource(
+        "/content/sessions/child-1/jcr:content/limit-zero-component", limitProps);
+    context.request().setResource(limitResource);
+    CardListTagSearchDataSource ds =
+        context.request().adaptTo(CardListTagSearchDataSource.class);
+    assertEquals(0, ds.getLimit());
+  }
+
+  @Test
+  public void testGetCardElementsWithSortByTitle() {
+    Map<String, Object> sortProps = new HashMap<>();
+    sortProps.put("tags", new String[]{"/etc/tags/topic/java"});
+    sortProps.put("readMoreText", "View Session");
+    sortProps.put("sortBy", "title");
+    Resource sortResource = context.create().resource(
+        "/content/sessions/child-1/jcr:content/sort-title-cards-component", sortProps);
+    context.request().setResource(sortResource);
+    CardListTagSearchDataSource ds =
+        context.request().adaptTo(CardListTagSearchDataSource.class);
+    // child-2 matched, child-1 excluded (current page), child-3 no tags
+    assertEquals(1, ds.getCardElements().size());
+  }
+
+  @Test
+  public void testGetCardElementsWithSortByName() {
+    Map<String, Object> sortProps = new HashMap<>();
+    sortProps.put("tags", new String[]{"/etc/tags/topic/java"});
+    sortProps.put("readMoreText", "View Session");
+    sortProps.put("sortBy", "name");
+    Resource sortResource = context.create().resource(
+        "/content/sessions/child-1/jcr:content/sort-name-cards-component", sortProps);
+    context.request().setResource(sortResource);
+    CardListTagSearchDataSource ds =
+        context.request().adaptTo(CardListTagSearchDataSource.class);
+    assertEquals(1, ds.getCardElements().size());
+  }
+
+  @Test
+  public void testGetCardElementsWithReverse() {
+    Map<String, Object> reverseProps = new HashMap<>();
+    reverseProps.put("tags", new String[]{"/etc/tags/topic/java"});
+    reverseProps.put("readMoreText", "View Session");
+    reverseProps.put("reverse", true);
+    Resource reverseResource = context.create().resource(
+        "/content/sessions/child-1/jcr:content/reverse-cards-component", reverseProps);
+    context.request().setResource(reverseResource);
+    CardListTagSearchDataSource ds =
+        context.request().adaptTo(CardListTagSearchDataSource.class);
+    assertEquals(1, ds.getCardElements().size());
+  }
+
+  @Test
+  public void testGetCardElementsWithLimit() {
+    Map<String, Object> limitProps = new HashMap<>();
+    limitProps.put("tags", new String[]{"/etc/tags/topic/java"});
+    limitProps.put("readMoreText", "View Session");
+    limitProps.put("limit", "1");
+    Resource limitResource = context.create().resource(
+        "/content/sessions/child-1/jcr:content/limit-cards-component", limitProps);
+    context.request().setResource(limitResource);
+    CardListTagSearchDataSource ds =
+        context.request().adaptTo(CardListTagSearchDataSource.class);
+    // Only 1 matched page anyway, limit of 1 should still return 1
+    assertEquals(1, ds.getCardElements().size());
+  }
+
+  @Test
+  public void testGetCardElementsWithLimitZeroReturnsAll() {
+    Map<String, Object> limitProps = new HashMap<>();
+    limitProps.put("tags", new String[]{"/etc/tags/topic/java"});
+    limitProps.put("readMoreText", "View Session");
+    limitProps.put("limit", "0");
+    Resource limitResource = context.create().resource(
+        "/content/sessions/child-1/jcr:content/limit-zero-cards-component", limitProps);
+    context.request().setResource(limitResource);
+    CardListTagSearchDataSource ds =
+        context.request().adaptTo(CardListTagSearchDataSource.class);
+    assertEquals(1, ds.getCardElements().size());
+  }
+
+  @Test
+  public void testGetCardElementsWithSortAndReverse() {
+    Map<String, Object> sortRevProps = new HashMap<>();
+    sortRevProps.put("tags", new String[]{"/etc/tags/topic/java"});
+    sortRevProps.put("readMoreText", "View Session");
+    sortRevProps.put("sortBy", "name");
+    sortRevProps.put("reverse", true);
+    Resource sortRevResource = context.create().resource(
+        "/content/sessions/child-1/jcr:content/sort-reverse-cards-component", sortRevProps);
+    context.request().setResource(sortRevResource);
+    CardListTagSearchDataSource ds =
+        context.request().adaptTo(CardListTagSearchDataSource.class);
+    assertEquals(1, ds.getCardElements().size());
+  }
+
+  @Test
+  public void testGetCardElementsWithSortAndLimit() {
+    Map<String, Object> sortLimitProps = new HashMap<>();
+    sortLimitProps.put("tags", new String[]{"/etc/tags/topic/java"});
+    sortLimitProps.put("readMoreText", "View Session");
+    sortLimitProps.put("sortBy", "title");
+    sortLimitProps.put("limit", "1");
+    Resource sortLimitResource = context.create().resource(
+        "/content/sessions/child-1/jcr:content/sort-limit-cards-component", sortLimitProps);
+    context.request().setResource(sortLimitResource);
+    CardListTagSearchDataSource ds =
+        context.request().adaptTo(CardListTagSearchDataSource.class);
+    assertEquals(1, ds.getCardElements().size());
+  }
+
+  @Test
+  public void testGetCardElementsNoSortNoReverseNoLimit() {
+    // Default behavior — no sort/reverse/limit properties set
+    assertEquals(1, cardListTagSearchDataSource.getCardElements().size());
+  }
+
+  @Test
+  public void testGetTaggedPagesWithNoTagService() {
+    // When tagRetrievalService is null, should return empty
+    Map<String, Object> noServiceProps = new HashMap<>();
+    noServiceProps.put("tags", new String[]{"/etc/tags/topic/java"});
+    noServiceProps.put("readMoreText", "View");
+    Resource noServiceResource = context.create().resource(
+        "/content/sessions/child-1/jcr:content/no-service-component", noServiceProps);
+    context.request().setResource(noServiceResource);
+    // The service is already registered in context, so this tests the non-null path.
+    // Null service path is exercised in the base getTaggedPages when service isn't bound.
+    CardListTagSearchDataSource ds =
+        context.request().adaptTo(CardListTagSearchDataSource.class);
+    assertNotNull(ds);
+  }
 }

--- a/src/test/java/io/kestros/cms/components/basic/core/lists/cardlist/CardListTagSearchDataSourceTest.java
+++ b/src/test/java/io/kestros/cms/components/basic/core/lists/cardlist/CardListTagSearchDataSourceTest.java
@@ -370,4 +370,47 @@ public class CardListTagSearchDataSourceTest extends BaseDataSourceTest {
         context.request().adaptTo(CardListTagSearchDataSource.class);
     assertNotNull(ds);
   }
+
+  @Test
+  public void testGetCardElements_sortByCreated_doesNotCrash() {
+    Map<String, Object> sortProps = new HashMap<>();
+    sortProps.put("tags", new String[]{"/etc/tags/topic/java"});
+    sortProps.put("readMoreText", "View Session");
+    sortProps.put("sortBy", "created");
+    Resource sortResource = context.create().resource(
+        "/content/sessions/child-1/jcr:content/sort-created-component", sortProps);
+    context.request().setResource(sortResource);
+    CardListTagSearchDataSource ds =
+        context.request().adaptTo(CardListTagSearchDataSource.class);
+    assertEquals(1, ds.getCardElements().size());
+  }
+
+  @Test
+  public void testGetCardElements_sortByModified_doesNotCrash() {
+    Map<String, Object> sortProps = new HashMap<>();
+    sortProps.put("tags", new String[]{"/etc/tags/topic/java"});
+    sortProps.put("readMoreText", "View Session");
+    sortProps.put("sortBy", "modified");
+    Resource sortResource = context.create().resource(
+        "/content/sessions/child-1/jcr:content/sort-modified-component", sortProps);
+    context.request().setResource(sortResource);
+    CardListTagSearchDataSource ds =
+        context.request().adaptTo(CardListTagSearchDataSource.class);
+    assertEquals(1, ds.getCardElements().size());
+  }
+
+  @Test
+  public void testGetCardElements_sortByCreatedReversed() {
+    Map<String, Object> sortProps = new HashMap<>();
+    sortProps.put("tags", new String[]{"/etc/tags/topic/java"});
+    sortProps.put("readMoreText", "View Session");
+    sortProps.put("sortBy", "created");
+    sortProps.put("reverse", true);
+    Resource sortResource = context.create().resource(
+        "/content/sessions/child-1/jcr:content/sort-created-reverse-component", sortProps);
+    context.request().setResource(sortResource);
+    CardListTagSearchDataSource ds =
+        context.request().adaptTo(CardListTagSearchDataSource.class);
+    assertEquals(1, ds.getCardElements().size());
+  }
 }


### PR DESCRIPTION
## Summary
Completes TASK-197 by adding all remaining features on top of the sort/reverse/limit work already merged into develop:

1. **CardListTagSearchDataSource sort/reverse/limit** — adds sorting by title/name, reverse order, and limit controls to the tag-search card-list datasource Java class, plus comprehensive unit tests
2. **Selectfield options format fix** — converts all 5 dialog JSON selectfield options from JSON arrays to proper JCR child node format (the standard Kestros pattern)
3. **Created Date and Last Modified sort options** — adds two new sort options to all 5 dialog JSONs and implements date-based sorting in all 4 active Java datasource classes

### What was already in develop
- Sort/reverse/limit dialog fields in all 5 JSON files
- Sort/reverse/limit Java logic in CardListChildPagesDataSource, CardListAssetsDataSource, LinkListChildPageDataSource
- Tests for all three of those datasources

### What this PR adds
- Sort/reverse/limit Java logic in CardListTagSearchDataSource (the last missing datasource)
- Unit tests for CardListTagSearchDataSource sort/reverse/limit
- JCR child node format for selectfield options in all 5 dialogs
- Created Date and Last Modified sort options in all 5 dialog JSONs
- Date-based sort logic in all 4 Java datasource classes (pages use jcr:content jcr:created/jcr:lastModified, assets use Asset.getCreatedDate()/getModifiedDate())
- 17 new unit tests for date sort options across all 4 test classes

## Test Results
374 tests pass, 0 failures, 0 errors

## Acceptance Criteria Status
- [x] Sort By, Reverse Order, Limit fields in all 5 dialog JSONs
- [x] Sort options include: None, Title, Name, Created Date, Last Modified
- [x] card-list/child-pages: sort/reverse/limit in Java (including date sort)
- [x] card-list/asset-list: sort/reverse/limit in Java (including date sort)
- [x] card-list/tag-search: sort/reverse/limit in Java (including date sort)
- [x] link-list/child-pages: sort/reverse/limit in Java (including date sort)
- [x] link-list/tag-search: dialog fields added (no Java class — dialog only)
- [x] All existing unit tests pass
- [x] New unit tests cover sort/reverse/limit for tag search datasource
- [x] New unit tests cover created/modified date sort options
- [x] TagRetrievalService properly injected and used
- [x] Bundle Active on CMS dev instance (port 8000)

Supersedes #76 and #81.