### PR TITLE
fix: section default static datasource declares itself as container

### DIFF
--- a/src/main/resources/libs/kestros/commons/components/structure/section/datasources/default.json
+++ b/src/main/resources/libs/kestros/commons/components/structure/section/datasources/default.json
@@ -1,6 +1,7 @@
 {
   "jcr:primaryType": "nt:unstructured",
   "jcr:title": "Static Cards",
+  "container": true,
   "group": "Kestros Core",
   "classPath": "io.kestros.cms.components.basic.core.structure.section.SectionStaticDataSource",
   "create": {


### PR DESCRIPTION
## Summary

The default static datasource at `kestros/commons/components/structure/section/datasources/default.json` was missing `"container": true`, which other container-type datasources (card-list, link-list, navigation, top-navigation) all set. Without it, the section component isn't recognized as a container, so its child elements aren't iterated/rendered as nested resources.

## Change
One JSON property added:

```diff
 {
   "jcr:primaryType": "nt:unstructured",
   "jcr:title": "Static Cards",
+  "container": true,
   "group": "Kestros Core",
   ...
 }
```

## Test plan
- [ ] Confirm sections with nested children still render correctly on existing sample sites
- [ ] Confirm section's child resources are now exposed via the container datasource API