### PR TITLE
chore: fill empty kestros-basic-components pom description (Central Portal gate)

### DIFF
--- a/kestros-basic-components/pom.xml
+++ b/kestros-basic-components/pom.xml
@@ -34,7 +34,7 @@
     <version>0.3.1</version>
 
     <name>Kestros Basic Components</name>
-    <description></description>
+    <description>Basic content components (navigation, lists, structure, media) for Kestros sites.</description>
 
     <licenses>
         <license>


### PR DESCRIPTION
`kestros-basic-components/pom.xml` on develop still has `<description></description>`, which fails Central Portal validation with "Project description is missing".

This was fixed on `release/0.3.1` as b83d37c, but that commit edited the **root** pom, before the repo became a multi-module reactor. Cherry-picking it conflicts, so the same description is applied to the module pom instead — that module is the artifact published to Central. The root and `-testing` poms already have descriptions.
