### PR TITLE
release: kestros-basic-components 0.3.2

### DIFF
--- a/kestros-basic-components-testing/pom.xml
+++ b/kestros-basic-components-testing/pom.xml
@@ -31,7 +31,7 @@
 
     <groupId>io.kestros.cms</groupId>
     <artifactId>kestros-basic-components-testing</artifactId>
-    <version>0.3.1</version>
+    <version>0.3.2</version>
     <packaging>jar</packaging>
 
     <name>Kestros Basic Components - Testing Support</name>

--- a/kestros-basic-components/pom.xml
+++ b/kestros-basic-components/pom.xml
@@ -31,7 +31,7 @@
 
     <groupId>io.kestros.cms</groupId>
     <artifactId>kestros-basic-components</artifactId>
-    <version>0.3.1</version>
+    <version>0.3.2</version>
 
     <name>Kestros Basic Components</name>
     <description></description>

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
 
     <groupId>io.kestros.cms</groupId>
     <artifactId>kestros-basic-components-parent</artifactId>
-    <version>0.3.1</version>
+    <version>0.3.2</version>
     <packaging>pom</packaging>
 
     <name>Kestros Basic Components (Reactor)</name>


### PR DESCRIPTION
## Release: kestros-basic-components 0.3.2

Version bump only (0.3.1 → 0.3.2) across the reactor for the next Maven Central release. 0.3.1 is already published, so a new version is required.

### What this release publishes (three artifacts)
- `io.kestros.cms:kestros-basic-components-parent` (pom) — reactor aggregator
- `io.kestros.cms:kestros-basic-components` (bundle) — unchanged, republished at 0.3.2
- `io.kestros.cms:kestros-basic-components-testing` (jar) — **new** shared JUnit base classes for datasource tests, first published here

### Context
The multi-module restructure + `-test` module landed in #96 (already merged to develop). This branch only carries the version bump so the release job can publish all three modules.

### Downstream
The archetype PR (kestros-archetypes#45) depends on `kestros-basic-components-testing [0.3.0,0.3.99]`, so it can only merge/release **after** this 0.3.2 release syncs to Central.
