### PR TITLE
chore: reconcile strict-profile fixes from release/kestros-basic-components-testing/0.3.2 into develop

### DIFF
--- a/kestros-basic-components-testing/src/main/java/io/kestros/cms/components/basic/testing/BaseDataSourceTest.java
+++ b/kestros-basic-components-testing/src/main/java/io/kestros/cms/components/basic/testing/BaseDataSourceTest.java
@@ -1,3 +1,21 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
 package io.kestros.cms.components.basic.testing;
 
 import static org.mockito.ArgumentMatchers.any;

--- a/kestros-basic-components-testing/src/main/java/io/kestros/cms/components/basic/testing/BaseDataSourceTest.java
+++ b/kestros-basic-components-testing/src/main/java/io/kestros/cms/components/basic/testing/BaseDataSourceTest.java
@@ -28,6 +28,12 @@ public abstract class BaseDataSourceTest {
   @Rule
   public final SlingContext context = new SlingContext();
 
+  /**
+   * Registers the datasource services every Kestros datasource model resolves at construction
+   * time (theme, UI framework, variation and view retrieval).
+   *
+   * @throws Exception if service registration fails.
+   */
   @Before
   public void registerDataSourceServices() throws Exception {
     context.registerService(ComponentVariationRetrievalService.class,


### PR DESCRIPTION
Cherry-picks bccd495 and f0746a5, which were pushed to `release/kestros-basic-components-testing/0.3.2` at 17:36 and 17:38 on 2026-07-24 — after PR #98 merged at 17:30. Nothing carried them back.

- javadoc on `BaseDataSourceTest#registerDataSourceServices` (checkstyle JavadocMethod)
- GPL license header on `BaseDataSourceTest` (apache-rat)

Without these, a strict build from develop fails apache-rat on this file.
