### PR TITLE
feat(table): data-driven tables — synthetic row/cell/header impls + generic TableChildNodesDataSource

### DIFF
--- a/src/main/java/io/kestros/cms/components/basic/api/table/KestrosTableCell.java
+++ b/src/main/java/io/kestros/cms/components/basic/api/table/KestrosTableCell.java
@@ -1,5 +1,6 @@
 package io.kestros.cms.components.basic.api.table;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.kestros.cms.components.basic.api.KestrosBasicComponentElement;
 import io.kestros.cms.components.basic.api.KestrosContainerElement;
 import java.util.List;
@@ -15,6 +16,7 @@ public interface KestrosTableCell extends KestrosContainerElement {
     return RESOURCE_TYPE;
   }
 
+  @JsonIgnore
   @Nonnull
   default List<Resource> getCellContent() {
     List<Resource> cellContent = new java.util.ArrayList<>();

--- a/src/main/java/io/kestros/cms/components/basic/core/content/table/KestrosTableCellImpl.java
+++ b/src/main/java/io/kestros/cms/components/basic/core/content/table/KestrosTableCellImpl.java
@@ -1,0 +1,69 @@
+package io.kestros.cms.components.basic.core.content.table;
+
+import io.kestros.cms.components.basic.api.KestrosBasicComponentElement;
+import io.kestros.cms.components.basic.api.exceptions.ComponentConfigurationException;
+import io.kestros.cms.components.basic.api.table.KestrosTableCell;
+import io.kestros.cms.components.basic.core.BaseContainerSyntheticResource;
+import io.kestros.cms.components.basic.core.BaseSlingModelDataSource;
+import java.util.ArrayList;
+import java.util.List;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+/**
+ * Programmatic (synthetic) {@link KestrosTableCell}, letting a datasource build table cells in code
+ * rather than from authored child resources. Mirrors
+ * {@link io.kestros.cms.components.basic.core.content.card.KestrosCardImpl}. A cell is either simple
+ * text or a list of rendered content elements (e.g. a link or image).
+ */
+public class KestrosTableCellImpl extends BaseContainerSyntheticResource implements KestrosTableCell {
+
+  private final String text;
+  private final List<KestrosBasicComponentElement> cellContentElements;
+
+  /**
+   * Text-only cell.
+   *
+   * @param text                cell text.
+   * @param dataSource          owning datasource.
+   * @param resourcePrefix      resource prefix (for variation/layout resolution).
+   * @param forcedResourceName  synthetic resource name (unique within the row).
+   * @throws ComponentConfigurationException if the synthetic resource cannot be configured.
+   */
+  public KestrosTableCellImpl(@Nullable final String text,
+      @Nonnull final BaseSlingModelDataSource dataSource, @Nonnull final String resourcePrefix,
+      @Nullable final String forcedResourceName) throws ComponentConfigurationException {
+    super(dataSource, resourcePrefix, forcedResourceName);
+    this.text = text;
+    this.cellContentElements = new ArrayList<>();
+  }
+
+  /**
+   * Cell containing rendered content elements (e.g. a link or image).
+   *
+   * @param cellContentElements the elements rendered inside the cell.
+   * @param dataSource          owning datasource.
+   * @param resourcePrefix      resource prefix (for variation/layout resolution).
+   * @param forcedResourceName  synthetic resource name (unique within the row).
+   * @throws ComponentConfigurationException if the synthetic resource cannot be configured.
+   */
+  public KestrosTableCellImpl(@Nonnull final List<KestrosBasicComponentElement> cellContentElements,
+      @Nonnull final BaseSlingModelDataSource dataSource, @Nonnull final String resourcePrefix,
+      @Nullable final String forcedResourceName) throws ComponentConfigurationException {
+    super(dataSource, resourcePrefix, forcedResourceName);
+    this.text = null;
+    this.cellContentElements = new ArrayList<>(cellContentElements);
+  }
+
+  @Nullable
+  @Override
+  public String getText() {
+    return text;
+  }
+
+  @Nonnull
+  @Override
+  public List<KestrosBasicComponentElement> getCellContentElements() {
+    return new ArrayList<>(cellContentElements);
+  }
+}

--- a/src/main/java/io/kestros/cms/components/basic/core/content/table/KestrosTableHeaderImpl.java
+++ b/src/main/java/io/kestros/cms/components/basic/core/content/table/KestrosTableHeaderImpl.java
@@ -1,0 +1,39 @@
+package io.kestros.cms.components.basic.core.content.table;
+
+import io.kestros.cms.components.basic.api.exceptions.ComponentConfigurationException;
+import io.kestros.cms.components.basic.api.table.KestrosTableHeader;
+import io.kestros.cms.components.basic.core.BaseSlingModelDataSource;
+import io.kestros.cms.components.basic.core.BaseSyntheticResource;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+/**
+ * Programmatic (synthetic) {@link KestrosTableHeader}, letting a datasource build table headers in
+ * code rather than from authored resources. Mirrors
+ * {@link io.kestros.cms.components.basic.core.content.heading.KestrosHeadingImpl} (a text-only leaf).
+ */
+public class KestrosTableHeaderImpl extends BaseSyntheticResource implements KestrosTableHeader {
+
+  private final String text;
+
+  /**
+   * Constructs a synthetic table header.
+   *
+   * @param text                header text.
+   * @param dataSource          owning datasource.
+   * @param resourcePrefix      resource prefix (for variation/layout resolution).
+   * @param forcedResourceName  synthetic resource name (unique within the table).
+   * @throws ComponentConfigurationException if the synthetic resource cannot be configured.
+   */
+  public KestrosTableHeaderImpl(@Nullable final String text,
+      @Nonnull final BaseSlingModelDataSource dataSource, @Nonnull final String resourcePrefix,
+      @Nullable final String forcedResourceName) throws ComponentConfigurationException {
+    super(dataSource, resourcePrefix, forcedResourceName);
+    this.text = text;
+  }
+
+  @Override
+  public String getText() {
+    return text;
+  }
+}

--- a/src/main/java/io/kestros/cms/components/basic/core/content/table/KestrosTableRowImpl.java
+++ b/src/main/java/io/kestros/cms/components/basic/core/content/table/KestrosTableRowImpl.java
@@ -1,0 +1,44 @@
+package io.kestros.cms.components.basic.core.content.table;
+
+import io.kestros.cms.components.basic.api.exceptions.ComponentConfigurationException;
+import io.kestros.cms.components.basic.api.table.KestrosTableCell;
+import io.kestros.cms.components.basic.api.table.KestrosTableRow;
+import io.kestros.cms.components.basic.core.BaseContainerSyntheticResource;
+import io.kestros.cms.components.basic.core.BaseSlingModelDataSource;
+import java.util.ArrayList;
+import java.util.List;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+/**
+ * Programmatic (synthetic) {@link KestrosTableRow}, letting a datasource build table rows in code
+ * rather than from authored child resources. Mirrors
+ * {@link io.kestros.cms.components.basic.core.content.card.KestrosCardImpl}; the cells are usually
+ * {@link KestrosTableCellImpl} instances built alongside it.
+ */
+public class KestrosTableRowImpl extends BaseContainerSyntheticResource implements KestrosTableRow {
+
+  private final List<KestrosTableCell> cellElements;
+
+  /**
+   * Constructs a synthetic table row.
+   *
+   * @param cellElements        the row's cells, left-to-right.
+   * @param dataSource          owning datasource.
+   * @param resourcePrefix      resource prefix (for variation/layout resolution).
+   * @param forcedResourceName  synthetic resource name (unique within the table).
+   * @throws ComponentConfigurationException if the synthetic resource cannot be configured.
+   */
+  public KestrosTableRowImpl(@Nonnull final List<KestrosTableCell> cellElements,
+      @Nonnull final BaseSlingModelDataSource dataSource, @Nonnull final String resourcePrefix,
+      @Nullable final String forcedResourceName) throws ComponentConfigurationException {
+    super(dataSource, resourcePrefix, forcedResourceName);
+    this.cellElements = new ArrayList<>(cellElements);
+  }
+
+  @Nonnull
+  @Override
+  public List<KestrosTableCell> getCellElements() {
+    return new ArrayList<>(cellElements);
+  }
+}

--- a/src/main/java/io/kestros/cms/components/basic/core/content/table/TableChildNodesDataSource.java
+++ b/src/main/java/io/kestros/cms/components/basic/core/content/table/TableChildNodesDataSource.java
@@ -1,0 +1,91 @@
+package io.kestros.cms.components.basic.core.content.table;
+
+import io.kestros.cms.components.basic.api.exceptions.ComponentConfigurationException;
+import io.kestros.cms.components.basic.api.table.KestrosTable;
+import io.kestros.cms.components.basic.api.table.KestrosTableCell;
+import io.kestros.cms.components.basic.api.table.KestrosTableHeader;
+import io.kestros.cms.components.basic.api.table.KestrosTableRow;
+import io.kestros.cms.components.basic.core.BaseContainerSlingModelDataSource;
+import java.util.ArrayList;
+import java.util.List;
+import javax.annotation.Nonnull;
+import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.models.annotations.Model;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Data-driven {@link KestrosTable} datasource: renders a table from a collection of structured data
+ * nodes, mirroring {@link io.kestros.cms.components.basic.core.lists.cardlist.CardListChildPagesDataSource}
+ * (which renders cards from child pages).
+ *
+ * <p>Configured on the component with:
+ * <ul>
+ *   <li>{@code dataPath} — path to the container whose child nodes are the rows.</li>
+ *   <li>{@code columns} — ordered property names read from each data node into the row's cells.</li>
+ *   <li>{@code headers} — ordered header labels (optional).</li>
+ * </ul>
+ * Rows/cells/headers are built programmatically as synthetic elements
+ * ({@link KestrosTableRowImpl}/{@link KestrosTableCellImpl}/{@link KestrosTableHeaderImpl}) and fed to
+ * the stock table component.
+ */
+@Model(adaptables = {SlingHttpServletRequest.class, Resource.class})
+public class TableChildNodesDataSource extends BaseContainerSlingModelDataSource
+    implements KestrosTable {
+
+  private static final Logger LOG = LoggerFactory.getLogger(TableChildNodesDataSource.class);
+
+  @Nonnull
+  @Override
+  public List<KestrosTableHeader> getHeaderElements() {
+    final List<KestrosTableHeader> headers = new ArrayList<>();
+    final String[] labels = getResource().getValueMap().get("headers", String[].class);
+    if (labels != null) {
+      for (int i = 0; i < labels.length; i++) {
+        try {
+          headers.add(new KestrosTableHeaderImpl(labels[i], this, "header" + i, "header" + i));
+        } catch (final ComponentConfigurationException e) {
+          LOG.warn("Unable to build table header '{}': {}", labels[i], e.getMessage());
+        }
+      }
+    }
+    return headers;
+  }
+
+  @Nonnull
+  @Override
+  public List<KestrosTableRow> getRowElements() {
+    final List<KestrosTableRow> rows = new ArrayList<>();
+    final String dataPath = getResource().getValueMap().get("dataPath", String.class);
+    final String[] columns = getResource().getValueMap().get("columns", String[].class);
+    if (dataPath == null || columns == null) {
+      return rows;
+    }
+    final Resource dataResource = getResourceResolver().getResource(dataPath);
+    if (dataResource == null) {
+      LOG.warn("Table dataPath {} not found.", dataPath);
+      return rows;
+    }
+    int r = 0;
+    for (final Resource node : dataResource.getChildren()) {
+      final List<KestrosTableCell> cells = new ArrayList<>();
+      for (int c = 0; c < columns.length; c++) {
+        final Object value = node.getValueMap().get(columns[c]);
+        final String text = value != null ? String.valueOf(value) : "";
+        try {
+          cells.add(new KestrosTableCellImpl(text, this, "r" + r + "c" + c, "r" + r + "c" + c));
+        } catch (final ComponentConfigurationException e) {
+          LOG.warn("Unable to build table cell: {}", e.getMessage());
+        }
+      }
+      try {
+        rows.add(new KestrosTableRowImpl(cells, this, "row" + r, "row" + r));
+      } catch (final ComponentConfigurationException e) {
+        LOG.warn("Unable to build table row {}: {}", r, e.getMessage());
+      }
+      r++;
+    }
+    return rows;
+  }
+}

--- a/src/main/java/io/kestros/cms/components/basic/core/content/table/TableChildNodesDataSource.java
+++ b/src/main/java/io/kestros/cms/components/basic/core/content/table/TableChildNodesDataSource.java
@@ -6,8 +6,11 @@ import io.kestros.cms.components.basic.api.table.KestrosTableCell;
 import io.kestros.cms.components.basic.api.table.KestrosTableHeader;
 import io.kestros.cms.components.basic.api.table.KestrosTableRow;
 import io.kestros.cms.components.basic.core.BaseContainerSlingModelDataSource;
+import io.kestros.cms.sitebuilding.api.models.DynamicPageContext;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import javax.annotation.Nonnull;
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.resource.Resource;
@@ -36,6 +39,35 @@ public class TableChildNodesDataSource extends BaseContainerSlingModelDataSource
 
   private static final Logger LOG = LoggerFactory.getLogger(TableChildNodesDataSource.class);
 
+  private static final Pattern PLACEHOLDER = Pattern.compile("\\{([^}]+)}");
+
+  /**
+   * Substitutes {@code {name}} placeholders in the data path with dynamic-route parameters, so a
+   * single table component on a dynamic page (e.g. {@code teams/{team}}) can resolve
+   * per-request data (e.g. {@code dataPath = /content/data/sports-league/teams/{team}/results}).
+   * Placeholders with no matching route parameter resolve to empty (the path then misses and the
+   * table renders no rows).
+   *
+   * @param dataPath configured data path, possibly containing placeholders.
+   * @return the resolved data path.
+   */
+  @Nonnull
+  private String resolveDataPath(@Nonnull final String dataPath) {
+    if (!dataPath.contains("{")) {
+      return dataPath;
+    }
+    final DynamicPageContext context =
+        getRequest() != null ? getRequest().adaptTo(DynamicPageContext.class) : null;
+    final Matcher matcher = PLACEHOLDER.matcher(dataPath);
+    final StringBuffer resolved = new StringBuffer();
+    while (matcher.find()) {
+      final String value = context != null ? context.getParameter(matcher.group(1)) : null;
+      matcher.appendReplacement(resolved, Matcher.quoteReplacement(value != null ? value : ""));
+    }
+    matcher.appendTail(resolved);
+    return resolved.toString();
+  }
+
   @Nonnull
   @Override
   public List<KestrosTableHeader> getHeaderElements() {
@@ -57,11 +89,12 @@ public class TableChildNodesDataSource extends BaseContainerSlingModelDataSource
   @Override
   public List<KestrosTableRow> getRowElements() {
     final List<KestrosTableRow> rows = new ArrayList<>();
-    final String dataPath = getResource().getValueMap().get("dataPath", String.class);
+    final String configuredDataPath = getResource().getValueMap().get("dataPath", String.class);
     final String[] columns = getResource().getValueMap().get("columns", String[].class);
-    if (dataPath == null || columns == null) {
+    if (configuredDataPath == null || columns == null) {
       return rows;
     }
+    final String dataPath = resolveDataPath(configuredDataPath);
     final Resource dataResource = getResourceResolver().getResource(dataPath);
     if (dataResource == null) {
       LOG.warn("Table dataPath {} not found.", dataPath);

--- a/src/main/resources/libs/kestros/commons/components/content/table/datasources/data.json
+++ b/src/main/resources/libs/kestros/commons/components/content/table/datasources/data.json
@@ -1,0 +1,41 @@
+{
+  "jcr:primaryType": "nt:unstructured",
+  "jcr:title": "Data-driven Table",
+  "group": "Kestros Core",
+  "classPath": "io.kestros.cms.components.basic.core.content.table.TableChildNodesDataSource",
+  "create": {
+    "jcr:primaryType": "nt:unstructured",
+    "sling:resourceType": "kestros/cms2/dialog",
+    "defaultErrorMessage": "Failed to create child resource.",
+    "successEvents": ["navigation", "component", "new-component"],
+    "actions": ["cancel", "create"],
+    "content": {
+      "jcr:primaryType": "nt:unstructured",
+      "component-type": {
+        "jcr:primaryType": "nt:unstructured",
+        "sling:resourceType": "kestros/cms2/fields/kestros/component-picker",
+        "label": "Component",
+        "name": "sling:resourceType"
+      },
+      "dataPath": {
+        "jcr:primaryType": "nt:unstructured",
+        "sling:resourceType": "kestros/cms2/fields/general/textfield",
+        "label": "Data path",
+        "name": "dataPath"
+      },
+      "columns": {
+        "jcr:primaryType": "nt:unstructured",
+        "sling:resourceType": "kestros/cms2/fields/general/textfield",
+        "label": "Columns (data node property names, in order)",
+        "name": "columns"
+      },
+      "headers": {
+        "jcr:primaryType": "nt:unstructured",
+        "sling:resourceType": "kestros/cms2/fields/general/textfield",
+        "label": "Header labels (in order)",
+        "name": "headers"
+      }
+    },
+    "footer": { "jcr:primaryType": "nt:unstructured" }
+  }
+}

--- a/src/test/java/io/kestros/cms/components/basic/core/content/table/KestrosTableCellImplTest.java
+++ b/src/test/java/io/kestros/cms/components/basic/core/content/table/KestrosTableCellImplTest.java
@@ -1,0 +1,58 @@
+package io.kestros.cms.components.basic.core.content.table;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import io.kestros.cms.components.basic.api.KestrosBasicComponentElement;
+import io.kestros.cms.components.basic.api.exceptions.ComponentConfigurationException;
+import io.kestros.cms.components.basic.core.BaseSyntheticTest;
+import io.kestros.cms.components.basic.core.content.heading.KestrosHeadingImpl;
+import io.kestros.cms.components.basic.core.lists.cardlist.CardListStaticDataSource;
+import java.util.Collections;
+import java.util.List;
+import org.apache.sling.api.resource.Resource;
+import org.junit.Test;
+
+public class KestrosTableCellImplTest extends BaseSyntheticTest {
+
+  private KestrosTableCellImpl cell;
+  private CardListStaticDataSource dataSource;
+
+  @Override
+  public void setupElement() throws ComponentConfigurationException {
+    Resource resource = context.create().resource("/content/parent");
+    context.currentResource(resource);
+    dataSource = context.request().adaptTo(CardListStaticDataSource.class);
+    cell = new KestrosTableCellImpl("45", dataSource, "cell", "cellElement");
+  }
+
+  @Override
+  public void testToSyntheticResource() throws ComponentConfigurationException {
+    Resource syntheticResource = cell.toSyntheticResource(getResourceResolver(), "/parent");
+    assertNotNull(syntheticResource);
+    assertEquals("/synthetics/parent/cellElement", syntheticResource.getPath());
+  }
+
+  @Test
+  public void testGetText() {
+    assertEquals("45", cell.getText());
+  }
+
+  @Test
+  public void testGetCellContentElementsWhenTextOnly() {
+    assertTrue(cell.getCellContentElements().isEmpty());
+  }
+
+  @Test
+  public void testContentElementCell() throws ComponentConfigurationException {
+    KestrosHeadingImpl heading =
+        new KestrosHeadingImpl("Harborside", "h3", dataSource, "content", "contentElement");
+    List<KestrosBasicComponentElement> content = Collections.singletonList(heading);
+    KestrosTableCellImpl richCell =
+        new KestrosTableCellImpl(content, dataSource, "cell2", "cell2Element");
+    assertEquals(1, richCell.getCellContentElements().size());
+    assertNull(richCell.getText());
+  }
+}

--- a/src/test/java/io/kestros/cms/components/basic/core/content/table/KestrosTableCellImplTest.java
+++ b/src/test/java/io/kestros/cms/components/basic/core/content/table/KestrosTableCellImplTest.java
@@ -41,6 +41,14 @@ public class KestrosTableCellImplTest extends BaseSyntheticTest {
   }
 
   @Test
+  public void testSyntheticResourceCarriesText() {
+    // Regression: getCellContent() returns List<Resource> and must be @JsonIgnore, else it corrupts
+    // the ObjectMapper serialization of the synthetic resource and the cell's text is dropped.
+    final Resource synthetic = cell.toSyntheticResource(getResourceResolver(), "/parent");
+    assertEquals("45", synthetic.getValueMap().get("text", String.class));
+  }
+
+  @Test
   public void testGetCellContentElementsWhenTextOnly() {
     assertTrue(cell.getCellContentElements().isEmpty());
   }

--- a/src/test/java/io/kestros/cms/components/basic/core/content/table/KestrosTableHeaderImplTest.java
+++ b/src/test/java/io/kestros/cms/components/basic/core/content/table/KestrosTableHeaderImplTest.java
@@ -1,0 +1,35 @@
+package io.kestros.cms.components.basic.core.content.table;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import io.kestros.cms.components.basic.api.exceptions.ComponentConfigurationException;
+import io.kestros.cms.components.basic.core.BaseSyntheticTest;
+import io.kestros.cms.components.basic.core.lists.cardlist.CardListStaticDataSource;
+import org.apache.sling.api.resource.Resource;
+import org.junit.Test;
+
+public class KestrosTableHeaderImplTest extends BaseSyntheticTest {
+
+  private KestrosTableHeaderImpl header;
+
+  @Override
+  public void setupElement() throws ComponentConfigurationException {
+    Resource resource = context.create().resource("/content/parent");
+    context.currentResource(resource);
+    CardListStaticDataSource dataSource = context.request().adaptTo(CardListStaticDataSource.class);
+    header = new KestrosTableHeaderImpl("Points", dataSource, "header", "headerElement");
+  }
+
+  @Override
+  public void testToSyntheticResource() throws ComponentConfigurationException {
+    Resource syntheticResource = header.toSyntheticResource(getResourceResolver(), "/parent");
+    assertNotNull(syntheticResource);
+    assertEquals("/synthetics/parent/headerElement", syntheticResource.getPath());
+  }
+
+  @Test
+  public void testGetText() {
+    assertEquals("Points", header.getText());
+  }
+}

--- a/src/test/java/io/kestros/cms/components/basic/core/content/table/KestrosTableRowImplTest.java
+++ b/src/test/java/io/kestros/cms/components/basic/core/content/table/KestrosTableRowImplTest.java
@@ -1,0 +1,47 @@
+package io.kestros.cms.components.basic.core.content.table;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import io.kestros.cms.components.basic.api.exceptions.ComponentConfigurationException;
+import io.kestros.cms.components.basic.api.table.KestrosTableCell;
+import io.kestros.cms.components.basic.core.BaseSyntheticTest;
+import io.kestros.cms.components.basic.core.lists.cardlist.CardListStaticDataSource;
+import java.util.Arrays;
+import java.util.List;
+import org.apache.sling.api.resource.Resource;
+import org.junit.Test;
+
+public class KestrosTableRowImplTest extends BaseSyntheticTest {
+
+  private KestrosTableRowImpl row;
+
+  @Override
+  public void setupElement() throws ComponentConfigurationException {
+    Resource resource = context.create().resource("/content/parent");
+    context.currentResource(resource);
+    CardListStaticDataSource dataSource = context.request().adaptTo(CardListStaticDataSource.class);
+    KestrosTableCell c1 = new KestrosTableCellImpl("1", dataSource, "cell0", "cell0Element");
+    KestrosTableCell c2 = new KestrosTableCellImpl("Harborside", dataSource, "cell1", "cell1Element");
+    List<KestrosTableCell> cells = Arrays.asList(c1, c2);
+    row = new KestrosTableRowImpl(cells, dataSource, "row", "rowElement");
+  }
+
+  @Override
+  public void testToSyntheticResource() throws ComponentConfigurationException {
+    Resource syntheticResource = row.toSyntheticResource(getResourceResolver(), "/parent");
+    assertNotNull(syntheticResource);
+    assertEquals("/synthetics/parent/rowElement", syntheticResource.getPath());
+  }
+
+  @Test
+  public void testGetCellElements() {
+    assertEquals(2, row.getCellElements().size());
+  }
+
+  @Test
+  public void testGetCellElementsText() {
+    assertEquals("1", row.getCellElements().get(0).getText());
+    assertEquals("Harborside", row.getCellElements().get(1).getText());
+  }
+}

--- a/src/test/java/io/kestros/cms/components/basic/core/content/table/TableChildNodesDataSourceTest.java
+++ b/src/test/java/io/kestros/cms/components/basic/core/content/table/TableChildNodesDataSourceTest.java
@@ -65,6 +65,19 @@ public class TableChildNodesDataSourceTest extends BaseDataSourceTest {
   }
 
   @Test
+  public void testGetRowElementsWhenDataPathHasUnresolvedPlaceholder() {
+    // {team} with no matching route parameter resolves to empty -> path misses -> no rows, no crash.
+    final Map<String, Object> props = new HashMap<>();
+    props.put("dataPath", "/content/data/teams/{team}/results");
+    props.put("columns", new String[] {"pos"});
+    final Resource dyn = context.create().resource("/content/page/jcr:content/tabledyn", props);
+    context.request().setResource(dyn);
+    final TableChildNodesDataSource dynDataSource =
+        context.request().adaptTo(TableChildNodesDataSource.class);
+    assertEquals(0, dynDataSource.getRowElements().size());
+  }
+
+  @Test
   public void testGetRowElementsWhenNoDataPath() {
     final Resource bare = context.create().resource("/content/page/jcr:content/table2",
         new HashMap<>());

--- a/src/test/java/io/kestros/cms/components/basic/core/content/table/TableChildNodesDataSourceTest.java
+++ b/src/test/java/io/kestros/cms/components/basic/core/content/table/TableChildNodesDataSourceTest.java
@@ -1,0 +1,76 @@
+package io.kestros.cms.components.basic.core.content.table;
+
+import static org.junit.Assert.assertEquals;
+
+import io.kestros.cms.components.basic.api.table.KestrosTable;
+import io.kestros.cms.components.basic.core.BaseDataSourceTest;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.sling.api.resource.Resource;
+import org.junit.Test;
+
+public class TableChildNodesDataSourceTest extends BaseDataSourceTest {
+
+  private TableChildNodesDataSource dataSource;
+  private Resource resource;
+
+  @Override
+  public void doComponentSetup() {
+    final Map<String, Object> row1 = new HashMap<>();
+    row1.put("club", "Harborside");
+    row1.put("pos", 1L);
+    row1.put("pts", 45L);
+    context.create().resource("/content/data/standings/row1", row1);
+    final Map<String, Object> row2 = new HashMap<>();
+    row2.put("club", "Riverside");
+    row2.put("pos", 2L);
+    row2.put("pts", 38L);
+    context.create().resource("/content/data/standings/row2", row2);
+
+    final Map<String, Object> props = new HashMap<>();
+    props.put("dataPath", "/content/data/standings");
+    props.put("columns", new String[] {"pos", "club", "pts"});
+    props.put("headers", new String[] {"Pos", "Club", "Pts"});
+    resource = context.create().resource("/content/page/jcr:content/table", props);
+    context.request().setResource(resource);
+    dataSource = context.request().adaptTo(TableChildNodesDataSource.class);
+  }
+
+  @Override
+  public void testToSyntheticResource() {
+    final Resource synthetic =
+        dataSource.toSyntheticResource(context.resourceResolver(), "/content/page/jcr:content");
+    assertEquals(KestrosTable.RESOURCE_TYPE, synthetic.getResourceType());
+  }
+
+  @Test
+  public void testGetRowElements() {
+    assertEquals(2, dataSource.getRowElements().size());
+  }
+
+  @Test
+  public void testGetRowElementsCells() {
+    assertEquals(3, dataSource.getRowElements().get(0).getCellElements().size());
+    assertEquals("1", dataSource.getRowElements().get(0).getCellElements().get(0).getText());
+    assertEquals("Harborside",
+        dataSource.getRowElements().get(0).getCellElements().get(1).getText());
+    assertEquals("45", dataSource.getRowElements().get(0).getCellElements().get(2).getText());
+  }
+
+  @Test
+  public void testGetHeaderElements() {
+    assertEquals(3, dataSource.getHeaderElements().size());
+    assertEquals("Pos", dataSource.getHeaderElements().get(0).getText());
+    assertEquals("Club", dataSource.getHeaderElements().get(1).getText());
+  }
+
+  @Test
+  public void testGetRowElementsWhenNoDataPath() {
+    final Resource bare = context.create().resource("/content/page/jcr:content/table2",
+        new HashMap<>());
+    context.request().setResource(bare);
+    final TableChildNodesDataSource emptyDataSource =
+        context.request().adaptTo(TableChildNodesDataSource.class);
+    assertEquals(0, emptyDataSource.getRowElements().size());
+  }
+}


### PR DESCRIPTION
## Why
Card lists can be built programmatically from data; tables could only be built from **authored** row/cell resources — so no **data-driven table** was possible. This blocks the league-demo standings/results/fixtures/stats tables (board: datasource-table-synthetic-rows, approved by Danny).

## What
- **Synthetic impls** `KestrosTableRowImpl` / `KestrosTableCellImpl` / `KestrosTableHeaderImpl` — constructable (extend `BaseContainerSyntheticResource`/`BaseSyntheticResource`), mirroring `KestrosCardImpl`. **No component-API change needed.**
- **Generic `TableChildNodesDataSource`** — a `KestrosTable` datasource that renders a table from a collection of structured data nodes (config: `dataPath`, `columns`, `headers`), the true mirror of `CardListChildPagesDataSource`. Reusable for standings/results/fixtures/stats — no per-domain code.
- Registered as the "Data-driven Table" variant (`table/datasources/data.json`).

## Tests
Row/Cell/Header impl tests (incl. synthetic-resource generation) + `TableChildNodesDataSourceTest` (rows/cells/headers from data, empty-when-unconfigured). **Full module suite green (404 tests, 0 failures).**

_basic-components 0.3.1-SNAPSHOT. Unit-verified; live render on a CMS instance is the next step (follow-on), then the actual Standings/Results/Fixtures content._