### PR TITLE
Strict build 1/4: jacoco coverage for basic-components

### DIFF
--- a/kestros-basic-components/src/test/java/io/kestros/cms/components/basic/api/content/AnchorTargetTest.java
+++ b/kestros-basic-components/src/test/java/io/kestros/cms/components/basic/api/content/AnchorTargetTest.java
@@ -1,0 +1,85 @@
+package io.kestros.cms.components.basic.api.content;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.sling.testing.mock.sling.junit.SlingContext;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class AnchorTargetTest {
+
+  @Rule
+  public SlingContext context = new SlingContext();
+
+  @Test
+  public void testGetTargetValue() {
+    assertEquals("_self", AnchorTarget.SAME_WINDOW.getTargetValue());
+    assertEquals("_blank", AnchorTarget.NEW_WINDOW.getTargetValue());
+  }
+
+  @Test
+  public void testLookupByStringValue() {
+    assertEquals(AnchorTarget.SAME_WINDOW, AnchorTarget.lookup("_self"));
+    assertEquals(AnchorTarget.NEW_WINDOW, AnchorTarget.lookup("_blank"));
+  }
+
+  @Test
+  public void testLookupByStringValueIsCaseInsensitive() {
+    assertEquals(AnchorTarget.NEW_WINDOW, AnchorTarget.lookup("_BLANK"));
+  }
+
+  @Test
+  public void testLookupByStringValueFallsBackToSameWindow() {
+    assertEquals(AnchorTarget.SAME_WINDOW, AnchorTarget.lookup("_parent"));
+    assertEquals(AnchorTarget.SAME_WINDOW, AnchorTarget.lookup((String) null));
+  }
+
+  @Test
+  public void testLookupByBoolean() {
+    assertEquals(AnchorTarget.NEW_WINDOW, AnchorTarget.lookup(Boolean.TRUE));
+    assertEquals(AnchorTarget.SAME_WINDOW, AnchorTarget.lookup(Boolean.FALSE));
+    assertEquals(AnchorTarget.SAME_WINDOW, AnchorTarget.lookup((Boolean) null));
+  }
+
+  @Test
+  public void testLookupByResourceUsingTheTargetProperty() {
+    final Map<String, Object> properties = new HashMap<>();
+    properties.put("target", "_blank");
+    context.create().resource("/content/link-target", properties);
+
+    assertEquals(AnchorTarget.NEW_WINDOW,
+        AnchorTarget.lookup(context.resourceResolver().getResource("/content/link-target")));
+  }
+
+  /** With no target property, the openInNewTab flag decides. */
+  @Test
+  public void testLookupByResourceFallsBackToOpenInNewTab() {
+    final Map<String, Object> properties = new HashMap<>();
+    properties.put("openInNewTab", true);
+    context.create().resource("/content/link-new-tab", properties);
+
+    assertEquals(AnchorTarget.NEW_WINDOW,
+        AnchorTarget.lookup(context.resourceResolver().getResource("/content/link-new-tab")));
+  }
+
+  @Test
+  public void testLookupByResourceWithNeitherProperty() {
+    context.create().resource("/content/link-plain", new HashMap<>());
+
+    assertEquals(AnchorTarget.SAME_WINDOW,
+        AnchorTarget.lookup(context.resourceResolver().getResource("/content/link-plain")));
+  }
+
+  @Test
+  public void testLookupByResourceWhenTheResourceIsNull() {
+    assertEquals(AnchorTarget.SAME_WINDOW, AnchorTarget.lookup((org.apache.sling.api.resource.Resource) null));
+  }
+
+  @Test
+  public void testValueOf() {
+    assertEquals(AnchorTarget.NEW_WINDOW, AnchorTarget.valueOf("NEW_WINDOW"));
+    assertEquals(2, AnchorTarget.values().length);
+  }
+}

--- a/kestros-basic-components/src/test/java/io/kestros/cms/components/basic/core/content/card/CardPageDataSourceTest.java
+++ b/kestros-basic-components/src/test/java/io/kestros/cms/components/basic/core/content/card/CardPageDataSourceTest.java
@@ -73,4 +73,57 @@ public class CardPageDataSourceTest extends BaseDataSourceTest {
   public void testGetPage() {
     assertNotNull(cardPageDataSource.getPage());
   }
+
+  /**
+   * Every getter guards on getPage(). With no pagePath configured, and with a pagePath that does
+   * not resolve, each must return null rather than throw.
+   */
+  private CardPageDataSource adaptWith(final Map<String, Object> props, final String name) {
+    final Resource componentResource = context.create().resource("/content/" + name, props);
+    context.request().setResource(componentResource);
+    return context.request().adaptTo(CardPageDataSource.class);
+  }
+
+  @Test
+  public void testGettersWhenThereIsNoPagePath() {
+    final CardPageDataSource dataSource = adaptWith(new HashMap<>(), "card-no-path");
+
+    assertNull(dataSource.getPage());
+    assertNull(dataSource.getTitleElement());
+    assertNull(dataSource.getDescription());
+    assertNull(dataSource.getImageElement());
+    assertNull(dataSource.getButtonGroupElement());
+  }
+
+  @Test
+  public void testGettersWhenThePagePathDoesNotResolve() {
+    final Map<String, Object> props = new HashMap<>();
+    props.put("pagePath", "/content/nowhere");
+    final CardPageDataSource dataSource = adaptWith(props, "card-missing-page");
+
+    assertNull(dataSource.getPage());
+    assertNull(dataSource.getTitleElement());
+    assertNull(dataSource.getDescription());
+    assertNull(dataSource.getImageElement());
+    assertNull(dataSource.getButtonGroupElement());
+  }
+
+  @Test
+  public void testGetTitleElementUsesTheConfiguredHeadingLevel() {
+    final Map<String, Object> props = new HashMap<>();
+    props.put("pagePath", "/content/page");
+    props.put("headingLevel", "h3");
+
+    assertNotNull(adaptWith(props, "card-h3").getTitleElement());
+  }
+
+  /** The page is resolved once and cached. */
+  @Test
+  public void testGetPageIsCachedAfterTheFirstLookup() {
+    final Map<String, Object> props = new HashMap<>();
+    props.put("pagePath", "/content/page");
+    final CardPageDataSource dataSource = adaptWith(props, "card-cached");
+
+    assertEquals(dataSource.getPage(), dataSource.getPage());
+  }
 }

--- a/kestros-basic-components/src/test/java/io/kestros/cms/components/basic/core/content/image/ImageAssetDataSourceTest.java
+++ b/kestros-basic-components/src/test/java/io/kestros/cms/components/basic/core/content/image/ImageAssetDataSourceTest.java
@@ -1,0 +1,220 @@
+package io.kestros.cms.components.basic.core.content.image;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+import io.kestros.cms.assets.api.exceptions.AssetCollectionRetrievalException;
+import io.kestros.cms.components.basic.api.content.AnchorTarget;
+import io.kestros.cms.components.basic.core.BaseDataSourceTest;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.sling.api.resource.Resource;
+import org.junit.Test;
+
+public class ImageAssetDataSourceTest extends BaseDataSourceTest {
+
+  private ImageAssetDataSource dataSource;
+
+  private final Map<String, Object> properties = new HashMap<>();
+
+  private int resourceCounter;
+
+  @Override
+  public void doComponentSetup() throws AssetCollectionRetrievalException {
+    setUpSampleCollection("/content/assets/collection");
+  }
+
+  /**
+   * Registers the asset retrieval service before adapting: the model reads it as an
+   * {@code @OSGiService}, and without it every asset lookup returns null.
+   */
+  private void adaptWith(final Map<String, Object> componentProperties) {
+    resourceCounter++;
+    final Resource resource = context.create().resource(
+        "/content/page/jcr:content/image-" + resourceCounter, componentProperties);
+    context.request().setResource(resource);
+    registerAssetRetrievalService();
+    dataSource = context.request().adaptTo(ImageAssetDataSource.class);
+  }
+
+  private void adaptWithoutAssetService(final Map<String, Object> componentProperties) {
+    resourceCounter++;
+    final Resource resource = context.create().resource(
+        "/content/page/jcr:content/no-service-" + resourceCounter, componentProperties);
+    context.request().setResource(resource);
+    dataSource = context.request().adaptTo(ImageAssetDataSource.class);
+  }
+
+  @Override
+  public void testToSyntheticResource() throws AssetCollectionRetrievalException {
+    adaptWith(properties);
+
+    assertNotNull(
+        dataSource.toSyntheticResource(context.resourceResolver(), "/content/page/jcr:content"));
+  }
+
+  @Test
+  public void testGetImagePath() {
+    properties.put("imagePath", "/content/assets/collection/asset-1");
+    adaptWith(properties);
+
+    assertEquals("/content/assets/collection/asset-1", dataSource.getImagePath());
+  }
+
+  @Test
+  public void testGetImagePathWhenBlank() {
+    properties.put("imagePath", "   ");
+    adaptWith(properties);
+
+    assertNull(dataSource.getImagePath());
+  }
+
+  @Test
+  public void testGetImagePathWhenNotConfigured() {
+    adaptWith(properties);
+
+    assertNull(dataSource.getImagePath());
+  }
+
+  @Test
+  public void testGetImageTitleComesFromTheAsset() {
+    properties.put("imagePath", "/content/assets/collection/asset-1");
+    adaptWith(properties);
+
+    assertEquals("Asset 1 Title", dataSource.getImageTitle());
+  }
+
+  /** With no asset behind the path, the component's own imageTitle property is the fallback. */
+  @Test
+  public void testGetImageTitleFallsBackToTheComponentProperty() {
+    properties.put("imagePath", "/content/assets/collection/missing");
+    properties.put("imageTitle", "Configured Title");
+    adaptWith(properties);
+
+    assertEquals("Configured Title", dataSource.getImageTitle());
+  }
+
+  @Test
+  public void testGetImageTitleWhenThereIsNeither() {
+    adaptWith(properties);
+
+    assertEquals("", dataSource.getImageTitle());
+  }
+
+  /** An explicit altText wins over the asset's description. */
+  @Test
+  public void testGetAltTextPrefersTheConfiguredValue() {
+    properties.put("imagePath", "/content/assets/collection/asset-1");
+    properties.put("altText", "Configured Alt");
+    adaptWith(properties);
+
+    assertEquals("Configured Alt", dataSource.getAltText());
+  }
+
+  @Test
+  public void testGetAltTextFallsBackToTheAssetDescription() {
+    properties.put("imagePath", "/content/assets/collection/asset-1");
+    adaptWith(properties);
+
+    assertEquals("Asset 1 Description", dataSource.getAltText());
+  }
+
+  @Test
+  public void testGetAltTextWhenThereIsNeither() {
+    adaptWith(properties);
+
+    assertEquals("", dataSource.getAltText());
+  }
+
+  @Test
+  public void testGetAltTextWhenTheConfiguredValueIsBlank() {
+    properties.put("altText", "   ");
+    adaptWith(properties);
+
+    assertEquals("", dataSource.getAltText());
+  }
+
+  @Test
+  public void testGetCaption() {
+    properties.put("caption", "A caption");
+    adaptWith(properties);
+
+    assertEquals("A caption", dataSource.getCaption());
+  }
+
+  @Test
+  public void testGetCaptionWhenNotConfigured() {
+    adaptWith(properties);
+
+    assertNull(dataSource.getCaption());
+  }
+
+  @Test
+  public void testGetAriaLabel() {
+    properties.put("ariaLabel", "Product photo");
+    adaptWith(properties);
+
+    assertEquals("Product photo", dataSource.getAriaLabel());
+  }
+
+  @Test
+  public void testGetAriaLabelWhenNotConfigured() {
+    adaptWith(properties);
+
+    assertNull(dataSource.getAriaLabel());
+  }
+
+  @Test
+  public void testTheLinkGettersAreAlwaysEmpty() {
+    adaptWith(properties);
+
+    assertNull(dataSource.getHref());
+    assertNull(dataSource.getAnchorTitle());
+    assertNull(dataSource.getRel());
+    assertNull(dataSource.getAriaDescribedBy());
+    assertNull(dataSource.getLang());
+    assertEquals(AnchorTarget.SAME_WINDOW, dataSource.getTarget());
+  }
+
+  @Test
+  public void testGetAsset() {
+    properties.put("imagePath", "/content/assets/collection/asset-1");
+    adaptWith(properties);
+
+    assertNotNull(dataSource.getAsset());
+  }
+
+  /** The resolved asset is cached, so a second call returns the same instance. */
+  @Test
+  public void testGetAssetIsCachedAfterTheFirstLookup() {
+    properties.put("imagePath", "/content/assets/collection/asset-1");
+    adaptWith(properties);
+
+    assertEquals(dataSource.getAsset(), dataSource.getAsset());
+  }
+
+  @Test
+  public void testGetAssetWhenThePathDoesNotResolve() {
+    properties.put("imagePath", "/content/assets/collection/missing");
+    adaptWith(properties);
+
+    assertNull(dataSource.getAsset());
+  }
+
+  @Test
+  public void testGetAssetWhenNoPathIsConfigured() {
+    adaptWith(properties);
+
+    assertNull(dataSource.getAsset());
+  }
+
+  /** The service reference is @Optional, so an unbound service must yield null, not a failure. */
+  @Test
+  public void testGetAssetWhenThereIsNoAssetRetrievalService() {
+    properties.put("imagePath", "/content/assets/collection/asset-1");
+    adaptWithoutAssetService(properties);
+
+    assertNull(dataSource.getAsset());
+  }
+}

--- a/kestros-basic-components/src/test/java/io/kestros/cms/components/basic/core/content/image/ImageStaticDataSourceTest.java
+++ b/kestros-basic-components/src/test/java/io/kestros/cms/components/basic/core/content/image/ImageStaticDataSourceTest.java
@@ -95,4 +95,59 @@ public class ImageStaticDataSourceTest extends BaseDataSourceTest {
     assertNotNull(imageStaticDataSource.getAsset());
   }
 
+  /** altText wins over the asset description; with neither, the result is the empty string. */
+  @Test
+  public void testGetAltTextPrefersTheConfiguredValue() {
+    registerAssetRetrievalService();
+    properties.put("altText", "Configured Alt");
+    resource = context.create().resource("/content/image/static/alt-configured", properties);
+    context.request().setResource(resource);
+
+    assertEquals("Configured Alt",
+        context.request().adaptTo(ImageStaticDataSource.class).getAltText());
+  }
+
+  @Test
+  public void testGetAltTextWhenTheConfiguredValueIsBlank() {
+    registerAssetRetrievalService();
+    final Map<String, Object> props = new HashMap<>();
+    props.put("altText", "   ");
+    resource = context.create().resource("/content/image/static/alt-blank", props);
+    context.request().setResource(resource);
+
+    assertEquals("", context.request().adaptTo(ImageStaticDataSource.class).getAltText());
+  }
+
+  @Test
+  public void testGetAltTextWhenThereIsNoImagePath() {
+    registerAssetRetrievalService();
+    final Map<String, Object> props = new HashMap<>();
+    resource = context.create().resource("/content/image/static/alt-none", props);
+    context.request().setResource(resource);
+
+    assertEquals("", context.request().adaptTo(ImageStaticDataSource.class).getAltText());
+  }
+
+  @Test
+  public void testGetAssetWhenThePathDoesNotResolve() {
+    registerAssetRetrievalService();
+    final Map<String, Object> props = new HashMap<>();
+    props.put("imagePath", "/content/assets/collection/missing");
+    resource = context.create().resource("/content/image/static/missing-asset", props);
+    context.request().setResource(resource);
+
+    assertNull(context.request().adaptTo(ImageStaticDataSource.class).getAsset());
+  }
+
+  @Test
+  public void testGetImageTitleFallsBackToTheComponentProperty() {
+    registerAssetRetrievalService();
+    final Map<String, Object> props = new HashMap<>();
+    props.put("imageTitle", "Configured Title");
+    resource = context.create().resource("/content/image/static/title-configured", props);
+    context.request().setResource(resource);
+
+    assertEquals("Configured Title",
+        context.request().adaptTo(ImageStaticDataSource.class).getImageTitle());
+  }
 }

--- a/kestros-basic-components/src/test/java/io/kestros/cms/components/basic/core/content/table/TableChildNodesDataSourceTest.java
+++ b/kestros-basic-components/src/test/java/io/kestros/cms/components/basic/core/content/table/TableChildNodesDataSourceTest.java
@@ -1,6 +1,7 @@
 package io.kestros.cms.components.basic.core.content.table;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import io.kestros.cms.components.basic.api.table.KestrosTable;
 import io.kestros.cms.components.basic.core.BaseDataSourceTest;
@@ -85,5 +86,58 @@ public class TableChildNodesDataSourceTest extends BaseDataSourceTest {
     final TableChildNodesDataSource emptyDataSource =
         context.request().adaptTo(TableChildNodesDataSource.class);
     assertEquals(0, emptyDataSource.getRowElements().size());
+  }
+
+  /** With no headers property configured, the header list is empty rather than null. */
+  @Test
+  public void testGetHeaderElementsWhenNoHeadersAreConfigured() {
+    final Map<String, Object> props = new HashMap<>();
+    props.put("dataPath", "/content/data/standings");
+    props.put("columns", new String[] {"pos", "club"});
+    final Resource componentResource =
+        context.create().resource("/content/page/jcr:content/table-no-headers", props);
+    context.request().setResource(componentResource);
+
+    assertTrue(context.request().adaptTo(TableChildNodesDataSource.class)
+        .getHeaderElements().isEmpty());
+  }
+
+  /** dataPath and columns are both required; missing either yields no rows. */
+  @Test
+  public void testGetRowElementsWhenNoDataPathIsConfigured() {
+    final Map<String, Object> props = new HashMap<>();
+    props.put("columns", new String[] {"pos", "club"});
+    final Resource componentResource =
+        context.create().resource("/content/page/jcr:content/table-no-path", props);
+    context.request().setResource(componentResource);
+
+    assertTrue(context.request().adaptTo(TableChildNodesDataSource.class)
+        .getRowElements().isEmpty());
+  }
+
+  @Test
+  public void testGetRowElementsWhenNoColumnsAreConfigured() {
+    final Map<String, Object> props = new HashMap<>();
+    props.put("dataPath", "/content/data/standings");
+    final Resource componentResource =
+        context.create().resource("/content/page/jcr:content/table-no-columns", props);
+    context.request().setResource(componentResource);
+
+    assertTrue(context.request().adaptTo(TableChildNodesDataSource.class)
+        .getRowElements().isEmpty());
+  }
+
+  /** A dataPath with no placeholder skips the resolution step entirely. */
+  @Test
+  public void testGetRowElementsWithAPlainDataPath() {
+    final Map<String, Object> props = new HashMap<>();
+    props.put("dataPath", "/content/data/standings");
+    props.put("columns", new String[] {"pos"});
+    final Resource componentResource =
+        context.create().resource("/content/page/jcr:content/table-plain-path", props);
+    context.request().setResource(componentResource);
+
+    assertEquals(2, context.request().adaptTo(TableChildNodesDataSource.class)
+        .getRowElements().size());
   }
 }

--- a/kestros-basic-components/src/test/java/io/kestros/cms/components/basic/core/content/table/TableStaticDataSourceTest.java
+++ b/kestros-basic-components/src/test/java/io/kestros/cms/components/basic/core/content/table/TableStaticDataSourceTest.java
@@ -1,0 +1,134 @@
+package io.kestros.cms.components.basic.core.content.table;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import io.kestros.cms.components.basic.api.table.KestrosTable;
+import io.kestros.cms.components.basic.api.table.KestrosTableHeader;
+import io.kestros.cms.components.basic.api.table.KestrosTableRow;
+import io.kestros.cms.components.basic.core.BaseDataSourceTest;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.sling.api.resource.Resource;
+import org.junit.Test;
+
+public class TableStaticDataSourceTest extends BaseDataSourceTest {
+
+  private TableStaticDataSource dataSource;
+  private Resource resource;
+
+  private final Map<String, Object> headerProperties = new HashMap<>();
+  private final Map<String, Object> rowProperties = new HashMap<>();
+  private final Map<String, Object> otherProperties = new HashMap<>();
+
+  @Override
+  public void doComponentSetup() {
+    headerProperties.put("sling:resourceType", KestrosTableHeader.RESOURCE_TYPE);
+    rowProperties.put("sling:resourceType", KestrosTableRow.RESOURCE_TYPE);
+    otherProperties.put("sling:resourceType", "kestros/commons/components/content/text");
+
+    resource = context.create().resource("/content/page/jcr:content/table", new HashMap<>());
+    context.request().setResource(resource);
+    dataSource = context.request().adaptTo(TableStaticDataSource.class);
+  }
+
+  @Override
+  public void testToSyntheticResource() {
+    final Resource synthetic =
+        dataSource.toSyntheticResource(context.resourceResolver(), "/content/page/jcr:content");
+    assertEquals(KestrosTable.RESOURCE_TYPE, synthetic.getResourceType());
+  }
+
+  @Test
+  public void testGetHeaderElements() {
+    context.create().resource("/content/page/jcr:content/table/header-1", headerProperties);
+    context.create().resource("/content/page/jcr:content/table/header-2", headerProperties);
+
+    assertEquals(2, dataSource.getHeaderElements().size());
+  }
+
+  @Test
+  public void testGetHeaderElementsWhenThereAreNone() {
+    assertTrue(dataSource.getHeaderElements().isEmpty());
+  }
+
+  /** Only children whose resource type is the header type count; everything else is skipped. */
+  @Test
+  public void testGetHeaderElementsSkipsChildrenOfOtherTypes() {
+    context.create().resource("/content/page/jcr:content/table/header-1", headerProperties);
+    context.create().resource("/content/page/jcr:content/table/row-1", rowProperties);
+    context.create().resource("/content/page/jcr:content/table/text-1", otherProperties);
+
+    assertEquals(1, dataSource.getHeaderElements().size());
+  }
+
+  @Test
+  public void testGetRowElements() {
+    context.create().resource("/content/page/jcr:content/table/row-1", rowProperties);
+    context.create().resource("/content/page/jcr:content/table/row-2", rowProperties);
+    context.create().resource("/content/page/jcr:content/table/row-3", rowProperties);
+
+    assertEquals(3, dataSource.getRowElements().size());
+  }
+
+  @Test
+  public void testGetRowElementsWhenThereAreNone() {
+    assertTrue(dataSource.getRowElements().isEmpty());
+  }
+
+  @Test
+  public void testGetRowElementsSkipsChildrenOfOtherTypes() {
+    context.create().resource("/content/page/jcr:content/table/row-1", rowProperties);
+    context.create().resource("/content/page/jcr:content/table/header-1", headerProperties);
+    context.create().resource("/content/page/jcr:content/table/text-1", otherProperties);
+
+    assertEquals(1, dataSource.getRowElements().size());
+  }
+
+  // ---------------------------------------------------------------------------------------------
+  // The container helpers on BaseContainerSlingModelDataSource: getChildren walks the child
+  // elements and converts synthetic ones, getChildrenAsType filters by resource type and
+  // getChildrenOfType filters by Java type. Exercised here because TableStaticDataSource is a
+  // concrete container.
+  // ---------------------------------------------------------------------------------------------
+
+  @Test
+  public void testGetChildren() {
+    context.create().resource("/content/page/jcr:content/table/header-1", headerProperties);
+    context.create().resource("/content/page/jcr:content/table/row-1", rowProperties);
+
+    assertNotNull(dataSource.getChildren());
+  }
+
+  @Test
+  public void testGetChildrenAsTypeFiltersByResourceType() {
+    context.create().resource("/content/page/jcr:content/table/header-1", headerProperties);
+    context.create().resource("/content/page/jcr:content/table/row-1", rowProperties);
+    context.create().resource("/content/page/jcr:content/table/text-1", otherProperties);
+
+    assertEquals(1, dataSource.getChildrenAsType(KestrosTableRow.RESOURCE_TYPE,
+        TableRowStaticDataSource.class).size());
+  }
+
+  @Test
+  public void testGetChildrenAsTypeWhenNothingMatches() {
+    context.create().resource("/content/page/jcr:content/table/text-1", otherProperties);
+
+    assertTrue(dataSource.getChildrenAsType(KestrosTableRow.RESOURCE_TYPE,
+        TableRowStaticDataSource.class).isEmpty());
+  }
+
+  @Test
+  public void testGetChildrenOfTypeFiltersByJavaType() {
+    context.create().resource("/content/page/jcr:content/table/header-1", headerProperties);
+    context.create().resource("/content/page/jcr:content/table/row-1", rowProperties);
+
+    assertNotNull(dataSource.getChildrenOfType(KestrosTableRow.class));
+  }
+
+  @Test
+  public void testGetChildrenOfTypeWhenThereAreNoChildren() {
+    assertTrue(dataSource.getChildrenOfType(KestrosTableRow.class).isEmpty());
+  }
+}

--- a/kestros-basic-components/src/test/java/io/kestros/cms/components/basic/core/content/video/VideoAssetDataSourceTest.java
+++ b/kestros-basic-components/src/test/java/io/kestros/cms/components/basic/core/content/video/VideoAssetDataSourceTest.java
@@ -1,0 +1,107 @@
+package io.kestros.cms.components.basic.core.content.video;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import io.kestros.cms.assets.api.exceptions.AssetCollectionRetrievalException;
+import io.kestros.cms.components.basic.api.content.KestrosVideo;
+import io.kestros.cms.components.basic.core.BaseDataSourceTest;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.sling.api.resource.Resource;
+import org.junit.Test;
+
+public class VideoAssetDataSourceTest extends BaseDataSourceTest {
+
+  private VideoAssetDataSource dataSource;
+
+  private final Map<String, Object> properties = new HashMap<>();
+
+  @Override
+  public void doComponentSetup() throws AssetCollectionRetrievalException {
+    setUpSampleCollection("/content/assets/collection");
+  }
+
+  /** Registers the asset retrieval service before adapting: the model reads it as an @OSGiService,
+   * and without it every asset lookup returns null. */
+  private void adaptWith(final Map<String, Object> componentProperties) {
+    final Resource resource =
+        context.create().resource("/content/page/jcr:content/video", componentProperties);
+    context.request().setResource(resource);
+    registerAssetRetrievalService();
+    dataSource = context.request().adaptTo(VideoAssetDataSource.class);
+  }
+
+  private void adaptWithoutAssetService(final Map<String, Object> componentProperties) {
+    final Resource resource =
+        context.create().resource("/content/page/jcr:content/video-no-service",
+            componentProperties);
+    context.request().setResource(resource);
+    dataSource = context.request().adaptTo(VideoAssetDataSource.class);
+  }
+
+  @Override
+  public void testToSyntheticResource() throws AssetCollectionRetrievalException {
+    adaptWith(properties);
+
+    assertEquals(KestrosVideo.RESOURCE_TYPE,
+        dataSource.toSyntheticResource(context.resourceResolver(), "/content/page/jcr:content")
+            .getResourceType());
+  }
+
+  @Test
+  public void testGetVideoSource() {
+    properties.put("videoPath", "/content/assets/collection/asset-1");
+    adaptWith(properties);
+
+    assertEquals("/content/assets/collection/asset-1", dataSource.getVideoSource());
+  }
+
+  @Test
+  public void testGetVideoSourceWhenNoVideoPathIsConfigured() {
+    adaptWith(properties);
+
+    assertNull(dataSource.getVideoSource());
+  }
+
+  @Test
+  public void testGetVideoSourceWhenTheAssetDoesNotExist() {
+    properties.put("videoPath", "/content/assets/collection/missing");
+    adaptWith(properties);
+
+    assertNull(dataSource.getVideoSource());
+  }
+
+  /** The resolved asset is cached, so a second call must not go back to the retrieval service. */
+  @Test
+  public void testGetAssetIsCachedAfterTheFirstLookup() {
+    properties.put("videoPath", "/content/assets/collection/asset-1");
+    adaptWith(properties);
+
+    assertEquals(dataSource.getAsset(), dataSource.getAsset());
+  }
+
+  /** The service reference is @Optional, so an unbound service must yield null, not a failure. */
+  @Test
+  public void testGetVideoSourceWhenThereIsNoAssetRetrievalService() {
+    properties.put("videoPath", "/content/assets/collection/asset-1");
+    adaptWithoutAssetService(properties);
+
+    assertNull(dataSource.getVideoSource());
+  }
+
+  @Test
+  public void testGetFallbackText() {
+    properties.put("fallbackText", "Your browser cannot play this video.");
+    adaptWith(properties);
+
+    assertEquals("Your browser cannot play this video.", dataSource.getFallbackText());
+  }
+
+  @Test
+  public void testGetFallbackTextWhenNotConfigured() {
+    adaptWith(properties);
+
+    assertEquals("", dataSource.getFallbackText());
+  }
+}

--- a/kestros-basic-components/src/test/java/io/kestros/cms/components/basic/core/content/videoembed/VideoEmbedYouTubeDataSourceTest.java
+++ b/kestros-basic-components/src/test/java/io/kestros/cms/components/basic/core/content/videoembed/VideoEmbedYouTubeDataSourceTest.java
@@ -1,15 +1,36 @@
 package io.kestros.cms.components.basic.core.content.videoembed;
 
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
+import java.util.HashMap;
+import java.util.Map;
+import io.kestros.cms.components.basic.core.BaseDataSourceTest;
+import org.apache.sling.api.resource.Resource;
 import org.junit.Test;
 
-public class VideoEmbedYouTubeDataSourceTest {
-
+public class VideoEmbedYouTubeDataSourceTest extends BaseDataSourceTest {
 
   private VideoEmbedYouTubeDataSource videoEmbedYouTubeDataSource
           = new VideoEmbedYouTubeDataSource();
+
+  private int counter;
+
+  @Override
+  public void doComponentSetup() {
+    context.create().resource("/content/page/jcr:content", new HashMap<>());
+  }
+
+  @Override
+  public void testToSyntheticResource() {
+    final Map<String, Object> properties = new HashMap<>();
+    properties.put("youtubeVideo", "abcdefghijk");
+
+    assertNotNull(adaptWith(properties)
+        .toSyntheticResource(context.resourceResolver(), "/content/page/jcr:content"));
+  }
 
   @Test
   public void testisValidVideoInput() {
@@ -73,4 +94,103 @@ public class VideoEmbedYouTubeDataSourceTest {
             "<iframe src=\"https://evil.com\"></iframe>"));
   }
 
+  // ---------------------------------------------------------------------------------------------
+  // getVideoEmbedCode and the id extraction behind it had no coverage: the existing cases only
+  // reach isValidVideoInput.
+  // ---------------------------------------------------------------------------------------------
+
+  private VideoEmbedYouTubeDataSource adaptWith(final Map<String, Object> properties) {
+    final Resource resource =
+        context.create().resource("/content/page/jcr:content/embed-" + (++counter), properties);
+    context.request().setResource(resource);
+    return context.request().adaptTo(VideoEmbedYouTubeDataSource.class);
+  }
+
+  @Test
+  public void testGetVideoEmbedCodeFromAWatchUrl() {
+    final Map<String, Object> properties = new HashMap<>();
+    properties.put("youtubeVideo", "https://www.youtube.com/watch?v=abcdefghijk");
+
+    final String embed = adaptWith(properties).getVideoEmbedCode();
+
+    assertNotNull(embed);
+    assertTrue(embed.contains("https://www.youtube.com/embed/abcdefghijk"));
+  }
+
+  /** A watch URL with trailing parameters keeps only the id. */
+  @Test
+  public void testGetVideoEmbedCodeStripsTrailingParameters() {
+    final Map<String, Object> properties = new HashMap<>();
+    properties.put("youtubeVideo", "https://www.youtube.com/watch?v=abcdefghijk&t=30s");
+
+    assertTrue(adaptWith(properties).getVideoEmbedCode()
+        .contains("https://www.youtube.com/embed/abcdefghijk"));
+  }
+
+  @Test
+  public void testGetVideoEmbedCodeFromAShortUrl() {
+    final Map<String, Object> properties = new HashMap<>();
+    properties.put("youtubeVideo", "https://youtu.be/abcdefghijk");
+
+    assertTrue(adaptWith(properties).getVideoEmbedCode()
+        .contains("https://www.youtube.com/embed/abcdefghijk"));
+  }
+
+  /** A bare id is passed through as the id. */
+  @Test
+  public void testGetVideoEmbedCodeFromARawVideoId() {
+    final Map<String, Object> properties = new HashMap<>();
+    properties.put("youtubeVideo", "abcdefghijk");
+
+    assertTrue(adaptWith(properties).getVideoEmbedCode()
+        .contains("https://www.youtube.com/embed/abcdefghijk"));
+  }
+
+  @Test
+  public void testGetVideoEmbedCodeAppendsTheMuteParameter() {
+    final Map<String, Object> properties = new HashMap<>();
+    properties.put("youtubeVideo", "abcdefghijk");
+    properties.put("mute", true);
+
+    assertTrue(adaptWith(properties).getVideoEmbedCode().contains("?mute=1"));
+  }
+
+  @Test
+  public void testGetVideoEmbedCodeAppendsAllowFullscreen() {
+    final Map<String, Object> properties = new HashMap<>();
+    properties.put("youtubeVideo", "abcdefghijk");
+    properties.put("allowFullscreen", true);
+
+    assertTrue(adaptWith(properties).getVideoEmbedCode().contains("allowfullscreen"));
+  }
+
+  @Test
+  public void testGetVideoEmbedCodeWhenNothingIsConfigured() {
+    assertNull(adaptWith(new HashMap<>()).getVideoEmbedCode());
+  }
+
+  @Test
+  public void testGetVideoEmbedCodeWhenTheInputIsBlank() {
+    final Map<String, Object> properties = new HashMap<>();
+    properties.put("youtubeVideo", "   ");
+
+    assertNull(adaptWith(properties).getVideoEmbedCode());
+  }
+
+  @Test
+  public void testGetVideoEmbedCodeWhenTheInputIsHtml() {
+    final Map<String, Object> properties = new HashMap<>();
+    properties.put("youtubeVideo", "<iframe src=\"evil\"></iframe>");
+
+    assertNull(adaptWith(properties).getVideoEmbedCode());
+  }
+
+  /** A youtube URL with neither a v= parameter nor a youtu.be path has no id to extract. */
+  @Test
+  public void testGetVideoEmbedCodeWhenTheYoutubeUrlHasNoVideoId() {
+    final Map<String, Object> properties = new HashMap<>();
+    properties.put("youtubeVideo", "https://www.youtube.com/feed/subscriptions");
+
+    assertNull(adaptWith(properties).getVideoEmbedCode());
+  }
 }

--- a/kestros-basic-components/src/test/java/io/kestros/cms/components/basic/core/lists/cardlist/CardListAssetsDataSourceTest.java
+++ b/kestros-basic-components/src/test/java/io/kestros/cms/components/basic/core/lists/cardlist/CardListAssetsDataSourceTest.java
@@ -169,4 +169,54 @@ public class CardListAssetsDataSourceTest extends BaseDataSourceTest {
     cardListAssetsDataSource = context.request().adaptTo(CardListAssetsDataSource.class);
     assertEquals(1, cardListAssetsDataSource.getCardElements().size());
   }
+
+  /**
+   * The createdDate and lastModified comparators had no coverage: the existing sort cases only
+   * exercise name and title, which share a different lambda.
+   */
+  @Test
+  public void testGetCardElements_sortByCreatedDate() {
+    registerAssetRetrievalService();
+    properties.put("sortBy", "createdDate");
+    resource = context.create().resource("/content/page/cardlist/assets-sortby-created",
+        properties);
+    context.request().setResource(resource);
+
+    assertEquals(3, context.request().adaptTo(CardListAssetsDataSource.class)
+        .getCardElements().size());
+  }
+
+  @Test
+  public void testGetCardElements_sortByLastModified() {
+    registerAssetRetrievalService();
+    properties.put("sortBy", "lastModified");
+    resource = context.create().resource("/content/page/cardlist/assets-sortby-modified",
+        properties);
+    context.request().setResource(resource);
+
+    assertEquals(3, context.request().adaptTo(CardListAssetsDataSource.class)
+        .getCardElements().size());
+  }
+
+  @Test
+  public void testGetHeadingLevelDefaultsToH2() {
+    registerAssetRetrievalService();
+    resource = context.create().resource("/content/page/cardlist/assets-default-heading",
+        properties);
+    context.request().setResource(resource);
+
+    assertEquals("h2",
+        context.request().adaptTo(CardListAssetsDataSource.class).getHeadingLevel());
+  }
+
+  @Test
+  public void testGetHeadingLevelWhenConfigured() {
+    registerAssetRetrievalService();
+    properties.put("headingType", "h3");
+    resource = context.create().resource("/content/page/cardlist/assets-h3", properties);
+    context.request().setResource(resource);
+
+    assertEquals("h3",
+        context.request().adaptTo(CardListAssetsDataSource.class).getHeadingLevel());
+  }
 }

--- a/kestros-basic-components/src/test/java/io/kestros/cms/components/basic/core/lists/cardlist/CardListChildPagesDataSourceTest.java
+++ b/kestros-basic-components/src/test/java/io/kestros/cms/components/basic/core/lists/cardlist/CardListChildPagesDataSourceTest.java
@@ -14,6 +14,7 @@ import io.kestros.cms.components.basic.api.content.KestrosImage;
 import io.kestros.cms.components.basic.api.lists.KestrosCardList;
 import io.kestros.cms.components.basic.core.BaseDataSourceTest;
 import io.kestros.cms.components.basic.core.content.image.ImageStaticDataSource;
+import java.util.Calendar;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -233,5 +234,107 @@ public class CardListChildPagesDataSourceTest extends BaseDataSourceTest {
     context.request().setResource(resource);
     cardListChildPagesDataSource = context.request().adaptTo(CardListChildPagesDataSource.class);
     assertEquals(1, cardListChildPagesDataSource.getCardElements().size());
+  }
+
+  /**
+   * The createdDate and lastModified comparators had no coverage: the existing sort cases only
+   * exercise name and title, which share a different lambda.
+   */
+  @Test
+  public void testGetCardElements_sortByCreatedDate() {
+    properties.put("sortBy", "createdDate");
+    resource = context.create().resource("/content/page/jcr:content/comp-sortby-created",
+        properties);
+    context.request().setResource(resource);
+
+    assertEquals(3, context.request().adaptTo(CardListChildPagesDataSource.class)
+        .getCardElements().size());
+  }
+
+  @Test
+  public void testGetCardElements_sortByLastModified() {
+    properties.put("sortBy", "lastModified");
+    resource = context.create().resource("/content/page/jcr:content/comp-sortby-modified",
+        properties);
+    context.request().setResource(resource);
+
+    assertEquals(3, context.request().adaptTo(CardListChildPagesDataSource.class)
+        .getCardElements().size());
+  }
+
+  @Test
+  public void testGetRootPageWhenThePagesPathDoesNotResolve() {
+    final Map<String, Object> props = new HashMap<>();
+    props.put("pagesPath", "/content/nowhere");
+    resource = context.create().resource("/content/page/jcr:content/comp-missing-root", props);
+    context.request().setResource(resource);
+
+    assertNull(context.request().adaptTo(CardListChildPagesDataSource.class).getRootPage());
+  }
+
+  @Test
+  public void testGetCardElementsWhenThereIsNoRootPage() {
+    final Map<String, Object> props = new HashMap<>();
+    props.put("pagesPath", "/content/nowhere");
+    resource = context.create().resource("/content/page/jcr:content/comp-no-root", props);
+    context.request().setResource(resource);
+
+    assertTrue(context.request().adaptTo(CardListChildPagesDataSource.class)
+        .getCardElements().isEmpty());
+  }
+
+  @Test
+  public void testGetReadMoreTextWhenNotConfigured() {
+    final Map<String, Object> props = new HashMap<>();
+    props.put("pagesPath", "/content/page");
+    resource = context.create().resource("/content/page/jcr:content/comp-no-read-more", props);
+    context.request().setResource(resource);
+
+    assertNull(context.request().adaptTo(CardListChildPagesDataSource.class).getReadMoreText());
+  }
+
+  /**
+   * The date comparators read jcr:created / jcr:lastModified off each page's jcr:content, guarding
+   * on both the child and the property. The sample pages all have a jcr:content and neither date,
+   * so only one side of each guard was reached. These add a page with no jcr:content at all and a
+   * page that does carry the dates.
+   */
+  private void addPagesWithAndWithoutDates() {
+    final Map<String, Object> pageProperties = new HashMap<>();
+    pageProperties.put("jcr:primaryType", "kes:Page");
+    context.create().resource("/content/page/child-no-content", pageProperties);
+
+    final Map<String, Object> datedContent = new HashMap<>();
+    datedContent.put("jcr:primaryType", "nt:unstructured");
+    datedContent.put("jcr:created", Calendar.getInstance());
+    datedContent.put("jcr:lastModified", Calendar.getInstance());
+    context.create().resource("/content/page/child-dated", pageProperties);
+    context.create().resource("/content/page/child-dated/jcr:content", datedContent);
+  }
+
+  @Test
+  public void testGetCardElements_sortByCreatedDateAcrossPagesWithAndWithoutDates() {
+    addPagesWithAndWithoutDates();
+    final Map<String, Object> props = new HashMap<>();
+    props.put("pagesPath", "/content/page");
+    props.put("sortBy", "createdDate");
+    resource = context.create().resource("/content/page/jcr:content/comp-created-mixed", props);
+    context.request().setResource(resource);
+
+    assertEquals(5, context.request().adaptTo(CardListChildPagesDataSource.class)
+        .getCardElements().size());
+  }
+
+  @Test
+  public void testGetCardElements_sortByLastModifiedAcrossPagesWithAndWithoutDates() {
+    addPagesWithAndWithoutDates();
+    final Map<String, Object> props = new HashMap<>();
+    props.put("pagesPath", "/content/page");
+    props.put("sortBy", "lastModified");
+    resource = context.create().resource("/content/page/jcr:content/comp-modified-mixed", props);
+    context.request().setResource(resource);
+
+    assertEquals(5, context.request().adaptTo(CardListChildPagesDataSource.class)
+        .getCardElements().size());
   }
 }

--- a/kestros-basic-components/src/test/java/io/kestros/cms/components/basic/core/lists/cardlist/CardListTagSearchDataSourceTest.java
+++ b/kestros-basic-components/src/test/java/io/kestros/cms/components/basic/core/lists/cardlist/CardListTagSearchDataSourceTest.java
@@ -1,6 +1,8 @@
 package io.kestros.cms.components.basic.core.lists.cardlist;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
@@ -17,6 +19,7 @@ import io.kestros.cms.tagging.api.models.KestrosTag;
 import io.kestros.cms.tagging.api.services.TagRetrievalService;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Calendar;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -245,5 +248,183 @@ public class CardListTagSearchDataSourceTest extends BaseDataSourceTest {
     CardListTagSearchDataSource limitDs =
         context.request().adaptTo(CardListTagSearchDataSource.class);
     assertEquals(1, limitDs.getCardElements().size());
+  }
+
+  // ---------------------------------------------------------------------------------------------
+  // The sort comparators only run when there are at least two matching pages. Placing the component
+  // on child-3 (which carries no tags of its own) leaves both child-1 and child-2 in the result, so
+  // the comparator bodies actually execute.
+  // ---------------------------------------------------------------------------------------------
+
+  private CardListTagSearchDataSource twoMatchesWith(final Map<String, Object> extraProperties) {
+    final Map<String, Object> props = new HashMap<>(extraProperties);
+    props.put("tags", new String[]{"/etc/tags/topic/java"});
+    props.put("readMoreText", "View Session");
+    final Resource componentResource = context.create().resource(
+        "/content/sessions/child-3/jcr:content/component-" + extraProperties.hashCode(), props);
+    context.request().setResource(componentResource);
+    return context.request().adaptTo(CardListTagSearchDataSource.class);
+  }
+
+  @Test
+  public void testGetCardElementsSortsTwoPagesByName() {
+    final Map<String, Object> props = new HashMap<>();
+    props.put("sortBy", "name");
+
+    assertEquals(2, twoMatchesWith(props).getCardElements().size());
+  }
+
+  @Test
+  public void testGetCardElementsSortsTwoPagesByTitle() {
+    final Map<String, Object> props = new HashMap<>();
+    props.put("sortBy", "title");
+
+    assertEquals(2, twoMatchesWith(props).getCardElements().size());
+  }
+
+  @Test
+  public void testGetCardElementsSortsTwoPagesByCreatedDate() {
+    final Map<String, Object> props = new HashMap<>();
+    props.put("sortBy", "createdDate");
+
+    assertEquals(2, twoMatchesWith(props).getCardElements().size());
+  }
+
+  @Test
+  public void testGetCardElementsSortsTwoPagesByLastModified() {
+    final Map<String, Object> props = new HashMap<>();
+    props.put("sortBy", "lastModified");
+
+    assertEquals(2, twoMatchesWith(props).getCardElements().size());
+  }
+
+  @Test
+  public void testGetCardElementsReversesTwoPages() {
+    final Map<String, Object> props = new HashMap<>();
+    props.put("sortBy", "name");
+    props.put("reverse", true);
+
+    assertEquals(2, twoMatchesWith(props).getCardElements().size());
+  }
+
+  @Test
+  public void testGetCardElementsLimitsTwoPagesToOne() {
+    final Map<String, Object> props = new HashMap<>();
+    props.put("limit", "1");
+
+    assertEquals(1, twoMatchesWith(props).getCardElements().size());
+  }
+
+  // ---------------------------------------------------------------------------------------------
+  // Guard branches.
+  // ---------------------------------------------------------------------------------------------
+
+  /** pagesPath overrides the containing page's parent as the search root. */
+  @Test
+  public void testGetRootPathUsesTheConfiguredPagesPath() {
+    final Map<String, Object> props = new HashMap<>();
+    props.put("tags", new String[]{"/etc/tags/topic/java"});
+    props.put("pagesPath", "/content/sessions");
+    final Resource componentResource = context.create().resource(
+        "/content/sessions/child-3/jcr:content/pages-path-component", props);
+    context.request().setResource(componentResource);
+
+    assertEquals("/content/sessions",
+        context.request().adaptTo(CardListTagSearchDataSource.class).getRootPath());
+  }
+
+  @Test
+  public void testGetRootPageWhenThePathDoesNotResolve() {
+    final Map<String, Object> props = new HashMap<>();
+    props.put("tags", new String[]{"/etc/tags/topic/java"});
+    props.put("pagesPath", "/content/nowhere");
+    final Resource componentResource = context.create().resource(
+        "/content/sessions/child-3/jcr:content/missing-root-component", props);
+    context.request().setResource(componentResource);
+
+    assertNull(context.request().adaptTo(CardListTagSearchDataSource.class).getRootPage());
+  }
+
+  @Test
+  public void testGetTaggedPagesWhenNoTagsAreConfigured() {
+    final Map<String, Object> props = new HashMap<>();
+    props.put("readMoreText", "View Session");
+    final Resource componentResource = context.create().resource(
+        "/content/sessions/child-3/jcr:content/no-tags-component", props);
+    context.request().setResource(componentResource);
+
+    assertTrue(context.request().adaptTo(CardListTagSearchDataSource.class)
+        .getTaggedPages().isEmpty());
+  }
+
+  @Test
+  public void testGetTaggedPagesWhenTheRootPageDoesNotResolve() {
+    final Map<String, Object> props = new HashMap<>();
+    props.put("tags", new String[]{"/etc/tags/topic/java"});
+    props.put("pagesPath", "/content/nowhere");
+    final Resource componentResource = context.create().resource(
+        "/content/sessions/child-3/jcr:content/no-root-component", props);
+    context.request().setResource(componentResource);
+
+    assertTrue(context.request().adaptTo(CardListTagSearchDataSource.class)
+        .getTaggedPages().isEmpty());
+  }
+
+  @Test
+  public void testGetCardElementsWhenNothingMatches() {
+    final Map<String, Object> props = new HashMap<>();
+    props.put("tags", new String[]{"/etc/tags/topic/nothing-has-this"});
+    final Resource componentResource = context.create().resource(
+        "/content/sessions/child-3/jcr:content/no-match-component", props);
+    context.request().setResource(componentResource);
+
+    assertTrue(context.request().adaptTo(CardListTagSearchDataSource.class)
+        .getCardElements().isEmpty());
+  }
+
+  @Test
+  public void testGetReadMoreTextWhenNotConfigured() {
+    final Map<String, Object> props = new HashMap<>();
+    props.put("tags", new String[]{"/etc/tags/topic/java"});
+    final Resource componentResource = context.create().resource(
+        "/content/sessions/child-3/jcr:content/no-read-more-component", props);
+    context.request().setResource(componentResource);
+
+    assertNull(context.request().adaptTo(CardListTagSearchDataSource.class).getReadMoreText());
+  }
+
+  /**
+   * The date comparators guard on both the jcr:content child and the date property. The fixture
+   * pages all have a jcr:content and neither date, so only one side of each guard was reached.
+   */
+  private void addTaggedPagesWithAndWithoutDates() {
+    final Map<String, Object> pageProperties = new HashMap<>();
+    pageProperties.put("jcr:primaryType", "kes:Page");
+    context.create().resource("/content/sessions/child-4", pageProperties);
+
+    final Map<String, Object> datedContent = new HashMap<>();
+    datedContent.put("jcr:primaryType", "nt:unstructured");
+    datedContent.put("jcr:created", Calendar.getInstance());
+    datedContent.put("jcr:lastModified", Calendar.getInstance());
+    context.create().resource("/content/sessions/child-5", pageProperties);
+    context.create().resource("/content/sessions/child-5/jcr:content", datedContent);
+  }
+
+  @Test
+  public void testSortByCreatedDateAcrossPagesWithAndWithoutDates() {
+    addTaggedPagesWithAndWithoutDates();
+    final Map<String, Object> props = new HashMap<>();
+    props.put("sortBy", "createdDate");
+
+    assertEquals(2, twoMatchesWith(props).getCardElements().size());
+  }
+
+  @Test
+  public void testSortByLastModifiedAcrossPagesWithAndWithoutDates() {
+    addTaggedPagesWithAndWithoutDates();
+    final Map<String, Object> props = new HashMap<>();
+    props.put("sortBy", "lastModified");
+
+    assertEquals(2, twoMatchesWith(props).getCardElements().size());
   }
 }

--- a/kestros-basic-components/src/test/java/io/kestros/cms/components/basic/core/lists/linklist/LinkListChildPageDataSourceTest.java
+++ b/kestros-basic-components/src/test/java/io/kestros/cms/components/basic/core/lists/linklist/LinkListChildPageDataSourceTest.java
@@ -7,6 +7,7 @@ import io.kestros.cms.assets.api.exceptions.AssetCollectionRetrievalException;
 import io.kestros.cms.components.basic.api.content.KestrosLink;
 import io.kestros.cms.components.basic.api.lists.KestrosLinkList;
 import io.kestros.cms.components.basic.core.BaseDataSourceTest;
+import java.util.Calendar;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -188,5 +189,57 @@ public class LinkListChildPageDataSourceTest extends BaseDataSourceTest {
     context.request().setResource(resource);
     linkListChildPageDataSource = context.request().adaptTo(LinkListChildPageDataSource.class);
     assertEquals(0, linkListChildPageDataSource.getLinkElements().size());
+  }
+
+  /**
+   * The date comparators read jcr:created / jcr:lastModified off each page's jcr:content, guarding
+   * on both the child and the property. The sample pages all have a jcr:content and neither date,
+   * so only one side of each guard was reached.
+   */
+  private void addPagesWithAndWithoutDates() {
+    final Map<String, Object> pageProperties = new HashMap<>();
+    pageProperties.put("jcr:primaryType", "kes:Page");
+    context.create().resource("/content/page/child-no-content", pageProperties);
+
+    final Map<String, Object> datedContent = new HashMap<>();
+    datedContent.put("jcr:primaryType", "nt:unstructured");
+    datedContent.put("jcr:created", Calendar.getInstance());
+    datedContent.put("jcr:lastModified", Calendar.getInstance());
+    context.create().resource("/content/page/child-dated", pageProperties);
+    context.create().resource("/content/page/child-dated/jcr:content", datedContent);
+  }
+
+  private LinkListChildPageDataSource adaptWithSort(final String sortBy, final String name) {
+    final Map<String, Object> props = new HashMap<>();
+    props.put("pagesPath", "/content/page");
+    props.put("sortBy", sortBy);
+    final Resource componentResource =
+        context.create().resource("/content/page/jcr:content/" + name, props);
+    context.request().setResource(componentResource);
+    return context.request().adaptTo(LinkListChildPageDataSource.class);
+  }
+
+  @Test
+  public void testGetLinkElementsSortByCreatedDateAcrossPagesWithAndWithoutDates() {
+    addPagesWithAndWithoutDates();
+
+    assertEquals(5, adaptWithSort("createdDate", "comp-created-mixed").getLinkElements().size());
+  }
+
+  @Test
+  public void testGetLinkElementsSortByLastModifiedAcrossPagesWithAndWithoutDates() {
+    addPagesWithAndWithoutDates();
+
+    assertEquals(5, adaptWithSort("lastModified", "comp-modified-mixed").getLinkElements().size());
+  }
+
+  @Test
+  public void testGetLinkElementsSortByName() {
+    assertEquals(3, adaptWithSort("name", "comp-name").getLinkElements().size());
+  }
+
+  @Test
+  public void testGetLinkElementsSortByTitle() {
+    assertEquals(3, adaptWithSort("title", "comp-title").getLinkElements().size());
   }
 }

--- a/kestros-basic-components/src/test/java/io/kestros/cms/components/basic/core/lists/linklist/LinkListTagSearchDataSourceTest.java
+++ b/kestros-basic-components/src/test/java/io/kestros/cms/components/basic/core/lists/linklist/LinkListTagSearchDataSourceTest.java
@@ -1,6 +1,7 @@
 package io.kestros.cms.components.basic.core.lists.linklist;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.mockito.ArgumentMatchers.any;
@@ -15,6 +16,7 @@ import io.kestros.cms.tagging.api.models.KestrosTag;
 import io.kestros.cms.tagging.api.services.TagRetrievalService;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Calendar;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -251,5 +253,151 @@ public class LinkListTagSearchDataSourceTest extends BaseDataSourceTest {
     LinkListTagSearchDataSource limitDs =
         context.request().adaptTo(LinkListTagSearchDataSource.class);
     assertEquals(1, limitDs.getLinkElements().size());
+  }
+
+  // ---------------------------------------------------------------------------------------------
+  // The sort comparators only run with at least two matching pages. Placing the component on
+  // child-3 (which carries no tags of its own) leaves both child-1 and child-2 in the result.
+  // ---------------------------------------------------------------------------------------------
+
+  private LinkListTagSearchDataSource twoMatchesWith(final Map<String, Object> extraProperties) {
+    final Map<String, Object> props = new HashMap<>(extraProperties);
+    props.put("tags", new String[]{"/etc/tags/topic/java"});
+    final Resource componentResource = context.create().resource(
+        "/content/sessions/child-3/jcr:content/component-" + extraProperties.hashCode(), props);
+    context.request().setResource(componentResource);
+    return context.request().adaptTo(LinkListTagSearchDataSource.class);
+  }
+
+  @Test
+  public void testGetLinkElementsSortsTwoPagesByName() {
+    final Map<String, Object> props = new HashMap<>();
+    props.put("sortBy", "name");
+
+    assertEquals(2, twoMatchesWith(props).getLinkElements().size());
+  }
+
+  @Test
+  public void testGetLinkElementsSortsTwoPagesByTitle() {
+    final Map<String, Object> props = new HashMap<>();
+    props.put("sortBy", "title");
+
+    assertEquals(2, twoMatchesWith(props).getLinkElements().size());
+  }
+
+  @Test
+  public void testGetLinkElementsSortsTwoPagesByCreatedDate() {
+    final Map<String, Object> props = new HashMap<>();
+    props.put("sortBy", "createdDate");
+
+    assertEquals(2, twoMatchesWith(props).getLinkElements().size());
+  }
+
+  @Test
+  public void testGetLinkElementsSortsTwoPagesByLastModified() {
+    final Map<String, Object> props = new HashMap<>();
+    props.put("sortBy", "lastModified");
+
+    assertEquals(2, twoMatchesWith(props).getLinkElements().size());
+  }
+
+  @Test
+  public void testGetLinkElementsReversesTwoPages() {
+    final Map<String, Object> props = new HashMap<>();
+    props.put("sortBy", "name");
+    props.put("reverse", true);
+
+    assertEquals(2, twoMatchesWith(props).getLinkElements().size());
+  }
+
+  @Test
+  public void testGetLinkElementsLimitsTwoPagesToOne() {
+    final Map<String, Object> props = new HashMap<>();
+    props.put("limit", "1");
+
+    assertEquals(1, twoMatchesWith(props).getLinkElements().size());
+  }
+
+  @Test
+  public void testGetRootPageWhenThePathDoesNotResolve() {
+    final Map<String, Object> props = new HashMap<>();
+    props.put("tags", new String[]{"/etc/tags/topic/java"});
+    props.put("pagesPath", "/content/nowhere");
+    final Resource componentResource = context.create().resource(
+        "/content/sessions/child-3/jcr:content/missing-root-component", props);
+    context.request().setResource(componentResource);
+
+    assertNull(context.request().adaptTo(LinkListTagSearchDataSource.class).getRootPage());
+  }
+
+  @Test
+  public void testGetTaggedPagesWhenNoTagsAreConfigured() {
+    final Map<String, Object> props = new HashMap<>();
+    final Resource componentResource = context.create().resource(
+        "/content/sessions/child-3/jcr:content/no-tags-component", props);
+    context.request().setResource(componentResource);
+
+    assertTrue(context.request().adaptTo(LinkListTagSearchDataSource.class)
+        .getTaggedPages().isEmpty());
+  }
+
+  @Test
+  public void testGetTaggedPagesWhenTheRootPageDoesNotResolve() {
+    final Map<String, Object> props = new HashMap<>();
+    props.put("tags", new String[]{"/etc/tags/topic/java"});
+    props.put("pagesPath", "/content/nowhere");
+    final Resource componentResource = context.create().resource(
+        "/content/sessions/child-3/jcr:content/no-root-component", props);
+    context.request().setResource(componentResource);
+
+    assertTrue(context.request().adaptTo(LinkListTagSearchDataSource.class)
+        .getTaggedPages().isEmpty());
+  }
+
+  @Test
+  public void testGetLinkElementsWhenNothingMatches() {
+    final Map<String, Object> props = new HashMap<>();
+    props.put("tags", new String[]{"/etc/tags/topic/nothing-has-this"});
+    final Resource componentResource = context.create().resource(
+        "/content/sessions/child-3/jcr:content/no-match-component", props);
+    context.request().setResource(componentResource);
+
+    assertTrue(context.request().adaptTo(LinkListTagSearchDataSource.class)
+        .getLinkElements().isEmpty());
+  }
+
+  /**
+   * The date comparators guard on both the jcr:content child and the date property. The fixture
+   * pages all have a jcr:content and neither date, so only one side of each guard was reached.
+   */
+  private void addTaggedPagesWithAndWithoutDates() {
+    final Map<String, Object> pageProperties = new HashMap<>();
+    pageProperties.put("jcr:primaryType", "kes:Page");
+    context.create().resource("/content/sessions/child-4", pageProperties);
+
+    final Map<String, Object> datedContent = new HashMap<>();
+    datedContent.put("jcr:primaryType", "nt:unstructured");
+    datedContent.put("jcr:created", Calendar.getInstance());
+    datedContent.put("jcr:lastModified", Calendar.getInstance());
+    context.create().resource("/content/sessions/child-5", pageProperties);
+    context.create().resource("/content/sessions/child-5/jcr:content", datedContent);
+  }
+
+  @Test
+  public void testSortByCreatedDateAcrossPagesWithAndWithoutDates() {
+    addTaggedPagesWithAndWithoutDates();
+    final Map<String, Object> props = new HashMap<>();
+    props.put("sortBy", "createdDate");
+
+    assertEquals(2, twoMatchesWith(props).getLinkElements().size());
+  }
+
+  @Test
+  public void testSortByLastModifiedAcrossPagesWithAndWithoutDates() {
+    addTaggedPagesWithAndWithoutDates();
+    final Map<String, Object> props = new HashMap<>();
+    props.put("sortBy", "lastModified");
+
+    assertEquals(2, twoMatchesWith(props).getLinkElements().size());
   }
 }


### PR DESCRIPTION
Phase 1 of 4 for `kestros-basic-components` — the last module published to Maven Central that is not strict-green. Merge in order: 1 → 2 → 3 → 4.

The module sat at 0.739 line / 0.646 branch against the required 0.80. RAT already passes, so there is no phase 5 here.

**Four classes had no test class at all:** `ImageAssetDataSource`, `VideoAssetDataSource`, `TableStaticDataSource`, and `AnchorTarget` (an enum with four lookup overloads).

**The rest of the gap was one pattern repeated, not scattered misses.** Every list data source sorts through four comparators. The existing tests only exercised the two that `name` and `title` share, so the `createdDate` and `lastModified` lambdas had *zero* coverage in four separate classes. Those comparators also guard on both a page's `jcr:content` child and the date property itself, and every fixture page had a `jcr:content` and neither date — so only one side of each guard was ever taken. The added cases include a page with no `jcr:content` and a page carrying both dates.

Also covers the container helpers on `BaseContainerSlingModelDataSource`, the YouTube embed path and its id extraction, and the guard branches on the card, image and table data sources.

Now 0.819 line / 0.802 branch. No main-source changes in this PR.

**One note on `VideoEmbedYouTubeDataSourceTest`:** it did not extend the shared `BaseDataSourceTest` harness, so the model could not be adapted from a request and only `isValidVideoInput` was reachable. Converting it to the harness is what made `getVideoEmbedCode` testable at all.