### PR TITLE
fix: move accordion-panel to .hidden component group

### DIFF
--- a/src/main/resources/libs/kestros/commons/components/structure/accordion-panel.json
+++ b/src/main/resources/libs/kestros/commons/components/structure/accordion-panel.json
@@ -2,7 +2,7 @@
   "jcr:primaryType": "kes:ComponentType",
   "jcr:title": "Accordion Panel",
   "jcr:description": "",
-  "componentGroup": "Accordion Content",
+  "componentGroup": ".hidden",
   "sling:resourceSuperType": "kestros/commons/components/content-area",
   "container": true,
   "kes:allowedComponents": [


### PR DESCRIPTION
Accordion Panel is a child component of Accordion and should not appear as a standalone option in the components list. Moves it from "Accordion Content" group to ".hidden".