### PR TITLE
fix(basic-components): add jcr:description to section/card-list/navigation

### DIFF
--- a/src/main/resources/libs/kestros/commons/components/lists/card-list.json
+++ b/src/main/resources/libs/kestros/commons/components/lists/card-list.json
@@ -1,7 +1,7 @@
 {
   "jcr:primaryType": "kes:ComponentType",
   "jcr:title": "Card List",
-  "jcr:description": "",
+  "jcr:description": "Displays a list of cards from a configurable datasource (child pages, assets, or tag search).",
   "componentGroup": "List Components",
   "sling:resourceSuperType": "kestros/commons/components/content-area",
   "editable": true,

--- a/src/main/resources/libs/kestros/commons/components/navigation/navigation.json
+++ b/src/main/resources/libs/kestros/commons/components/navigation/navigation.json
@@ -1,7 +1,7 @@
 {
   "jcr:primaryType": "kes:ComponentType",
   "jcr:title": "Navigation",
-  "jcr:description": "",
+  "jcr:description": "Renders a navigation menu of links from a configurable source.",
   "componentGroup": "Navigation Components",
   "sling:resourceSuperType": "kestros/commons/components/content-area",
   "editable": true,

--- a/src/main/resources/libs/kestros/commons/components/structure/section.json
+++ b/src/main/resources/libs/kestros/commons/components/structure/section.json
@@ -1,7 +1,7 @@
 {
   "jcr:primaryType": "kes:ComponentType",
   "jcr:title": "Section",
-  "jcr:description": "",
+  "jcr:description": "Structural section that groups child components into a layout container.",
   "componentGroup": "Layout Components",
   "sling:resourceSuperType": "kestros/commons/components/content-area",
   "container": true,


### PR DESCRIPTION
These OOB component definitions shipped with an empty `jcr:description`, which the component detail-page validation map flags as a WARNING ("The jcr:description property must be configured."). Adds a concise description to each.

Verified live (set on the running pro-dev instance): all three now show **0 errors / 0 warnings**. Combined with the component-validation super-type fix (kestros-development-management **#59**), **all OOB components are now fully green** on their detail validation maps.

Note: `Sling-Initial-Content` won't overwrite the existing empty property on a redeploy, so this applies to fresh instances; the running instance was updated via request for verification.