### PR TITLE
fix: richtext UTF-8 truncation workaround

### DIFF
--- a/src/main/java/io/kestros/cms/components/basic/core/TextSanitizer.java
+++ b/src/main/java/io/kestros/cms/components/basic/core/TextSanitizer.java
@@ -1,0 +1,41 @@
+package io.kestros.cms.components.basic.core;
+
+import javax.annotation.Nullable;
+
+/**
+ * Converts multi-byte Unicode characters to numeric HTML entities to work around
+ * a Sling HTL engine bug where Content-Length is calculated using character count
+ * instead of UTF-8 byte count, causing page output truncation.
+ */
+public final class TextSanitizer {
+
+  private TextSanitizer() {
+  }
+
+  @Nullable
+  public static String escapeMultiByteToEntities(@Nullable String text) {
+    if (text == null) {
+      return null;
+    }
+    boolean hasMultiByte = false;
+    for (int i = 0; i < text.length(); i++) {
+      if (text.charAt(i) > 127) {
+        hasMultiByte = true;
+        break;
+      }
+    }
+    if (!hasMultiByte) {
+      return text;
+    }
+    StringBuilder sb = new StringBuilder(text.length() + 32);
+    for (int i = 0; i < text.length(); i++) {
+      char c = text.charAt(i);
+      if (c > 127) {
+        sb.append("&#").append((int) c).append(';');
+      } else {
+        sb.append(c);
+      }
+    }
+    return sb.toString();
+  }
+}

--- a/src/main/java/io/kestros/cms/components/basic/core/content/richtext/KestrosRichTextImpl.java
+++ b/src/main/java/io/kestros/cms/components/basic/core/content/richtext/KestrosRichTextImpl.java
@@ -4,6 +4,7 @@ import io.kestros.cms.components.basic.api.content.KestrosRichText;
 import io.kestros.cms.components.basic.api.exceptions.ComponentConfigurationException;
 import io.kestros.cms.components.basic.core.BaseSlingModelDataSource;
 import io.kestros.cms.components.basic.core.BaseSyntheticResource;
+import io.kestros.cms.components.basic.core.TextSanitizer;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
@@ -17,7 +18,7 @@ public class KestrosRichTextImpl extends BaseSyntheticResource implements Kestro
       @Nonnull String resourcePrefix, @Nullable String forcedResourceName)
       throws ComponentConfigurationException {
     super(dataSource, resourcePrefix, forcedResourceName);
-    this.text = text;
+    this.text = TextSanitizer.escapeMultiByteToEntities(text);
   }
 
   @Nullable

--- a/src/main/java/io/kestros/cms/components/basic/core/content/richtext/RichTextDataSourceComponent.java
+++ b/src/main/java/io/kestros/cms/components/basic/core/content/richtext/RichTextDataSourceComponent.java
@@ -2,6 +2,7 @@ package io.kestros.cms.components.basic.core.content.richtext;
 
 import io.kestros.cms.components.basic.api.content.KestrosRichText;
 import io.kestros.cms.components.basic.core.BaseDataSourceComponent;
+import io.kestros.cms.components.basic.core.TextSanitizer;
 import javax.annotation.Nullable;
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.resource.Resource;
@@ -15,6 +16,6 @@ public class RichTextDataSourceComponent extends BaseDataSourceComponent<Kestros
   @Nullable
   @Override
   public String getText() {
-    return getComponentData().getText();
+    return TextSanitizer.escapeMultiByteToEntities(getComponentData().getText());
   }
 }

--- a/src/test/java/io/kestros/cms/components/basic/core/content/richtext/RichTextDataSourceComponentTest.java
+++ b/src/test/java/io/kestros/cms/components/basic/core/content/richtext/RichTextDataSourceComponentTest.java
@@ -1,0 +1,79 @@
+package io.kestros.cms.components.basic.core.content.richtext;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import io.kestros.cms.components.basic.core.TextSanitizer;
+import org.junit.Test;
+
+public class RichTextDataSourceComponentTest {
+
+  @Test
+  public void testNull() {
+    assertNull(TextSanitizer.escapeMultiByteToEntities(null));
+  }
+
+  @Test
+  public void testEmpty() {
+    assertEquals("", TextSanitizer.escapeMultiByteToEntities(""));
+  }
+
+  @Test
+  public void testAsciiPassesThrough() {
+    assertEquals("Hello world", TextSanitizer.escapeMultiByteToEntities("Hello world"));
+  }
+
+  @Test
+  public void testHtmlPassesThrough() {
+    String html = "<p>Hello <strong>world</strong></p>";
+    assertEquals(html, TextSanitizer.escapeMultiByteToEntities(html));
+  }
+
+  @Test
+  public void testEmDash() {
+    assertEquals("Goals &#8212; Assists",
+        TextSanitizer.escapeMultiByteToEntities("Goals \u2014 Assists"));
+  }
+
+  @Test
+  public void testTwoEmDashes() {
+    assertEquals("&#8212;&#8212;",
+        TextSanitizer.escapeMultiByteToEntities("\u2014\u2014"));
+  }
+
+  @Test
+  public void testCurlyQuotes() {
+    assertEquals("&#8220;Hello&#8221;",
+        TextSanitizer.escapeMultiByteToEntities("\u201CHello\u201D"));
+  }
+
+  @Test
+  public void testRightArrow() {
+    assertEquals("A &#8594; B",
+        TextSanitizer.escapeMultiByteToEntities("A \u2192 B"));
+  }
+
+  @Test
+  public void testCurlyApostrophe() {
+    assertEquals("What&#8217;s next",
+        TextSanitizer.escapeMultiByteToEntities("What\u2019s next"));
+  }
+
+  @Test
+  public void testMixedHtmlAndUnicode() {
+    assertEquals("<p>Goals &#8212; &#8220;Assists&#8221;</p>",
+        TextSanitizer.escapeMultiByteToEntities("<p>Goals \u2014 \u201CAssists\u201D</p>"));
+  }
+
+  @Test
+  public void testHtmlEntitiesUntouched() {
+    String html = "<p>Goals &mdash; Assists</p>";
+    assertEquals(html, TextSanitizer.escapeMultiByteToEntities(html));
+  }
+
+  @Test
+  public void testCopyright() {
+    assertEquals("&#169; 2026",
+        TextSanitizer.escapeMultiByteToEntities("\u00A9 2026"));
+  }
+}


### PR DESCRIPTION
## Summary
- Adds `TextSanitizer` utility that converts multi-byte Unicode characters to numeric HTML entities before HTL rendering
- Applied in `RichTextDataSourceComponent` and `KestrosRichTextImpl`
- Works around a Sling HTL engine bug where response length is calculated using char count instead of UTF-8 byte count, causing pages with multi-byte characters in richtext to be truncated (missing `</body></html>`)

## Test plan
- [ ] 12 unit tests pass for TextSanitizer
- [ ] Deploy to QA, update richtext HTL to use `RichTextDataSourceComponent`
- [ ] League-demo pages render complete (`</body></html>` present)
- [ ] Richtext content with em dashes, curly quotes, arrows renders correctly in browser