### PR TITLE
Fix synthetic table cell text rendering, order, and recursion

### DIFF
--- a/src/main/java/io/kestros/cms/components/basic/api/table/KestrosTableCell.java
+++ b/src/main/java/io/kestros/cms/components/basic/api/table/KestrosTableCell.java
@@ -24,6 +24,11 @@ public interface KestrosTableCell extends KestrosContainerElement {
     return cellContent;
   }
 
+  @javax.annotation.Nullable
+  default String getText() {
+    return null;
+  }
+
   @Nonnull
   List<KestrosBasicComponentElement> getCellContentElements();
 

--- a/src/main/java/io/kestros/cms/components/basic/api/table/KestrosTableRow.java
+++ b/src/main/java/io/kestros/cms/components/basic/api/table/KestrosTableRow.java
@@ -1,5 +1,6 @@
 package io.kestros.cms.components.basic.api.table;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.kestros.cms.components.basic.api.KestrosBasicComponentElement;
 import io.kestros.cms.components.basic.api.KestrosContainerElement;
 import java.util.ArrayList;
@@ -20,6 +21,7 @@ public interface KestrosTableRow extends KestrosContainerElement {
   @Nonnull
   List<KestrosTableCell> getCellElements();
 
+  @JsonIgnore
   @Nonnull
   default List<Resource> getCells() {
     List<Resource> cells = new ArrayList<>();

--- a/src/main/java/io/kestros/cms/components/basic/core/BaseComponentElement.java
+++ b/src/main/java/io/kestros/cms/components/basic/core/BaseComponentElement.java
@@ -119,7 +119,7 @@ public abstract class BaseComponentElement implements KestrosBasicComponentEleme
       };
       if (this instanceof KestrosContainerElement) {
         KestrosContainerElement container = (KestrosContainerElement) this;
-        Map<String, Resource> childResources = new HashMap<>();
+        Map<String, Resource> childResources = new java.util.LinkedHashMap<>();
         for (KestrosBasicComponentElement child : container.getChildElements()) {
           Resource childSyntheticResource = child.toSyntheticResource(resourceResolver,
               syntheticResource.getPath());

--- a/src/main/java/io/kestros/cms/components/basic/core/content/table/TableCellDataSourceComponent.java
+++ b/src/main/java/io/kestros/cms/components/basic/core/content/table/TableCellDataSourceComponent.java
@@ -18,4 +18,10 @@ public class TableCellDataSourceComponent extends BaseContainerDataSourceCompone
   public List<KestrosBasicComponentElement> getCellContentElements() {
     return getComponentData().getCellContentElements();
   }
+
+  @Override
+  public String getText() {
+    KestrosTableCell data = getComponentData();
+    return data == null ? null : data.getText();
+  }
 }

--- a/src/main/java/io/kestros/cms/components/basic/core/content/table/TableCellStaticDataSource.java
+++ b/src/main/java/io/kestros/cms/components/basic/core/content/table/TableCellStaticDataSource.java
@@ -33,4 +33,9 @@ public class TableCellStaticDataSource extends BaseContainerSlingModelDataSource
     // This should never get hit, since we can just look to child resources instead of synthesizing them, but we need to return something here to satisfy the interface contract.
     return new ArrayList<>();
   }
+
+  @Override
+  public String getText() {
+    return getResource().getValueMap().get("text", String.class);
+  }
 }

--- a/src/main/resources/libs/kestros/commons/components/content/table-cell/common/content.html
+++ b/src/main/resources/libs/kestros/commons/components/content/table-cell/common/content.html
@@ -2,5 +2,6 @@
 <sly data-sly-use.includes="/libs/kestros/commons/components/includes.html"/>
 
 <td class="${tableCell.inlineVariations}">
+    <sly data-sly-test="${tableCell.text}">${tableCell.text}</sly>
     <sly data-sly-call="${includes.contentArea}"/>
 </td>


### PR DESCRIPTION
## Summary
- @JsonIgnore on KestrosTableRow.getCells() fixes infinite recursion during Jackson serialization in toSyntheticResource()
- getText() on KestrosTableCell interface + TableCellStaticDataSource reads cell text from value map
- LinkedHashMap in BaseComponentElement.toSyntheticResource() preserves child insertion order

## Test plan
- [x] Existing tests pass
- [x] Verified on QA: league-demo game-log table renders cell text in correct order