### PR TITLE
release: kestros-basic-components-testing 0.3.2

### DIFF
--- a/kestros-basic-components-testing/pom.xml
+++ b/kestros-basic-components-testing/pom.xml
@@ -31,7 +31,7 @@
 
     <groupId>io.kestros.cms</groupId>
     <artifactId>kestros-basic-components-testing</artifactId>
-    <version>0.3.1</version>
+    <version>0.3.2</version>
     <packaging>jar</packaging>
 
     <name>Kestros Basic Components - Testing Support</name>


### PR DESCRIPTION
## Release: kestros-basic-components-testing 0.3.2

First Maven Central release of the new **kestros-basic-components-testing** module (shared JUnit base classes for datasource tests; landed in #96).

Version bump touches **only** `kestros-basic-components-testing/pom.xml` (0.3.1 → 0.3.2). The `kestros-basic-components` bundle is unchanged and stays at 0.3.1 — it is not part of this release.

### Downstream
Archetype `kestros-archetypes#45` depends on `kestros-basic-components-testing [0.3.0,0.3.99]`, so it can merge/release once 0.3.2 syncs to Central.
