### PR TITLE
Strict build 2/4: SpotBugs in basic-components — 427 to 46, and 3 decisions for you

### DIFF
--- a/kestros-basic-components-testing/src/main/java/io/kestros/cms/components/basic/testing/BaseDataSourceTest.java
+++ b/kestros-basic-components-testing/src/main/java/io/kestros/cms/components/basic/testing/BaseDataSourceTest.java
@@ -18,6 +18,7 @@
 
 package io.kestros.cms.components.basic.testing;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -41,6 +42,10 @@ import org.junit.Rule;
  * {@code context.addModelsForClasses(YourDataSource.class)} and create the resource the datasource
  * adapts from.</p>
  */
+@SuppressFBWarnings(value = "PRMC_POSSIBLY_REDUNDANT_METHOD_CALLS",
+    justification = "The repeated call the detector sees is Mockito's any() matcher, which has"
+        + " to be invoked once per stubbing. Both lookups deliberately resolve to the same"
+        + " theme.")
 public abstract class BaseDataSourceTest {
 
   @Rule
@@ -63,7 +68,9 @@ public abstract class BaseDataSourceTest {
     // Elements resolve the containing page's theme and UI Framework as they are constructed.
     Theme theme = mock(Theme.class);
     when(theme.getUiFramework()).thenReturn(mock(UiFramework.class));
-    ThemeProviderService themeProviderService = mock(ThemeProviderService.class);
+    final ThemeProviderService themeProviderService = mock(ThemeProviderService.class);
+    // Both lookups resolve to the same theme; stubbed from one mock rather than two calls that
+    // read as if they could differ.
     when(themeProviderService.getThemeForPage(any())).thenReturn(theme);
     when(themeProviderService.getThemeForComponent(any())).thenReturn(theme);
     context.registerService(ThemeProviderService.class, themeProviderService);

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/api/KestrosBasicComponentElement.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/api/KestrosBasicComponentElement.java
@@ -96,7 +96,7 @@ public interface KestrosBasicComponentElement {
   String getId();
 
   @JsonIgnore
-  @Nullable
+  @Nonnull
   UiFramework getUiFramework() throws InvalidThemeException, ResourceNotFoundException,
       InvalidUiFrameworkException, ThemeRetrievalException, UiFrameworkRetrievalException,
       ModelAdaptionException;

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/api/KestrosBasicComponentElement.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/api/KestrosBasicComponentElement.java
@@ -137,7 +137,7 @@ public interface KestrosBasicComponentElement {
 
   @Nonnull
   default Boolean isSynthetic() {
-    return true;
+    return Boolean.TRUE;
   }
 
   default boolean isDataSourceComponent() {

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/api/KestrosBasicComponentElement.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/api/KestrosBasicComponentElement.java
@@ -112,6 +112,7 @@ public interface KestrosBasicComponentElement {
 
   List<ComponentVariation> getVariations();
 
+  @Nonnull
   default String getInlineVariations() {
     StringJoiner joiner = new StringJoiner(" ");
     for (ComponentVariation variation : getVariations()) {
@@ -134,6 +135,7 @@ public interface KestrosBasicComponentElement {
     return getResource().getPath();
   }
 
+  @Nonnull
   default Boolean isSynthetic() {
     return true;
   }
@@ -144,6 +146,7 @@ public interface KestrosBasicComponentElement {
   }
 
   @JsonIgnore
+  @Nonnull
   default Map<String, String> getRequestAttributes() {
     Map<String, String> attributes = new HashMap<>();
     attributes.put("resourceType", getComponentResourceType());

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/api/KestrosBasicComponentElement.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/api/KestrosBasicComponentElement.java
@@ -24,9 +24,12 @@ import org.apache.sling.api.resource.ResourceResolver;
 public interface KestrosBasicComponentElement {
 
 
-  String getLayout(String propertyName);
+  @Nullable
+  String getLayout(@Nonnull String propertyName);
 
-  List<ComponentVariation> getElementVariations(String propertyName, String componentType);
+  @Nonnull
+  List<ComponentVariation> getElementVariations(@Nonnull String propertyName,
+      @Nonnull String componentType);
 
 //  @Deprecated
 //  static List<ComponentVariation> getAppliedVariations(String propertyName,
@@ -93,11 +96,13 @@ public interface KestrosBasicComponentElement {
   String getId();
 
   @JsonIgnore
+  @Nullable
   UiFramework getUiFramework() throws InvalidThemeException, ResourceNotFoundException,
       InvalidUiFrameworkException, ThemeRetrievalException, UiFrameworkRetrievalException,
       ModelAdaptionException;
 
   @JsonIgnore
+  @Nonnull
   Resource getResource();
 
   @JsonIgnore
@@ -105,11 +110,14 @@ public interface KestrosBasicComponentElement {
   SlingHttpServletRequest getRequest();
 
   @JsonIgnore
+  @Nonnull
   ResourceResolver getResourceResolver();
 
   @JsonIgnore
+  @Nullable
   String getParentPath();
 
+  @Nonnull
   List<ComponentVariation> getVariations();
 
   @Nonnull
@@ -154,6 +162,7 @@ public interface KestrosBasicComponentElement {
   }
 
   @JsonIgnore
+  @Nonnull
   Resource toSyntheticResource(@Nonnull final ResourceResolver resourceResolver,
       @Nonnull final String parentPath);
 

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/api/content/AnchorTarget.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/api/content/AnchorTarget.java
@@ -30,6 +30,7 @@ public enum AnchorTarget {
    *
    * @return The corresponding AnchorTarget enum, or SAME_WINDOW if not found.
    */
+  @Nonnull
   public static AnchorTarget lookup(@Nullable String targetValue) {
     if (targetValue != null) {
       for (AnchorTarget anchorTarget : values()) {
@@ -49,6 +50,7 @@ public enum AnchorTarget {
    *
    * @return The corresponding AnchorTarget enum.
    */
+  @Nonnull
   public static AnchorTarget lookup(@Nullable Boolean openInNewWindow) {
     if (openInNewWindow != null && openInNewWindow) {
       return NEW_WINDOW;
@@ -56,6 +58,7 @@ public enum AnchorTarget {
     return SAME_WINDOW;
   }
 
+  @Nonnull
   public static AnchorTarget lookup(@Nullable Resource resource) {
     AnchorTarget target = SAME_WINDOW;
     if (resource != null) {

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/api/content/AnchorTarget.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/api/content/AnchorTarget.java
@@ -1,6 +1,5 @@
 package io.kestros.cms.components.basic.api.content;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.apache.sling.api.resource.Resource;
@@ -31,19 +30,12 @@ public enum AnchorTarget {
    *
    * @return The corresponding AnchorTarget enum, or SAME_WINDOW if not found.
    */
-  @SuppressFBWarnings(value = "IMPROPER_UNICODE",
-      justification = "The values compared are this enum's own fixed ASCII target values"
-          + " (_self, _blank, _parent, _top), so the Unicode case-folding hazard the detector"
-          + " warns about cannot arise. An earlier version of this branch dodged the finding by"
-          + " rewriting it as regionMatches(true, ...) + a length check - MEASURED as identical"
-          + " case-insensitive semantics with the finding simply not raised, which silenced the"
-          + " detector without fixing anything and made the code unreadable. Suppressed honestly"
-          + " instead.")
   @Nonnull
   public static AnchorTarget lookup(@Nullable String targetValue) {
     if (targetValue != null) {
+      String foldedTargetValue = toAsciiLowerCase(targetValue);
       for (AnchorTarget anchorTarget : values()) {
-        if (anchorTarget.getTargetValue().equalsIgnoreCase(targetValue)) {
+        if (anchorTarget.getTargetValue().equals(foldedTargetValue)) {
           return anchorTarget;
         }
       }
@@ -78,6 +70,35 @@ public enum AnchorTarget {
       }
     }
     return target;
+  }
+
+  /**
+   * Lowercases the ASCII letters A-Z and leaves every other character untouched.
+   *
+   * <p>This exists instead of {@code equalsIgnoreCase} or {@code toLowerCase(Locale)} because both
+   * of those apply full Unicode case folding, under which characters that are not ASCII compare
+   * equal to ASCII ones - {@code U+212A KELVIN SIGN} folds to {@code k}, so {@code "_blanK"}
+   * would have matched {@code _blank}. Every target value this enum declares is ASCII, so folding
+   * beyond ASCII can only ever create a false match. Restricting the fold removes that, which is
+   * also what SpotBugs' IMPROPER_UNICODE is pointing at.</p>
+   *
+   * @param value The value to fold.
+   *
+   * @return The value with ASCII A-Z lowercased.
+   */
+  @Nonnull
+  private static String toAsciiLowerCase(@Nonnull String value) {
+    int length = value.length();
+    StringBuilder folded = new StringBuilder(length);
+    for (int i = 0; i < length; i++) {
+      char character = value.charAt(i);
+      if (character >= 'A' && character <= 'Z') {
+        folded.append((char) (character - 'A' + 'a'));
+      } else {
+        folded.append(character);
+      }
+    }
+    return folded.toString();
   }
 
   /**

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/api/content/AnchorTarget.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/api/content/AnchorTarget.java
@@ -66,7 +66,7 @@ public enum AnchorTarget {
     if (resource != null) {
       String anchorTargetString = resource.getValueMap().get("target", String.class);
       target = AnchorTarget.lookup(anchorTargetString);
-      if (target.equals(AnchorTarget.SAME_WINDOW)) {
+      if (target == AnchorTarget.SAME_WINDOW) {
         target = AnchorTarget.lookup(resource.getValueMap().get("openInNewTab", Boolean.FALSE));
       }
     }

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/api/content/AnchorTarget.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/api/content/AnchorTarget.java
@@ -65,7 +65,7 @@ public enum AnchorTarget {
       String anchorTargetString = resource.getValueMap().get("target", String.class);
       target = AnchorTarget.lookup(anchorTargetString);
       if (target.equals(AnchorTarget.SAME_WINDOW)) {
-        target = AnchorTarget.lookup(resource.getValueMap().get("openInNewTab", false));
+        target = AnchorTarget.lookup(resource.getValueMap().get("openInNewTab", Boolean.FALSE));
       }
     }
     return target;

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/api/content/AnchorTarget.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/api/content/AnchorTarget.java
@@ -34,7 +34,9 @@ public enum AnchorTarget {
   public static AnchorTarget lookup(@Nullable String targetValue) {
     if (targetValue != null) {
       for (AnchorTarget anchorTarget : values()) {
-        if (anchorTarget.getTargetValue().equalsIgnoreCase(targetValue)) {
+        if (anchorTarget.getTargetValue().regionMatches(true, 0, targetValue, 0,
+            anchorTarget.getTargetValue().length())
+            && anchorTarget.getTargetValue().length() == targetValue.length()) {
           return anchorTarget;
         }
       }

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/api/content/AnchorTarget.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/api/content/AnchorTarget.java
@@ -1,5 +1,6 @@
 package io.kestros.cms.components.basic.api.content;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.apache.sling.api.resource.Resource;
@@ -30,13 +31,19 @@ public enum AnchorTarget {
    *
    * @return The corresponding AnchorTarget enum, or SAME_WINDOW if not found.
    */
+  @SuppressFBWarnings(value = "IMPROPER_UNICODE",
+      justification = "The values compared are this enum's own fixed ASCII target values"
+          + " (_self, _blank, _parent, _top), so the Unicode case-folding hazard the detector"
+          + " warns about cannot arise. An earlier version of this branch dodged the finding by"
+          + " rewriting it as regionMatches(true, ...) + a length check - MEASURED as identical"
+          + " case-insensitive semantics with the finding simply not raised, which silenced the"
+          + " detector without fixing anything and made the code unreadable. Suppressed honestly"
+          + " instead.")
   @Nonnull
   public static AnchorTarget lookup(@Nullable String targetValue) {
     if (targetValue != null) {
       for (AnchorTarget anchorTarget : values()) {
-        if (anchorTarget.getTargetValue().regionMatches(true, 0, targetValue, 0,
-            anchorTarget.getTargetValue().length())
-            && anchorTarget.getTargetValue().length() == targetValue.length()) {
+        if (anchorTarget.getTargetValue().equalsIgnoreCase(targetValue)) {
           return anchorTarget;
         }
       }

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/api/content/HeadingLevels.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/api/content/HeadingLevels.java
@@ -29,10 +29,12 @@ public enum HeadingLevels {
     return null;
   }
 
+  @Nonnull
   public String getDisplayText() {
     return displayText;
   }
 
+  @Nonnull
   public String getValue() {
     return value;
   }

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/api/content/KestrosButton.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/api/content/KestrosButton.java
@@ -1,5 +1,6 @@
 package io.kestros.cms.components.basic.api.content;
 
+import javax.annotation.Nonnull;
 /**
  * Core button element API.
  */
@@ -7,6 +8,7 @@ public interface KestrosButton extends KestrosLink {
 
   String RESOURCE_TYPE = "/libs/kestros/commons/components/content/button";
 
+  @Nonnull
   default String getComponentResourceType() {
     return RESOURCE_TYPE;
   }

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/api/content/KestrosButtonGroup.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/api/content/KestrosButtonGroup.java
@@ -20,8 +20,9 @@ public interface KestrosButtonGroup extends KestrosContainerElement {
 
   @Nonnull
   default List<Resource> getButtons() {
-    List<Resource> buttons = new ArrayList<>();
-    for (KestrosButton button : getButtonsElements()) {
+    final List<KestrosButton> sourceButtons = getButtonsElements();
+    final List<Resource> buttons = new ArrayList<>(sourceButtons.size());
+    for (KestrosButton button : sourceButtons) {
       buttons.add(button.getResource());
     }
     return buttons;

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/api/content/KestrosCard.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/api/content/KestrosCard.java
@@ -17,6 +17,7 @@ public interface KestrosCard extends KestrosContainerElement {
   String RESOURCE_TYPE = "/libs/kestros/commons/components/content/card";
 
   @Override
+  @Nonnull
   default String getComponentResourceType() {
     return RESOURCE_TYPE;
   }

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/api/content/KestrosHeading.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/api/content/KestrosHeading.java
@@ -9,6 +9,7 @@ public interface KestrosHeading extends KestrosBasicComponentElement {
   String RESOURCE_TYPE = "/libs/kestros/commons/components/content/heading";
 
   @Override
+  @Nonnull
   default String getComponentResourceType() {
     return RESOURCE_TYPE;
   }

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/api/content/KestrosImage.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/api/content/KestrosImage.java
@@ -9,6 +9,7 @@ public interface KestrosImage extends KestrosBasicComponentElement {
   String RESOURCE_TYPE = "/libs/kestros/commons/components/content/image";
 
   @Override
+  @Nonnull
   default String getComponentResourceType() {
     return RESOURCE_TYPE;
   }

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/api/content/KestrosLink.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/api/content/KestrosLink.java
@@ -11,6 +11,7 @@ public interface KestrosLink extends KestrosBasicComponentElement {
 
   String RESOURCE_TYPE = "/libs/kestros/commons/components/content/link";
 
+  @Nonnull
   default String getComponentResourceType() {
     return RESOURCE_TYPE;
   }

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/api/content/KestrosRichText.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/api/content/KestrosRichText.java
@@ -1,5 +1,6 @@
 package io.kestros.cms.components.basic.api.content;
 
+import javax.annotation.Nonnull;
 import io.kestros.cms.components.basic.api.KestrosBasicComponentElement;
 import javax.annotation.Nullable;
 
@@ -8,6 +9,7 @@ public interface KestrosRichText extends KestrosBasicComponentElement {
   String RESOURCE_TYPE = "/libs/kestros/commons/components/content/richtext";
 
   @Override
+  @Nonnull
   default String getComponentResourceType() {
     return RESOURCE_TYPE;
   }

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/api/content/KestrosVideo.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/api/content/KestrosVideo.java
@@ -9,6 +9,7 @@ public interface KestrosVideo extends KestrosBasicComponentElement {
   String RESOURCE_TYPE = "/libs/kestros/commons/components/content/video";
 
   @Override
+  @Nonnull
   default String getComponentResourceType() {
     return RESOURCE_TYPE;
   }

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/api/content/KestrosVideoEmbed.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/api/content/KestrosVideoEmbed.java
@@ -1,5 +1,6 @@
 package io.kestros.cms.components.basic.api.content;
 
+import javax.annotation.Nonnull;
 import io.kestros.cms.components.basic.api.KestrosBasicComponentElement;
 import javax.annotation.Nullable;
 
@@ -8,6 +9,7 @@ public interface KestrosVideoEmbed extends KestrosBasicComponentElement {
   String RESOURCE_TYPE = "/libs/kestros/commons/components/content/video-embed";
 
   @Override
+  @Nonnull
   default String getComponentResourceType() {
     return RESOURCE_TYPE;
   }

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/api/content/TextElementType.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/api/content/TextElementType.java
@@ -1,5 +1,6 @@
 package io.kestros.cms.components.basic.api.content;
 
+import javax.annotation.Nonnull;
 public enum TextElementType {
   PARAGRAPH("Paragraph", "paragraph"),
   PREFORMATTED("Preformatted", "preformatted"),
@@ -13,10 +14,12 @@ public enum TextElementType {
     this.value = value;
   }
 
+  @Nonnull
   public String getDisplayText() {
     return displayText;
   }
 
+  @Nonnull
   public String getValue() {
     return value;
   }

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/api/exceptions/ComponentConfigurationException.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/api/exceptions/ComponentConfigurationException.java
@@ -7,11 +7,11 @@ public class ComponentConfigurationException extends Exception {
     super(message);
   }
 
-  public ComponentConfigurationException(String message, @Nonnull Throwable cause) {
+  public ComponentConfigurationException(@Nonnull String message, @Nonnull Throwable cause) {
     super(message, cause);
   }
 
-  public ComponentConfigurationException(Throwable cause) {
+  public ComponentConfigurationException(@Nonnull Throwable cause) {
     super(cause);
   }
 }

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/api/exceptions/ComponentConfigurationException.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/api/exceptions/ComponentConfigurationException.java
@@ -3,7 +3,7 @@ package io.kestros.cms.components.basic.api.exceptions;
 import javax.annotation.Nonnull;
 public class ComponentConfigurationException extends Exception {
 
-  public ComponentConfigurationException(String message) {
+  public ComponentConfigurationException(@Nonnull String message) {
     super(message);
   }
 

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/api/exceptions/ComponentConfigurationException.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/api/exceptions/ComponentConfigurationException.java
@@ -1,12 +1,13 @@
 package io.kestros.cms.components.basic.api.exceptions;
 
+import javax.annotation.Nonnull;
 public class ComponentConfigurationException extends Exception {
 
   public ComponentConfigurationException(String message) {
     super(message);
   }
 
-  public ComponentConfigurationException(String message, Throwable cause) {
+  public ComponentConfigurationException(String message, @Nonnull Throwable cause) {
     super(message, cause);
   }
 

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/api/exceptions/ComponentElementRenderingException.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/api/exceptions/ComponentElementRenderingException.java
@@ -1,0 +1,30 @@
+
+package io.kestros.cms.components.basic.api.exceptions;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import javax.annotation.Nonnull;
+
+/**
+ * Thrown when a basic component cannot build one of its child elements for rendering.
+ *
+ * <p>Unchecked, because these getters are called from HTL, which cannot handle a checked
+ * exception. Typed rather than a bare {@code RuntimeException} so a rendering failure can be told
+ * apart from any other runtime failure, and so the message names the component and the element
+ * that failed rather than surfacing a bare cause.</p>
+ */
+@SuppressFBWarnings("IMC_IMMATURE_CLASS_NO_EQUALS")
+public class ComponentElementRenderingException extends RuntimeException {
+
+  private static final long serialVersionUID = 1L;
+
+  /**
+   * Thrown when a basic component cannot build one of its child elements for rendering.
+   *
+   * @param message Which element could not be built, and for which component.
+   * @param cause Underlying failure.
+   */
+  public ComponentElementRenderingException(@Nonnull final String message,
+      @Nonnull final Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/api/exceptions/ComponentElementRenderingException.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/api/exceptions/ComponentElementRenderingException.java
@@ -27,4 +27,13 @@ public class ComponentElementRenderingException extends RuntimeException {
       @Nonnull final Throwable cause) {
     super(message, cause);
   }
+
+  /**
+   * Thrown when a basic component cannot build one of its child elements for rendering.
+   *
+   * @param message Which element could not be built, and for which component.
+   */
+  public ComponentElementRenderingException(@Nonnull final String message) {
+    super(message);
+  }
 }

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/api/lists/KestrosCardList.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/api/lists/KestrosCardList.java
@@ -20,8 +20,9 @@ public interface KestrosCardList extends KestrosContainerElement {
 
   @Nonnull
   default List<Resource> getCards() {
-    List<Resource> cards = new ArrayList<>();
-    for (KestrosCard card : getCardElements()) {
+    final List<KestrosCard> sourceCards = getCardElements();
+    final List<Resource> cards = new ArrayList<>(sourceCards.size());
+    for (KestrosCard card : sourceCards) {
       cards.add(card.getResource());
     }
     return cards;

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/api/lists/KestrosCardList.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/api/lists/KestrosCardList.java
@@ -13,6 +13,7 @@ public interface KestrosCardList extends KestrosContainerElement {
   String RESOURCE_TYPE = "/libs/kestros/commons/components/lists/card-list";
 
   @Override
+  @Nonnull
   default String getComponentResourceType() {
     return RESOURCE_TYPE;
   }
@@ -29,6 +30,7 @@ public interface KestrosCardList extends KestrosContainerElement {
   @Nonnull
   List<KestrosCard> getCardElements();
 
+  @Nonnull
   default List<KestrosBasicComponentElement> getChildElements() {
     return new ArrayList<>(getCardElements());
   }

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/api/lists/KestrosLinkList.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/api/lists/KestrosLinkList.java
@@ -19,8 +19,9 @@ public interface KestrosLinkList extends KestrosContainerElement {
 
   @Nonnull
   default List<Resource> getLinks() {
-    List<Resource> links = new ArrayList<>();
-    for (KestrosLink link : getLinkElements()) {
+    final List<KestrosLink> sourceLinks = getLinkElements();
+    final List<Resource> links = new ArrayList<>(sourceLinks.size());
+    for (KestrosLink link : sourceLinks) {
       links.add(link.getResource());
     }
     return links;

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/api/navigation/KestrosBreadCrumb.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/api/navigation/KestrosBreadCrumb.java
@@ -13,6 +13,7 @@ public interface KestrosBreadCrumb extends KestrosLink {
     return RESOURCE_TYPE;
   }
 
+  @Nonnull
   Boolean isFirstItem();
   Boolean isLastItem();
 }

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/api/navigation/KestrosBreadCrumb.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/api/navigation/KestrosBreadCrumb.java
@@ -15,5 +15,6 @@ public interface KestrosBreadCrumb extends KestrosLink {
 
   @Nonnull
   Boolean isFirstItem();
+  @Nonnull
   Boolean isLastItem();
 }

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/api/navigation/KestrosBreadCrumbs.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/api/navigation/KestrosBreadCrumbs.java
@@ -19,8 +19,9 @@ public interface KestrosBreadCrumbs extends KestrosContainerElement {
 
   @Nonnull
   default List<Resource> getLinks() {
-    List<Resource> links = new ArrayList<>();
-    for (KestrosBreadCrumb link : getLinkElements()) {
+    final List<KestrosBreadCrumb> sourceLinks = getLinkElements();
+    final List<Resource> links = new ArrayList<>(sourceLinks.size());
+    for (KestrosBreadCrumb link : sourceLinks) {
       links.add(link.getResource());
     }
     return links;

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/api/navigation/KestrosNavigation.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/api/navigation/KestrosNavigation.java
@@ -19,8 +19,9 @@ public interface KestrosNavigation extends KestrosContainerElement {
 
   @Nonnull
   default List<Resource> getNavigationLinks() {
-    List<Resource> resources = new ArrayList<>();
-    for (KestrosNavigationItem item : getNavigationLinkElements()) {
+    final List<KestrosNavigationItem> sourceResources = getNavigationLinkElements();
+    final List<Resource> resources = new ArrayList<>(sourceResources.size());
+    for (KestrosNavigationItem item : sourceResources) {
       resources.add(item.getResource());
     }
     return resources;

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/api/navigation/KestrosNavigationItem.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/api/navigation/KestrosNavigationItem.java
@@ -24,8 +24,9 @@ public interface KestrosNavigationItem extends KestrosLink, KestrosContainerElem
 
   @Nonnull
   default List<Resource> getNavigationItemLinks() {
-    List<Resource> resources = new ArrayList<>();
-    for (KestrosNavigationItem item : getNavigationItems()) {
+    final List<KestrosNavigationItem> sourceResources = getNavigationItems();
+    final List<Resource> resources = new ArrayList<>(sourceResources.size());
+    for (KestrosNavigationItem item : sourceResources) {
       resources.add(item.getResource());
     }
     return resources;

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/api/navigation/KestrosNavigationItem.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/api/navigation/KestrosNavigationItem.java
@@ -17,6 +17,7 @@ public interface KestrosNavigationItem extends KestrosLink, KestrosContainerElem
     return RESOURCE_TYPE;
   }
 
+  @Nonnull
   Boolean isActive();
 
   @Nonnull

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/api/navigation/KestrosTopNavigation.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/api/navigation/KestrosTopNavigation.java
@@ -21,8 +21,9 @@ public interface KestrosTopNavigation extends KestrosContainerElement {
 
   @Nonnull
   default List<Resource> getNavigationLinks() {
-    List<Resource> resources = new ArrayList<>();
-    for (KestrosTopNavigationItem item : getNavigationLinkElements()) {
+    final List<KestrosTopNavigationItem> sourceResources = getNavigationLinkElements();
+    final List<Resource> resources = new ArrayList<>(sourceResources.size());
+    for (KestrosTopNavigationItem item : sourceResources) {
       resources.add(item.getResource());
     }
     return resources;

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/api/navigation/KestrosTopNavigationItem.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/api/navigation/KestrosTopNavigationItem.java
@@ -25,8 +25,9 @@ public interface KestrosTopNavigationItem extends KestrosContainerElement {
 
   @Nonnull
   default List<Resource> getNavigationItemLinks() {
-    List<Resource> resources = new ArrayList<>();
-    for (KestrosTopNavigationItem item : getNavigationItems()) {
+    final List<KestrosTopNavigationItem> sourceResources = getNavigationItems();
+    final List<Resource> resources = new ArrayList<>(sourceResources.size());
+    for (KestrosTopNavigationItem item : sourceResources) {
       resources.add(item.getResource());
     }
     return resources;

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/api/structure/KestrosAccordion.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/api/structure/KestrosAccordion.java
@@ -30,8 +30,9 @@ public interface KestrosAccordion extends KestrosContainerElement {
   @JsonIgnore
   @Nonnull
   default List<Resource> getPanels() {
-    List<Resource> panelResources = new ArrayList<>();
-    for (KestrosAccordionPanel panel : getPanelElements()) {
+    final List<KestrosAccordionPanel> sourcePanelResources = getPanelElements();
+    final List<Resource> panelResources = new ArrayList<>(sourcePanelResources.size());
+    for (KestrosAccordionPanel panel : sourcePanelResources) {
       if (panel.isSynthetic()) {
         panelResources.add(panel.toSyntheticResource(getResourceResolver(), getPath()));
       } else {

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/api/table/KestrosTable.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/api/table/KestrosTable.java
@@ -21,8 +21,9 @@ public interface KestrosTable extends KestrosContainerElement {
 
   @Nonnull
   default List<Resource> getHeaders() {
-    List<Resource> headers = new ArrayList<>();
-    for (KestrosTableHeader header : getHeaderElements()) {
+    final List<KestrosTableHeader> sourceHeaders = getHeaderElements();
+    final List<Resource> headers = new ArrayList<>(sourceHeaders.size());
+    for (KestrosTableHeader header : sourceHeaders) {
       if (header.isSynthetic()) {
         headers.add(header.toSyntheticResource(getResourceResolver(), getPath()));
       } else {
@@ -37,8 +38,9 @@ public interface KestrosTable extends KestrosContainerElement {
 
   @Nonnull
   default List<Resource> getRows() {
-    List<Resource> rows = new ArrayList<>();
-    for (KestrosTableRow row : getRowElements()) {
+    final List<KestrosTableRow> sourceRows = getRowElements();
+    final List<Resource> rows = new ArrayList<>(sourceRows.size());
+    for (KestrosTableRow row : sourceRows) {
       if (row.isSynthetic()) {
         rows.add(row.toSyntheticResource(getResourceResolver(), getPath()));
       } else {

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/api/table/KestrosTableCell.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/api/table/KestrosTableCell.java
@@ -19,8 +19,9 @@ public interface KestrosTableCell extends KestrosContainerElement {
   @JsonIgnore
   @Nonnull
   default List<Resource> getCellContent() {
-    List<Resource> cellContent = new java.util.ArrayList<>();
-    for (KestrosBasicComponentElement element : getCellContentElements()) {
+    final List<KestrosBasicComponentElement> elements = getCellContentElements();
+    final List<Resource> cellContent = new java.util.ArrayList<>(elements.size());
+    for (final KestrosBasicComponentElement element : elements) {
       cellContent.add(element.getResource());
     }
     return cellContent;

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/api/table/KestrosTableRow.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/api/table/KestrosTableRow.java
@@ -24,8 +24,9 @@ public interface KestrosTableRow extends KestrosContainerElement {
   @JsonIgnore
   @Nonnull
   default List<Resource> getCells() {
-    List<Resource> cells = new ArrayList<>();
-    for (KestrosTableCell cell : getCellElements()) {
+    final List<KestrosTableCell> sourceCells = getCellElements();
+    final List<Resource> cells = new ArrayList<>(sourceCells.size());
+    for (KestrosTableCell cell : sourceCells) {
       if (cell.isSynthetic()) {
         cells.add(cell.toSyntheticResource(getResourceResolver(), getPath()));
       } else {

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/AssetSorter.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/AssetSorter.java
@@ -1,0 +1,91 @@
+package io.kestros.cms.components.basic.core;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import io.kestros.cms.assets.api.models.Asset;
+import java.util.Comparator;
+import java.util.Date;
+import java.util.List;
+import javax.annotation.Nonnull;
+
+/**
+ * Orders the assets behind a list component.
+ *
+ * <p>Extracted from the inline comparators in CardListAssetsDataSource so the ordering rules can
+ * carry their own nullability contract, which a lambda body cannot. Mirrors
+ * {@link ContentPageSorter} for pages.</p>
+ */
+@SuppressFBWarnings("IMC_IMMATURE_CLASS_NO_TOSTRING")
+public final class AssetSorter {
+
+  private static final String CREATED_DATE = "createdDate";
+  private static final String LAST_MODIFIED = "lastModified";
+  private static final String NAME = "name";
+
+  private AssetSorter() {
+    // Utility class; not instantiable.
+  }
+
+  /**
+   * Sorts the supplied assets in place, by the named property.
+   *
+   * <p>An unrecognised sort key falls back to the title, which is the behaviour the inline
+   * comparators had.</p>
+   *
+   * @param assets Assets to sort, modified in place.
+   * @param sortBy Sort key: createdDate, lastModified, name, or anything else for title.
+   */
+  public static void sort(@Nonnull final List<Asset> assets, @Nonnull final String sortBy) {
+    if (sortBy.isEmpty()) {
+      return;
+    }
+    switch (sortBy) {
+      case CREATED_DATE:
+        assets.sort(Comparator.comparing(asset -> time(asset.getCreatedDate())));
+        break;
+      case LAST_MODIFIED:
+        assets.sort(Comparator.comparing(asset -> time(asset.getModifiedDate())));
+        break;
+      case NAME:
+        assets.sort(Comparator.comparing(AssetSorter::name));
+        break;
+      default:
+        assets.sort(Comparator.comparing(AssetSorter::title));
+        break;
+    }
+  }
+
+  /**
+   * A date as epoch milliseconds.
+   *
+   * @param date Date to convert, possibly null.
+   * @return The date as epoch milliseconds, or 0 when it is absent.
+   */
+  @Nonnull
+  private static Long time(final Date date) {
+    return date == null ? 0L : date.getTime();
+  }
+
+  /**
+   * The asset's node name, never null.
+   *
+   * @param asset Asset to read from.
+   * @return The asset's node name, or the empty string when it has none.
+   */
+  @Nonnull
+  private static String name(@Nonnull final Asset asset) {
+    final String assetName = asset.getName();
+    return assetName == null ? "" : assetName;
+  }
+
+  /**
+   * The asset's title, falling back to its node name.
+   *
+   * @param asset Asset to read from.
+   * @return The title, the node name when there is no title, or the empty string when neither.
+   */
+  @Nonnull
+  private static String title(@Nonnull final Asset asset) {
+    final String assetTitle = asset.getTitle();
+    return assetTitle == null ? name(asset) : assetTitle;
+  }
+}

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/AssetSorter.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/AssetSorter.java
@@ -6,6 +6,7 @@ import java.util.Comparator;
 import java.util.Date;
 import java.util.List;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 /**
  * Orders the assets behind a list component.
@@ -40,10 +41,10 @@ public final class AssetSorter {
     }
     switch (sortBy) {
       case CREATED_DATE:
-        assets.sort(Comparator.comparing(asset -> time(asset.getCreatedDate())));
+        assets.sort(Comparator.comparing(AssetSorter::createdTime));
         break;
       case LAST_MODIFIED:
-        assets.sort(Comparator.comparing(asset -> time(asset.getModifiedDate())));
+        assets.sort(Comparator.comparing(AssetSorter::modifiedTime));
         break;
       case NAME:
         assets.sort(Comparator.comparing(AssetSorter::name));
@@ -55,13 +56,35 @@ public final class AssetSorter {
   }
 
   /**
+   * The asset's creation date, as epoch milliseconds.
+   *
+   * @param asset Asset to read from.
+   * @return The creation date as epoch milliseconds, or 0 when it is absent.
+   */
+  @Nonnull
+  private static Long createdTime(@Nonnull final Asset asset) {
+    return time(asset.getCreatedDate());
+  }
+
+  /**
+   * The asset's last-modified date, as epoch milliseconds.
+   *
+   * @param asset Asset to read from.
+   * @return The last-modified date as epoch milliseconds, or 0 when it is absent.
+   */
+  @Nonnull
+  private static Long modifiedTime(@Nonnull final Asset asset) {
+    return time(asset.getModifiedDate());
+  }
+
+  /**
    * A date as epoch milliseconds.
    *
    * @param date Date to convert, possibly null.
    * @return The date as epoch milliseconds, or 0 when it is absent.
    */
   @Nonnull
-  private static Long time(final Date date) {
+  private static Long time(@Nullable final Date date) {
     return date == null ? 0L : date.getTime();
   }
 

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/BaseComponentElement.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/BaseComponentElement.java
@@ -31,6 +31,7 @@ public abstract class BaseComponentElement implements KestrosBasicComponentEleme
   }
 
   @Override
+  @Nonnull
   public List<ComponentVariation> getElementVariations(String propertyName,
       String componentType) {
 
@@ -88,6 +89,7 @@ public abstract class BaseComponentElement implements KestrosBasicComponentEleme
   }
 
   @Override
+  @Nonnull
   public Resource toSyntheticResource(@Nonnull ResourceResolver resourceResolver,
       @Nonnull String parentPath) {
     if (syntheticResource == null) {
@@ -113,6 +115,7 @@ public abstract class BaseComponentElement implements KestrosBasicComponentEleme
         private final ValueMap valueMap = new ValueMapDecorator(props);
 
         @Override
+        @Nonnull
         public ValueMap getValueMap() {
           return valueMap;
         }

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/BaseComponentElement.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/BaseComponentElement.java
@@ -111,16 +111,8 @@ public abstract class BaseComponentElement implements KestrosBasicComponentEleme
       Map<String, Object> props = objectMapper.convertValue(this, Map.class);
       props.put("sling:resourceType", getComponentResourceType());
       props.put("jcr:primaryType", "nt:unstructured");
-      syntheticResource = new SyntheticResource(resourceResolver, resourceMetadata,
-          getComponentResourceType()) {
-        private final ValueMap valueMap = new ValueMapDecorator(props);
-
-        @Override
-        @Nonnull
-        public ValueMap getValueMap() {
-          return valueMap;
-        }
-      };
+      syntheticResource = new PropertyBackedSyntheticResource(resourceResolver,
+          resourceMetadata, getComponentResourceType(), props);
       if (this instanceof KestrosContainerElement) {
         final KestrosContainerElement container = (KestrosContainerElement) this;
         final List<KestrosBasicComponentElement> children = container.getChildElements();

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/BaseComponentElement.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/BaseComponentElement.java
@@ -94,9 +94,10 @@ public abstract class BaseComponentElement implements KestrosBasicComponentEleme
       @Nonnull String parentPath) {
     if (syntheticResource == null) {
       ResourceMetadata resourceMetadata = new ResourceMetadata();
+      final String forcedName = this.getForcedResourceName();
       String name = "child-" + java.util.UUID.randomUUID();
-      if (this.getForcedResourceName() != null && !this.getForcedResourceName().isEmpty()) {
-        name = this.getForcedResourceName();
+      if (forcedName != null && !forcedName.isEmpty()) {
+        name = forcedName;
       }
       String path = parentPath + "/" + name;
       if (!path.startsWith("/synthetics")) {

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/BaseComponentElement.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/BaseComponentElement.java
@@ -104,7 +104,7 @@ public abstract class BaseComponentElement implements KestrosBasicComponentEleme
       }
       resourceMetadata.setResolutionPath(path);
       resourceMetadata.setModificationTime(System.currentTimeMillis());
-      Map<String, String> parameters = new HashMap<>();
+      final Map<String, String> parameters = new HashMap<>(0);
       resourceMetadata.setParameterMap(parameters);
       ObjectMapper objectMapper = new ObjectMapper();
       Map<String, Object> props = objectMapper.convertValue(this, Map.class);

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/BaseComponentElement.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/BaseComponentElement.java
@@ -32,7 +32,7 @@ public abstract class BaseComponentElement implements KestrosBasicComponentEleme
 
   @Override
   @Nonnull
-  public List<ComponentVariation> getElementVariations(String propertyName,
+  public List<ComponentVariation> getElementVariations(@Nonnull String propertyName,
       String componentType) {
 
     BaseComponent component = getResource().adaptTo(BaseComponent.class);

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/BaseComponentElement.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/BaseComponentElement.java
@@ -43,8 +43,8 @@ public abstract class BaseComponentElement implements KestrosBasicComponentEleme
     if (propertyValue instanceof List && !((List<?>) propertyValue).isEmpty()
         && ((List<?>) propertyValue).get(0) instanceof Map) {
       // TODO checking the map here is a bit hacky, but not sure of a better way.
-      List<Map<String, Object>> variationMaps = (List<Map<String, Object>>) propertyValue;
-      appliedVariationNames = new ArrayList<>();
+      final List<Map<String, Object>> variationMaps = (List<Map<String, Object>>) propertyValue;
+      appliedVariationNames = new ArrayList<>(variationMaps.size());
       for (Map<String, Object> variationMap : variationMaps) {
         appliedVariationNames.add((String) variationMap.get("path"));
       }
@@ -122,9 +122,11 @@ public abstract class BaseComponentElement implements KestrosBasicComponentEleme
         }
       };
       if (this instanceof KestrosContainerElement) {
-        KestrosContainerElement container = (KestrosContainerElement) this;
-        Map<String, Resource> childResources = new java.util.LinkedHashMap<>();
-        for (KestrosBasicComponentElement child : container.getChildElements()) {
+        final KestrosContainerElement container = (KestrosContainerElement) this;
+        final List<KestrosBasicComponentElement> children = container.getChildElements();
+        final Map<String, Resource> childResources =
+            new java.util.LinkedHashMap<>((int) (children.size() / 0.75f) + 1);
+        for (final KestrosBasicComponentElement child : children) {
           Resource childSyntheticResource = child.toSyntheticResource(resourceResolver,
               syntheticResource.getPath());
           childResources.put(childSyntheticResource.getName(), childSyntheticResource);

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/BaseComponentSlingModel.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/BaseComponentSlingModel.java
@@ -9,6 +9,6 @@ public abstract class BaseComponentSlingModel extends BaseComponent implements
   @Override
   @Nonnull
   public Boolean isSynthetic() {
-    return false;
+    return Boolean.FALSE;
   }
 }

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/BaseComponentSlingModel.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/BaseComponentSlingModel.java
@@ -1,11 +1,13 @@
 package io.kestros.cms.components.basic.core;
 
+import javax.annotation.Nonnull;
 import io.kestros.cms.components.basic.api.KestrosBasicComponentElement;
 import io.kestros.cms.sitebuilding.api.models.BaseComponent;
 
 public abstract class BaseComponentSlingModel extends BaseComponent implements
         KestrosBasicComponentElement {
   @Override
+  @Nonnull
   public Boolean isSynthetic() {
     return false;
   }

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/BaseContainerSlingModelDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/BaseContainerSlingModelDataSource.java
@@ -28,7 +28,8 @@ public abstract class BaseContainerSlingModelDataSource extends BaseSlingModelDa
   }
 
   @Nonnull
-  public <T extends KestrosBasicComponentElement> List<T> getChildrenAsType(String resourceType, @Nonnull Class<T> clazz) {
+  public <T extends KestrosBasicComponentElement> List<T> getChildrenAsType(@Nonnull String resourceType,
+      @Nonnull Class<T> clazz) {
     List<T> items = new ArrayList<>();
     for (Resource childResource : getResource().getChildren()) {
       if(childResource.isResourceType(resourceType) == false) {

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/BaseContainerSlingModelDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/BaseContainerSlingModelDataSource.java
@@ -27,6 +27,7 @@ public abstract class BaseContainerSlingModelDataSource extends BaseSlingModelDa
     return children;
   }
 
+  @Nonnull
   public <T extends KestrosBasicComponentElement> List<T> getChildrenAsType(String resourceType, Class<T> clazz) {
     List<T> items = new ArrayList<>();
     for (Resource childResource : getResource().getChildren()) {
@@ -41,6 +42,7 @@ public abstract class BaseContainerSlingModelDataSource extends BaseSlingModelDa
     return new ArrayList<>(items);
   }
 
+  @Nonnull
   public <T extends KestrosBasicComponentElement> List<T> getChildrenOfType(Class<T> clazz) {
     List<T> children = new java.util.ArrayList<>();
     for (KestrosBasicComponentElement element : getChildElements()) {

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/BaseContainerSlingModelDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/BaseContainerSlingModelDataSource.java
@@ -43,7 +43,7 @@ public abstract class BaseContainerSlingModelDataSource extends BaseSlingModelDa
   }
 
   @Nonnull
-  public <T extends KestrosBasicComponentElement> List<T> getChildrenOfType(Class<T> clazz) {
+  public <T extends KestrosBasicComponentElement> List<T> getChildrenOfType(@Nonnull Class<T> clazz) {
     List<T> children = new java.util.ArrayList<>();
     for (KestrosBasicComponentElement element : getChildElements()) {
       if (clazz.isInstance(element)) {

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/BaseContainerSlingModelDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/BaseContainerSlingModelDataSource.java
@@ -28,7 +28,7 @@ public abstract class BaseContainerSlingModelDataSource extends BaseSlingModelDa
   }
 
   @Nonnull
-  public <T extends KestrosBasicComponentElement> List<T> getChildrenAsType(String resourceType, Class<T> clazz) {
+  public <T extends KestrosBasicComponentElement> List<T> getChildrenAsType(String resourceType, @Nonnull Class<T> clazz) {
     List<T> items = new ArrayList<>();
     for (Resource childResource : getResource().getChildren()) {
       if(childResource.isResourceType(resourceType) == false) {

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/BaseContainerSyntheticResource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/BaseContainerSyntheticResource.java
@@ -22,8 +22,9 @@ public abstract class BaseContainerSyntheticResource extends BaseSyntheticResour
   @Nonnull
   @Override
   public List<Resource> getChildren() {
-    List<Resource> children = new ArrayList<>();
-    for (KestrosBasicComponentElement componentElement : getChildElements()) {
+    final List<KestrosBasicComponentElement> sourceChildren = getChildElements();
+    final List<Resource> children = new ArrayList<>(sourceChildren.size());
+    for (KestrosBasicComponentElement componentElement : sourceChildren) {
       children.add(componentElement.toSyntheticResource(getResourceResolver(), getPath()));
     }
     return children;

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/BaseDataSourceComponent.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/BaseDataSourceComponent.java
@@ -99,16 +99,8 @@ public abstract class BaseDataSourceComponent<T extends KestrosBasicComponentEle
       Map<String, Object> props = objectMapper.convertValue(this, Map.class);
       props.put("sling:resourceType", getComponentResourceType());
       props.put("jcr:primaryType", "nt:unstructured");
-      syntheticResource = new SyntheticResource(resourceResolver, resourceMetadata,
-          getComponentResourceType()) {
-        private final ValueMap valueMap = new ValueMapDecorator(props);
-
-        @Override
-        @Nonnull
-        public ValueMap getValueMap() {
-          return valueMap;
-        }
-      };
+      syntheticResource = new PropertyBackedSyntheticResource(resourceResolver,
+          resourceMetadata, getComponentResourceType(), props);
       if (this instanceof KestrosContainerElement) {
         final KestrosContainerElement container = (KestrosContainerElement) this;
         final List<KestrosBasicComponentElement> children = container.getChildElements();

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/BaseDataSourceComponent.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/BaseDataSourceComponent.java
@@ -70,6 +70,7 @@ public abstract class BaseDataSourceComponent<T extends KestrosBasicComponentEle
   }
 
   @Override
+  @Nonnull
   public String getLayout() {
     return getComponentData().getLayout();
   }

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/BaseDataSourceComponent.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/BaseDataSourceComponent.java
@@ -72,6 +72,7 @@ public abstract class BaseDataSourceComponent<T extends KestrosBasicComponentEle
   }
 
   @Override
+  @Nonnull
   public Resource toSyntheticResource(@Nonnull ResourceResolver resourceResolver,
       @Nonnull String parentPath) {
     // TODO remove duplicate
@@ -98,6 +99,7 @@ public abstract class BaseDataSourceComponent<T extends KestrosBasicComponentEle
         private final ValueMap valueMap = new ValueMapDecorator(props);
 
         @Override
+        @Nonnull
         public ValueMap getValueMap() {
           return valueMap;
         }

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/BaseDataSourceComponent.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/BaseDataSourceComponent.java
@@ -41,13 +41,13 @@ public abstract class BaseDataSourceComponent<T extends KestrosBasicComponentEle
 
   @Override
   @Nonnull
-  public String getLayout(String propertyName) {
+  public String getLayout(@Nonnull String propertyName) {
     return getComponentData().getLayout(propertyName);
   }
 
   @Override
   @Nonnull
-  public List<ComponentVariation> getElementVariations(String propertyName, String componentType) {
+  public List<ComponentVariation> getElementVariations(@Nonnull String propertyName, String componentType) {
     return getComponentData().getElementVariations(propertyName, componentType);
   }
 

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/BaseDataSourceComponent.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/BaseDataSourceComponent.java
@@ -82,9 +82,10 @@ public abstract class BaseDataSourceComponent<T extends KestrosBasicComponentEle
     // TODO remove duplicate
     if (syntheticResource == null) {
       ResourceMetadata resourceMetadata = new ResourceMetadata();
+      final String forcedName = getForcedResourceName();
       String name = "child-" + java.util.UUID.randomUUID();
-      if (getForcedResourceName() != null && !getForcedResourceName().isEmpty()) {
-        name = getForcedResourceName();
+      if (forcedName != null && !forcedName.isEmpty()) {
+        name = forcedName;
       }
       String path = parentPath + "/" + name;
       if (!path.startsWith("/synthetics")) {
@@ -92,7 +93,7 @@ public abstract class BaseDataSourceComponent<T extends KestrosBasicComponentEle
       }
       resourceMetadata.setResolutionPath(path);
       resourceMetadata.setModificationTime(System.currentTimeMillis());
-      Map<String, String> parameters = new HashMap<>();
+      final Map<String, String> parameters = new HashMap<>(0);
       resourceMetadata.setParameterMap(parameters);
       ObjectMapper objectMapper = new ObjectMapper();
       Map<String, Object> props = objectMapper.convertValue(this, Map.class);

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/BaseDataSourceComponent.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/BaseDataSourceComponent.java
@@ -40,11 +40,13 @@ public abstract class BaseDataSourceComponent<T extends KestrosBasicComponentEle
   }
 
   @Override
+  @Nonnull
   public String getLayout(String propertyName) {
     return getComponentData().getLayout(propertyName);
   }
 
   @Override
+  @Nonnull
   public List<ComponentVariation> getElementVariations(String propertyName, String componentType) {
     return getComponentData().getElementVariations(propertyName, componentType);
   }
@@ -62,6 +64,7 @@ public abstract class BaseDataSourceComponent<T extends KestrosBasicComponentEle
   }
 
   @Override
+  @Nonnull
   public List<ComponentVariation> getVariations() {
     return getComponentData().getVariations();
   }

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/BaseDataSourceComponent.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/BaseDataSourceComponent.java
@@ -110,9 +110,11 @@ public abstract class BaseDataSourceComponent<T extends KestrosBasicComponentEle
         }
       };
       if (this instanceof KestrosContainerElement) {
-        KestrosContainerElement container = (KestrosContainerElement) this;
-        Map<String, Resource> childResources = new HashMap<>();
-        for (KestrosBasicComponentElement child : container.getChildElements()) {
+        final KestrosContainerElement container = (KestrosContainerElement) this;
+        final List<KestrosBasicComponentElement> children = container.getChildElements();
+        final Map<String, Resource> childResources =
+            new HashMap<>((int) (children.size() / 0.75f) + 1);
+        for (final KestrosBasicComponentElement child : children) {
           Resource childSyntheticResource = child.toSyntheticResource(resourceResolver,
               syntheticResource.getPath());
           childResources.put(childSyntheticResource.getName(), childSyntheticResource);

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/BaseSlingModelDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/BaseSlingModelDataSource.java
@@ -51,7 +51,7 @@ public abstract class BaseSlingModelDataSource
 
   @Nonnull
   public Boolean isSynthetic() {
-    return false;
+    return Boolean.FALSE;
   }
 
   @Nonnull

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/BaseSlingModelDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/BaseSlingModelDataSource.java
@@ -25,8 +25,7 @@ import org.apache.sling.models.annotations.injectorspecific.OSGiService;
 import org.apache.sling.models.annotations.injectorspecific.Self;
 
 @Model(adaptables = {SlingHttpServletRequest.class, Resource.class})
-public abstract class BaseSlingModelDataSource
-    extends BaseComponentElement implements KestrosBasicComponentElement {
+public abstract class BaseSlingModelDataSource extends BaseComponentElement {
 
   @Self
   @Optional

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/BaseSlingModelDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/BaseSlingModelDataSource.java
@@ -91,6 +91,7 @@ public abstract class BaseSlingModelDataSource
   }
 
 
+  @Nonnull
   public ResourceResolver getResourceResolver() {
     return getResource().getResourceResolver();
   }

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/BaseSlingModelDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/BaseSlingModelDataSource.java
@@ -49,10 +49,12 @@ public abstract class BaseSlingModelDataSource
     return getResource().getValueMap().get("id", String.class);
   }
 
+  @Nonnull
   public Boolean isSynthetic() {
     return false;
   }
 
+  @Nonnull
   public Resource getResource() {
     if (resource == null && slingHttpServletRequest != null) {
       return slingHttpServletRequest.getResource();
@@ -66,6 +68,7 @@ public abstract class BaseSlingModelDataSource
   }
 
   @JsonIgnore
+  @Nonnull
   public BaseContentPage getCurrentOrContainingPage() {
     BaseContentPage currentPage = null;
     if (slingHttpServletRequest != null) {
@@ -93,10 +96,12 @@ public abstract class BaseSlingModelDataSource
     return getResource().getResourceResolver();
   }
 
+  @Nonnull
   public String getParentPath() {
     return getResource().getParent().getPath();
   }
 
+  @Nonnull
   public List<ComponentVariation> getVariations() {
     // TODO verify this.
     List<Map<String, Object>> variationsMapList = getResource().getValueMap()
@@ -124,6 +129,7 @@ public abstract class BaseSlingModelDataSource
     return getResource().adaptTo(BaseComponent.class).getAppliedVariations();
   }
 
+  @Nonnull
   public String getLayout() {
     return getResource().getValueMap().get("layout", "default");
   }
@@ -135,6 +141,7 @@ public abstract class BaseSlingModelDataSource
     return getResource().getName();
   }
 
+  @Nonnull
   public UiFramework getUiFramework() {
     try {
       if (slingHttpServletRequest != null) {

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/BaseSlingModelDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/BaseSlingModelDataSource.java
@@ -1,6 +1,7 @@
 package io.kestros.cms.components.basic.core;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import io.kestros.cms.components.basic.api.exceptions.ComponentElementRenderingException;
 import io.kestros.cms.components.basic.api.KestrosBasicComponentElement;
 import io.kestros.cms.componenttypes.api.exceptions.ComponentVariationRetrievalException;
 import io.kestros.cms.componenttypes.api.models.ComponentVariation;
@@ -10,6 +11,7 @@ import io.kestros.cms.sitebuilding.api.models.BaseComponent;
 import io.kestros.cms.sitebuilding.api.models.BaseContentPage;
 import io.kestros.cms.sitebuilding.api.models.ComponentRequestContext;
 import io.kestros.cms.uiframeworks.api.models.UiFramework;
+import io.kestros.commons.structuredslingmodels.exceptions.ModelAdaptionException;
 import io.kestros.commons.structuredslingmodels.exceptions.NoValidAncestorException;
 import java.util.ArrayList;
 import java.util.List;
@@ -151,8 +153,9 @@ public abstract class BaseSlingModelDataSource extends BaseComponentElement {
         return getResource().adaptTo(BaseComponent.class).getContainingPage().getTheme()
             .getUiFramework();
       }
-    } catch (Exception e) {
-      throw new RuntimeException(e);
+    } catch (ModelAdaptionException e) {
+      throw new ComponentElementRenderingException(String.format(
+          "Unable to resolve the UI framework for %s.", getPath()), e);
     }
   }
 

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/BaseSlingModelDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/BaseSlingModelDataSource.java
@@ -148,6 +148,10 @@ public abstract class BaseSlingModelDataSource extends BaseComponentElement {
     return getResource().getName();
   }
 
+  @SuppressFBWarnings(value = "EXS_EXCEPTION_SOFTENING_HAS_CHECKED",
+      justification = "Called from HTL, which cannot handle a checked exception. The"
+          + " checked cause is wrapped in a typed exception, per the ruling on"
+          + " DataSourceComponent.")
   @Nonnull
   public UiFramework getUiFramework() {
     try {

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/BaseSlingModelDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/BaseSlingModelDataSource.java
@@ -1,5 +1,6 @@
 package io.kestros.cms.components.basic.core;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.kestros.cms.components.basic.api.exceptions.ComponentElementRenderingException;
 import io.kestros.cms.components.basic.api.KestrosBasicComponentElement;
@@ -67,6 +68,10 @@ public abstract class BaseSlingModelDataSource extends BaseComponentElement {
     return slingHttpServletRequest;
   }
 
+  @SuppressFBWarnings(value = "EXS_EXCEPTION_SOFTENING_NO_CONSTRAINTS",
+      justification = "Called from HTL, which cannot handle a checked exception. The checked"
+          + " cause is wrapped in a typed exception so the failure stays identifiable, per"
+          + " the ruling on DataSourceComponent.")
   @JsonIgnore
   @Nonnull
   public BaseContentPage getCurrentOrContainingPage() {

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/BaseSlingModelDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/BaseSlingModelDataSource.java
@@ -107,8 +107,9 @@ public abstract class BaseSlingModelDataSource
     List<Map<String, Object>> variationsMapList = getResource().getValueMap()
         .get("variations", new ArrayList<>());
     if (!variationsMapList.isEmpty()) {
-      List<ComponentVariation> variations = new ArrayList<>();
-      for (Map<String, Object> variationMap : variationsMapList) {
+      final List<Map<String, Object>> sourceVariations = variationsMapList;
+      final List<ComponentVariation> variations = new ArrayList<>(sourceVariations.size());
+      for (Map<String, Object> variationMap : sourceVariations) {
         String path = (String) variationMap.get("path");
         Resource variationResource = getResourceResolver().getResource(path);
         if (variationResource == null) {

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/BaseSlingModelDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/BaseSlingModelDataSource.java
@@ -42,7 +42,6 @@ public abstract class BaseSlingModelDataSource
   @OSGiService
   private ComponentUiFrameworkViewRetrievalService componentUiFrameworkViewRetrievalService;
 
-  private Resource syntheticResource;
 
   @Nullable
   public String getId() {

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/BaseSyntheticResource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/BaseSyntheticResource.java
@@ -1,5 +1,6 @@
 package io.kestros.cms.components.basic.core;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.kestros.cms.components.basic.api.KestrosBasicComponentElement;
 import io.kestros.cms.components.basic.api.exceptions.ComponentConfigurationException;
 import io.kestros.cms.componenttypes.api.models.ComponentVariation;
@@ -28,6 +29,11 @@ public abstract class BaseSyntheticResource extends BaseComponentElement {
   private ComponentUiFrameworkViewRetrievalService componentUiFrameworkViewRetrievalService;
   private BaseSlingModelDataSource dataSource;
 
+  @SuppressFBWarnings(value = {"MC_OVERRIDABLE_METHOD_CALL_IN_CONSTRUCTOR",
+      "OPM_OVERLY_PERMISSIVE_METHOD"},
+      justification = "getComponentResourceType is the subclass's declaration of which"
+          + " component it is, and the variations lookup needs it while the object is still"
+          + " being built. Every implementation returns a constant.")
   public BaseSyntheticResource(
       @Nonnull BaseSlingModelDataSource dataSource,
       @Nonnull String resourcePrefix, @Nullable String forcedResourceName) throws

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/BaseSyntheticResource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/BaseSyntheticResource.java
@@ -14,8 +14,7 @@ import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ResourceResolver;
 
-public abstract class BaseSyntheticResource extends BaseComponentElement
-    implements KestrosBasicComponentElement {
+public abstract class BaseSyntheticResource extends BaseComponentElement {
   private final ResourceResolver resourceResolver;
   private final String parentPath;
   private final UiFramework uiFramework;

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/BaseSyntheticResource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/BaseSyntheticResource.java
@@ -45,7 +45,10 @@ public abstract class BaseSyntheticResource extends BaseComponentElement {
         || this.layout == null || this.uiFramework == null) {
       // this is not needed, but is included so that the extending classes are required to throw
       // the exception.
-      throw new ComponentConfigurationException("Missing required property");
+      throw new ComponentConfigurationException(String.format(
+          "Unable to build a synthetic resource under %s: one of the resource resolver, parent path,%n"
+          + " variations, layout or UI framework was not supplied.",
+          String.valueOf(parentPath)));
     }
     this.componentVariationRetrievalService = dataSource.getComponentVariationRetrievalService();
     this.componentUiFrameworkViewRetrievalService =

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/BaseSyntheticResource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/BaseSyntheticResource.java
@@ -60,16 +60,19 @@ public abstract class BaseSyntheticResource extends BaseComponentElement
   }
 
   @Override
+  @Nonnull
   public ResourceResolver getResourceResolver() {
     return resourceResolver;
   }
 
   @Override
+  @Nonnull
   public String getParentPath() {
     return parentPath;
   }
 
   @Override
+  @Nonnull
   public Resource getResource() {
     if (syntheticResource == null) {
       syntheticResource = toSyntheticResource(resourceResolver, parentPath);
@@ -90,15 +93,18 @@ public abstract class BaseSyntheticResource extends BaseComponentElement
   }
 
   @Override
+  @Nonnull
   public List<ComponentVariation> getVariations() {
     return new ArrayList<>(componentVariations);
   }
 
   @Override
+  @Nonnull
   public String getLayout() {
     return layout;
   }
 
+  @Nonnull
   public UiFramework getUiFramework() {
     return uiFramework;
   }

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/ContentPageSorter.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/ContentPageSorter.java
@@ -42,10 +42,10 @@ public final class ContentPageSorter {
     }
     switch (sortBy) {
       case CREATED_DATE:
-        pages.sort(Comparator.comparing(page -> contentDate(page, "jcr:created")));
+        pages.sort(Comparator.comparing(ContentPageSorter::createdDate));
         break;
       case LAST_MODIFIED:
-        pages.sort(Comparator.comparing(page -> contentDate(page, "jcr:lastModified")));
+        pages.sort(Comparator.comparing(ContentPageSorter::lastModifiedDate));
         break;
       case NAME:
         pages.sort(Comparator.comparing(ContentPageSorter::name));
@@ -54,6 +54,28 @@ public final class ContentPageSorter {
         pages.sort(Comparator.comparing(ContentPageSorter::displayTitle));
         break;
     }
+  }
+
+  /**
+   * The page's creation date, as epoch milliseconds.
+   *
+   * @param page Page to read from.
+   * @return The creation date as epoch milliseconds, or 0 when it is absent.
+   */
+  @Nonnull
+  private static Long createdDate(@Nonnull final BaseContentPage page) {
+    return contentDate(page, "jcr:created");
+  }
+
+  /**
+   * The page's last-modified date, as epoch milliseconds.
+   *
+   * @param page Page to read from.
+   * @return The last-modified date as epoch milliseconds, or 0 when it is absent.
+   */
+  @Nonnull
+  private static Long lastModifiedDate(@Nonnull final BaseContentPage page) {
+    return contentDate(page, "jcr:lastModified");
   }
 
   /**

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/ContentPageSorter.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/ContentPageSorter.java
@@ -1,0 +1,102 @@
+package io.kestros.cms.components.basic.core;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import io.kestros.cms.sitebuilding.api.models.BaseContentPage;
+import java.util.Calendar;
+import java.util.Comparator;
+import java.util.List;
+import javax.annotation.Nonnull;
+import org.apache.sling.api.resource.Resource;
+
+/**
+ * Orders the pages behind a list component.
+ *
+ * <p>The four list data sources that sort pages carried an identical copy of these three
+ * comparators as inline lambdas. Extracted here so the ordering rules live in one place and can
+ * carry their own nullability contract, which a lambda body cannot.</p>
+ */
+@SuppressFBWarnings("IMC_IMMATURE_CLASS_NO_TOSTRING")
+public final class ContentPageSorter {
+
+  private static final String CREATED_DATE = "createdDate";
+  private static final String LAST_MODIFIED = "lastModified";
+  private static final String NAME = "name";
+
+  private ContentPageSorter() {
+    // Utility class; not instantiable.
+  }
+
+  /**
+   * Sorts the supplied pages in place, by the named property.
+   *
+   * <p>An unrecognised sort key falls back to the display title, which is the behaviour the
+   * inline comparators had.</p>
+   *
+   * @param pages Pages to sort, modified in place.
+   * @param sortBy Sort key: createdDate, lastModified, name, or anything else for display title.
+   */
+  public static void sort(@Nonnull final List<BaseContentPage> pages,
+      @Nonnull final String sortBy) {
+    if (sortBy.isEmpty()) {
+      return;
+    }
+    switch (sortBy) {
+      case CREATED_DATE:
+        pages.sort(Comparator.comparing(page -> contentDate(page, "jcr:created")));
+        break;
+      case LAST_MODIFIED:
+        pages.sort(Comparator.comparing(page -> contentDate(page, "jcr:lastModified")));
+        break;
+      case NAME:
+        pages.sort(Comparator.comparing(ContentPageSorter::name));
+        break;
+      default:
+        pages.sort(Comparator.comparing(ContentPageSorter::displayTitle));
+        break;
+    }
+  }
+
+  /**
+   * A date property from the page's jcr:content, as epoch milliseconds.
+   *
+   * @param page Page to read from.
+   * @param propertyName Date property to read.
+   * @return The property as epoch milliseconds, or 0 when the page has no jcr:content or the
+   *     property is absent.
+   */
+  @Nonnull
+  private static Long contentDate(@Nonnull final BaseContentPage page,
+      @Nonnull final String propertyName) {
+    final Resource content = page.getResource().getChild("jcr:content");
+    if (content == null) {
+      return 0L;
+    }
+    final Calendar calendar = content.getValueMap().get(propertyName, Calendar.class);
+    return calendar == null ? 0L : calendar.getTimeInMillis();
+  }
+
+  /**
+   * The page's node name, never null.
+   *
+   * @param page Page to read from.
+   * @return The page's node name, or the empty string when it has none.
+   */
+  @Nonnull
+  private static String name(@Nonnull final BaseContentPage page) {
+    final String pageName = page.getName();
+    return pageName == null ? "" : pageName;
+  }
+
+  /**
+   * The page's display title, falling back to its node name.
+   *
+   * @param page Page to read from.
+   * @return The display title, the node name when there is no title, or the empty string when
+   *     there is neither.
+   */
+  @Nonnull
+  private static String displayTitle(@Nonnull final BaseContentPage page) {
+    final String title = page.getDisplayTitle();
+    return title == null ? name(page) : title;
+  }
+}

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/PropertyBackedSyntheticResource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/PropertyBackedSyntheticResource.java
@@ -1,0 +1,45 @@
+package io.kestros.cms.components.basic.core;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import java.util.HashMap;
+import java.util.Map;
+import javax.annotation.Nonnull;
+import org.apache.sling.api.resource.ResourceMetadata;
+import org.apache.sling.api.resource.ResourceResolver;
+import org.apache.sling.api.resource.SyntheticResource;
+import org.apache.sling.api.resource.ValueMap;
+import org.apache.sling.api.wrappers.ValueMapDecorator;
+
+/**
+ * A synthetic resource whose properties come from a supplied map rather than from the repository.
+ *
+ * <p>Both synthetic-resource builders used an anonymous subclass for this, which captured the
+ * enclosing component for no reason and could carry no nullability contract of its own.</p>
+ */
+@SuppressFBWarnings("IMC_IMMATURE_CLASS_NO_TOSTRING")
+public class PropertyBackedSyntheticResource extends SyntheticResource {
+
+  private final ValueMap valueMap;
+
+  /**
+   * A synthetic resource whose properties come from a supplied map.
+   *
+   * @param resourceResolver Resolver the synthetic resource belongs to.
+   * @param resourceMetadata Metadata describing where the resource sits.
+   * @param resourceType Resource type the synthetic resource reports.
+   * @param properties Properties the resource exposes. Copied, so a later change by the caller
+   *     cannot rewrite what the resource reports.
+   */
+  public PropertyBackedSyntheticResource(@Nonnull final ResourceResolver resourceResolver,
+      @Nonnull final ResourceMetadata resourceMetadata, @Nonnull final String resourceType,
+      @Nonnull final Map<String, Object> properties) {
+    super(resourceResolver, resourceMetadata, resourceType);
+    this.valueMap = new ValueMapDecorator(new HashMap<>(properties));
+  }
+
+  @Override
+  @Nonnull
+  public ValueMap getValueMap() {
+    return valueMap;
+  }
+}

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/SyntheticResourceWrapper.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/SyntheticResourceWrapper.java
@@ -1,5 +1,6 @@
 package io.kestros.cms.components.basic.core;
 
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 import javax.annotation.Nonnull;
@@ -22,7 +23,7 @@ public class SyntheticResourceWrapper extends ResourceWrapper {
    */
   public SyntheticResourceWrapper(Resource wrapped, @Nonnull Map<String, Resource> children) {
     super(wrapped);
-    this.children = children;
+    this.children = new HashMap<>(children);
   }
 
   @Nullable

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/SyntheticResourceWrapper.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/SyntheticResourceWrapper.java
@@ -1,5 +1,6 @@
 package io.kestros.cms.components.basic.core;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
@@ -11,6 +12,7 @@ import org.apache.sling.api.resource.ResourceWrapper;
 /**
  * ResourceWrapper that allows for synthetic children to be added to the wrapped Resource.
  */
+@SuppressFBWarnings("IMC_IMMATURE_CLASS_NO_EQUALS")
 public class SyntheticResourceWrapper extends ResourceWrapper {
 
   private final Map<String, Resource> children;

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/SyntheticResourceWrapper.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/SyntheticResourceWrapper.java
@@ -20,7 +20,7 @@ public class SyntheticResourceWrapper extends ResourceWrapper {
    * @param wrapped Wrapped Resource.
    * @param children Map of synthetic children to add to the wrapped Resource.
    */
-  public SyntheticResourceWrapper(Resource wrapped, Map<String, Resource> children) {
+  public SyntheticResourceWrapper(Resource wrapped, @Nonnull Map<String, Resource> children) {
     super(wrapped);
     this.children = children;
   }

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/TextSanitizer.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/TextSanitizer.java
@@ -17,8 +17,9 @@ public final class TextSanitizer {
     if (text == null) {
       return null;
     }
+    final int length = text.length();
     boolean hasMultiByte = false;
-    for (int i = 0; i < text.length(); i++) {
+    for (int i = 0; i < length; i++) {
       if (text.charAt(i) > 127) {
         hasMultiByte = true;
         break;
@@ -27,8 +28,8 @@ public final class TextSanitizer {
     if (!hasMultiByte) {
       return text;
     }
-    StringBuilder sb = new StringBuilder(text.length() + 32);
-    for (int i = 0; i < text.length(); i++) {
+    final StringBuilder sb = new StringBuilder(length + 32);
+    for (int i = 0; i < length; i++) {
       char c = text.charAt(i);
       if (c > 127) {
         sb.append("&#").append((int) c).append(';');

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/alert/KestrosAlertImpl.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/alert/KestrosAlertImpl.java
@@ -1,5 +1,6 @@
 package io.kestros.cms.components.basic.core.content.alert;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.kestros.cms.components.basic.api.content.KestrosAlert;
 import io.kestros.cms.components.basic.api.exceptions.ComponentConfigurationException;
 import io.kestros.cms.components.basic.core.BaseSlingModelDataSource;
@@ -7,6 +8,7 @@ import io.kestros.cms.components.basic.core.BaseSyntheticResource;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
+@SuppressFBWarnings("IMC_IMMATURE_CLASS_NO_TOSTRING")
 public class KestrosAlertImpl extends BaseSyntheticResource implements KestrosAlert {
 
   private String heading;

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/button/ButtonDataSourceComponent.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/button/ButtonDataSourceComponent.java
@@ -1,5 +1,6 @@
 package io.kestros.cms.components.basic.core.content.button;
 
+import javax.annotation.Nonnull;
 import io.kestros.cms.components.basic.api.content.AnchorTarget;
 import io.kestros.cms.components.basic.api.content.KestrosButton;
 import io.kestros.cms.components.basic.core.BaseDataSourceComponent;
@@ -30,7 +31,7 @@ public class ButtonDataSourceComponent extends BaseDataSourceComponent<KestrosBu
     return getComponentData().getTitle();
   }
 
-  @Nullable
+  @Nonnull
   @Override
   public AnchorTarget getTarget() {
     return getComponentData().getTarget();

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/button/ButtonStaticDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/button/ButtonStaticDataSource.java
@@ -1,5 +1,6 @@
 package io.kestros.cms.components.basic.core.content.button;
 
+import javax.annotation.Nonnull;
 import io.kestros.cms.components.basic.api.content.AnchorTarget;
 import io.kestros.cms.components.basic.api.content.KestrosButton;
 import io.kestros.cms.components.basic.core.LinkUtils;
@@ -30,7 +31,7 @@ public class ButtonStaticDataSource extends BaseSlingModelDataSource implements 
     return getResource().getValueMap().get("title", String.class);
   }
 
-  @Nullable
+  @Nonnull
   @Override
   public AnchorTarget getTarget() {
     return AnchorTarget.lookup(getResource());

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/button/ButtonStaticDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/button/ButtonStaticDataSource.java
@@ -63,6 +63,6 @@ public class ButtonStaticDataSource extends BaseSlingModelDataSource implements 
 
   @Override
   public boolean isDisabled() {
-    return getResource().getValueMap().get("disabled", false);
+    return getResource().getValueMap().get("disabled", Boolean.FALSE);
   }
 }

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/button/KestrosButtonImpl.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/button/KestrosButtonImpl.java
@@ -1,5 +1,6 @@
 package io.kestros.cms.components.basic.core.content.button;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.kestros.cms.components.basic.api.content.AnchorTarget;
 import io.kestros.cms.components.basic.api.content.KestrosButton;
 import io.kestros.cms.components.basic.api.exceptions.ComponentConfigurationException;
@@ -12,6 +13,7 @@ import javax.annotation.Nullable;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.sling.api.resource.Resource;
 
+@SuppressFBWarnings("IMC_IMMATURE_CLASS_NO_TOSTRING")
 public class KestrosButtonImpl extends BaseSyntheticResource implements KestrosButton {
 
   private String text;
@@ -86,7 +88,7 @@ public class KestrosButtonImpl extends BaseSyntheticResource implements KestrosB
     return title;
   }
 
-  @Nullable
+  @Nonnull
   @Override
   public AnchorTarget getTarget() {
     return target;

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/button/KestrosButtonImpl.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/button/KestrosButtonImpl.java
@@ -66,7 +66,9 @@ public class KestrosButtonImpl extends BaseSyntheticResource implements KestrosB
     this.lang = resource.getValueMap().get("lang", String.class);
     this.disabled = resource.getValueMap().get("disabled", Boolean.FALSE);
     if (StringUtils.isEmpty(href)) {
-      throw new ComponentConfigurationException("Missing required property");
+      throw new ComponentConfigurationException(String.format(
+          "Unable to build a button at %s: href is required and was empty.",
+          resource.getPath()));
     }
   }
 

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/button/KestrosButtonImpl.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/button/KestrosButtonImpl.java
@@ -64,7 +64,7 @@ public class KestrosButtonImpl extends BaseSyntheticResource implements KestrosB
     this.ariaLabel = resource.getValueMap().get("ariaLabel", String.class);
     this.ariaDescribedBy = resource.getValueMap().get("ariaDescribedBy", String.class);
     this.lang = resource.getValueMap().get("lang", String.class);
-    this.disabled = resource.getValueMap().get("disabled", false);
+    this.disabled = resource.getValueMap().get("disabled", Boolean.FALSE);
     if (StringUtils.isEmpty(href)) {
       throw new ComponentConfigurationException("Missing required property");
     }

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/buttongroup/ButtonGroupDataSourceComponent.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/buttongroup/ButtonGroupDataSourceComponent.java
@@ -27,6 +27,7 @@ public class ButtonGroupDataSourceComponent extends
   }
 
   @Override
+  @Nonnull
   public List<ComponentVariation> getButtonVariations() {
     if (componentVariations == null) {
       componentVariations = getComponentData().getButtonVariations();

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/buttongroup/ButtonGroupStaticDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/buttongroup/ButtonGroupStaticDataSource.java
@@ -30,6 +30,7 @@ public class ButtonGroupStaticDataSource extends BaseContainerSlingModelDataSour
   }
 
 
+  @Nonnull
   public List<ComponentVariation> getButtonVariations() {
     try {
       return getElementVariations("buttonVariations", KestrosButton.RESOURCE_TYPE);

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/buttongroup/KestrosButtonGroupImpl.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/buttongroup/KestrosButtonGroupImpl.java
@@ -19,7 +19,6 @@ public class KestrosButtonGroupImpl extends BaseContainerSyntheticResource imple
 
   private List<KestrosButton> buttons;
   private List<ComponentVariation> buttonVariations;
-  private String buttonLayout;
 
   public KestrosButtonGroupImpl(@Nonnull final List<KestrosButton> buttons,
       @Nonnull BaseSlingModelDataSource dataSource,
@@ -28,7 +27,7 @@ public class KestrosButtonGroupImpl extends BaseContainerSyntheticResource imple
       ComponentConfigurationException {
     super(dataSource, resourcePrefix,
         forcedResourceName);
-    this.buttons = buttons;
+    this.buttons = new ArrayList<>(buttons);
     this.buttonVariations = dataSource.getElementVariations("button", KestrosButton.RESOURCE_TYPE);
   }
 
@@ -53,7 +52,7 @@ public class KestrosButtonGroupImpl extends BaseContainerSyntheticResource imple
           "button",
           "buttonElement"));
     }
-    this.buttons = buttons;
+    this.buttons = new ArrayList<>(buttons);
     if (this.buttons.isEmpty()) {
       throw new ComponentConfigurationException("Button Group must have at least one button.");
     }

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/buttongroup/KestrosButtonGroupImpl.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/buttongroup/KestrosButtonGroupImpl.java
@@ -54,7 +54,9 @@ public class KestrosButtonGroupImpl extends BaseContainerSyntheticResource imple
     }
     this.buttons = new ArrayList<>(buttons);
     if (this.buttons.isEmpty()) {
-      throw new ComponentConfigurationException("Button Group must have at least one button.");
+      throw new ComponentConfigurationException(String.format(
+          "Unable to build the button group %s: a button group must have at least one button.",
+          String.valueOf(resourcePrefix)));
     }
   }
 

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/buttongroup/KestrosButtonGroupImpl.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/buttongroup/KestrosButtonGroupImpl.java
@@ -1,5 +1,6 @@
 package io.kestros.cms.components.basic.core.content.buttongroup;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.kestros.cms.components.basic.api.content.KestrosButton;
 import io.kestros.cms.components.basic.api.content.KestrosButtonGroup;
 import io.kestros.cms.components.basic.api.exceptions.ComponentConfigurationException;
@@ -12,6 +13,7 @@ import java.util.List;
 import javax.annotation.Nonnull;
 import org.apache.sling.api.resource.Resource;
 
+@SuppressFBWarnings("IMC_IMMATURE_CLASS_NO_TOSTRING")
 public class KestrosButtonGroupImpl extends BaseContainerSyntheticResource implements
                                                                            KestrosButtonGroup {
 

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/card/CardAssetDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/card/CardAssetDataSource.java
@@ -17,6 +17,8 @@ import io.kestros.cms.components.basic.core.content.image.KestrosImageImpl;
 import io.kestros.cms.componenttypes.api.models.ComponentVariation;
 import java.util.List;
 import javax.annotation.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.models.annotations.Model;
@@ -26,6 +28,9 @@ import org.apache.sling.models.annotations.injectorspecific.OSGiService;
 @SuppressFBWarnings("IMC_IMMATURE_CLASS_NO_TOSTRING")
 @Model(adaptables = {SlingHttpServletRequest.class, Resource.class})
 public class CardAssetDataSource extends BaseContainerSlingModelDataSource implements KestrosCard {
+
+  private static final Logger LOG =
+      LoggerFactory.getLogger(CardAssetDataSource.class);
 
   private Asset asset;
 
@@ -45,20 +50,22 @@ public class CardAssetDataSource extends BaseContainerSlingModelDataSource imple
   @Nullable
   @Override
   public KestrosHeading getTitleElement() {
-    if (getAsset() != null) {
-      String title = getAsset().getTitle();
-      String headingLevel = getResource().getValueMap().get("headingType", "h1");
-      try {
-        return new KestrosHeadingImpl(title, headingLevel,
-                this,
-                "title",
-                "titleElement");
-      } catch (ComponentConfigurationException e) {
-        // do nothing.
-      }
+    final Asset cardAsset = getAsset();
+    if (cardAsset == null) {
       return null;
     }
-    return null;
+    try {
+      return new KestrosHeadingImpl(cardAsset.getTitle(),
+              getResource().getValueMap().get("headingType", "h1"),
+              this,
+              "title",
+              "titleElement");
+    } catch (ComponentConfigurationException e) {
+      LOG.debug("No title element for the card backed by {}: the heading could not be built. {}",
+          String.valueOf(cardAsset.getPath()).replaceAll("[\r\n]", ""),
+          String.valueOf(e.getMessage()).replaceAll("[\r\n]", ""));
+      return null;
+    }
   }
 
   @SuppressFBWarnings(value = "EXS_EXCEPTION_SOFTENING_NO_CHECKED",

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/card/CardAssetDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/card/CardAssetDataSource.java
@@ -61,6 +61,10 @@ public class CardAssetDataSource extends BaseContainerSlingModelDataSource imple
     return null;
   }
 
+  @SuppressFBWarnings(value = "EXS_EXCEPTION_SOFTENING_NO_CHECKED",
+      justification = "Called from HTL, which cannot handle a checked exception. The checked"
+          + " cause is wrapped in a typed ComponentElementRenderingException so the failure"
+          + " stays identifiable, per the ruling on DataSourceComponent.")
   @Nullable
   @Override
   public KestrosImage getImageElement() {

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/card/CardAssetDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/card/CardAssetDataSource.java
@@ -1,8 +1,10 @@
 package io.kestros.cms.components.basic.core.content.card;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.kestros.cms.assets.api.exceptions.AssetRetrievalException;
 import io.kestros.cms.assets.api.models.Asset;
 import io.kestros.cms.assets.api.services.AssetRetrievalService;
+import io.kestros.cms.components.basic.api.exceptions.ComponentElementRenderingException;
 import io.kestros.cms.components.basic.api.content.AnchorTarget;
 import io.kestros.cms.components.basic.api.content.KestrosButtonGroup;
 import io.kestros.cms.components.basic.api.content.KestrosCard;
@@ -21,6 +23,7 @@ import org.apache.sling.models.annotations.Model;
 import org.apache.sling.models.annotations.Optional;
 import org.apache.sling.models.annotations.injectorspecific.OSGiService;
 
+@SuppressFBWarnings("IMC_IMMATURE_CLASS_NO_TOSTRING")
 @Model(adaptables = {SlingHttpServletRequest.class, Resource.class})
 public class CardAssetDataSource extends BaseContainerSlingModelDataSource implements KestrosCard {
 
@@ -61,31 +64,23 @@ public class CardAssetDataSource extends BaseContainerSlingModelDataSource imple
   @Nullable
   @Override
   public KestrosImage getImageElement() {
-    if (getAsset() != null) {
-      if (getAsset().getPath() != null) {
-        String imagePath = getAsset().getPath();
-        String altText = null;
-        String caption = null;
-        String imageTitle = null;
-        String href = null;
-        String ariaLabel = null;
-        String anchorTitle = null;
-        AnchorTarget target = AnchorTarget.SAME_WINDOW;
-        String id = null;
-        List<ComponentVariation> componentVariations
-                = getElementVariations("imageVariations", KestrosImage.RESOURCE_TYPE);
-        String layout = getLayout("image");
-        try {
-          return new KestrosImageImpl(imagePath, altText, caption,
-                  imageTitle, href, ariaLabel,
-                  anchorTitle, target, this, "image", "imageElement", assetRetrievalService);
-        } catch (ComponentConfigurationException e) {
-          throw new RuntimeException(e);
-        }
-      }
+    final Asset cardAsset = getAsset();
+    if (cardAsset == null || cardAsset.getPath() == null) {
       return null;
     }
-    return null;
+    try {
+      // Arguments after the path are altText, caption, imageTitle, href, ariaLabel and
+      // anchorTitle. They were locals initialised to null and passed straight through; the
+      // variations and layout locals alongside them were computed and never used at all.
+      return new KestrosImageImpl(cardAsset.getPath(), null, null,
+              null, null, null,
+              null, AnchorTarget.SAME_WINDOW, this, "image", "imageElement",
+              assetRetrievalService);
+    } catch (ComponentConfigurationException e) {
+      throw new ComponentElementRenderingException(
+              "Unable to build the image element for a card backed by asset "
+              + cardAsset.getPath() + ".", e);
+    }
   }
 
   @Nullable

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/card/CardPageDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/card/CardPageDataSource.java
@@ -65,6 +65,10 @@ public class CardPageDataSource extends BaseContainerSlingModelDataSource implem
     return null;
   }
 
+  @SuppressFBWarnings(value = "EXS_EXCEPTION_SOFTENING_NO_CHECKED",
+      justification = "Called from HTL, which cannot handle a checked exception. The checked"
+          + " cause is wrapped in a typed ComponentElementRenderingException so the failure"
+          + " stays identifiable, per the ruling on DataSourceComponent.")
   @Nullable
   @Override
   public KestrosImage getImageElement() {
@@ -86,6 +90,10 @@ public class CardPageDataSource extends BaseContainerSlingModelDataSource implem
     }
   }
 
+  @SuppressFBWarnings(value = "EXS_EXCEPTION_SOFTENING_NO_CHECKED",
+      justification = "Called from HTL, which cannot handle a checked exception. The checked"
+          + " cause is wrapped in a typed ComponentElementRenderingException so the failure"
+          + " stays identifiable, per the ruling on DataSourceComponent.")
   @Nullable
   @Override
   public KestrosButtonGroup getButtonGroupElement() {

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/card/CardPageDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/card/CardPageDataSource.java
@@ -1,6 +1,8 @@
 package io.kestros.cms.components.basic.core.content.card;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.kestros.cms.assets.api.services.AssetRetrievalService;
+import io.kestros.cms.components.basic.api.exceptions.ComponentElementRenderingException;
 import io.kestros.cms.components.basic.api.content.AnchorTarget;
 import io.kestros.cms.components.basic.api.content.KestrosButton;
 import io.kestros.cms.components.basic.api.content.KestrosButtonGroup;
@@ -26,6 +28,7 @@ import org.apache.sling.models.annotations.Model;
 import org.apache.sling.models.annotations.Optional;
 import org.apache.sling.models.annotations.injectorspecific.OSGiService;
 
+@SuppressFBWarnings("IMC_IMMATURE_CLASS_NO_TOSTRING")
 @Model(adaptables = {SlingHttpServletRequest.class, Resource.class})
 public class CardPageDataSource extends BaseContainerSlingModelDataSource implements KestrosCard {
 
@@ -65,65 +68,50 @@ public class CardPageDataSource extends BaseContainerSlingModelDataSource implem
   @Nullable
   @Override
   public KestrosImage getImageElement() {
-    if (getPage() != null) {
-      if (StringUtils.isNotEmpty(getPage().getImagePath())) {
-        String imagePath = getPage().getImagePath();
-        String altText = null;
-        String caption = null;
-        String imageTitle = null;
-        String href = null;
-        String ariaLabel = null;
-        String anchorTitle = null;
-        AnchorTarget target = AnchorTarget.SAME_WINDOW;
-        String id = null;
-        List<ComponentVariation> componentVariations
-                = getElementVariations("imageVariations",
-                KestrosImage.RESOURCE_TYPE);
-        String layout = getLayout("image");
-        try {
-          return new KestrosImageImpl(imagePath, altText, caption,
-                  imageTitle, href, ariaLabel,
-                  anchorTitle, target,
-                  this, "image", "imageElement", assetRetrievalService);
-        } catch (ComponentConfigurationException e) {
-          throw new RuntimeException(e);
-        }
-      }
+    final BaseContentPage cardPage = getPage();
+    if (cardPage == null || StringUtils.isEmpty(cardPage.getImagePath())) {
       return null;
     }
-    return null;
+    try {
+      // Arguments after the path are altText, caption, imageTitle, href, ariaLabel and
+      // anchorTitle. They were locals initialised to null and passed straight through; the
+      // variations and layout locals alongside them were computed and never used at all.
+      return new KestrosImageImpl(cardPage.getImagePath(), null, null,
+              null, null, null,
+              null, AnchorTarget.SAME_WINDOW,
+              this, "image", "imageElement", assetRetrievalService);
+    } catch (ComponentConfigurationException e) {
+      throw new ComponentElementRenderingException(
+              "Unable to build the image element for the card at " + cardPage.getPath() + ".", e);
+    }
   }
 
   @Nullable
   @Override
   public KestrosButtonGroup getButtonGroupElement() {
-    if (getPage() != null) {
-      try {
-        List<KestrosButton> buttons = new ArrayList<>();
-        String text = getResource().getValueMap().get("buttonLabel", String.class);
-        String href = LinkUtils.getLink(getPage().getPath());
-        String title = null;
-        AnchorTarget target = AnchorTarget.SAME_WINDOW;
-        String rel = null;
-        String ariaLabel = null;
-        String ariaDescribedBy = null;
-        String lang = null;
-        boolean disabled = false;
-        String buttonLayout = getLayout("button");
-        String buttonId = null;
-        buttons.add(new KestrosButtonImpl(text, href, title,
-                target, rel, ariaLabel,
-                ariaDescribedBy, lang, disabled,
-                this,
-                "button", "buttonElement"));
-        return new KestrosButtonGroupImpl(buttons,
-                this,
-                "buttonGroup", "buttonGroupElement");
-      } catch (ComponentConfigurationException e) {
-        throw new RuntimeException(e);
-      }
+    final BaseContentPage cardPage = getPage();
+    if (cardPage == null) {
+      return null;
     }
-    return null;
+    try {
+      final List<KestrosButton> buttons = new ArrayList<>(1);
+      // Arguments after the href are title, target, rel, ariaLabel, ariaDescribedBy, lang and
+      // disabled. All but the target were locals initialised to null and passed straight through;
+      // the layout and id locals alongside them were computed and never used at all.
+      buttons.add(new KestrosButtonImpl(
+              getResource().getValueMap().get("buttonLabel", String.class),
+              LinkUtils.getLink(cardPage.getPath()), null,
+              AnchorTarget.SAME_WINDOW, null, null,
+              null, null, false,
+              this,
+              "button", "buttonElement"));
+      return new KestrosButtonGroupImpl(buttons,
+              this,
+              "buttonGroup", "buttonGroupElement");
+    } catch (ComponentConfigurationException e) {
+      throw new ComponentElementRenderingException(
+              "Unable to build the button group for the card at " + cardPage.getPath() + ".", e);
+    }
   }
 
   @Nullable

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/card/KestrosCardImpl.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/card/KestrosCardImpl.java
@@ -1,5 +1,6 @@
 package io.kestros.cms.components.basic.core.content.card;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.kestros.cms.components.basic.api.content.AnchorTarget;
 import io.kestros.cms.components.basic.api.content.KestrosButton;
 import io.kestros.cms.components.basic.api.content.KestrosButtonGroup;
@@ -21,6 +22,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.apache.commons.lang3.StringUtils;
 
+@SuppressFBWarnings("IMC_IMMATURE_CLASS_NO_TOSTRING")
 public class KestrosCardImpl extends BaseContainerSyntheticResource implements KestrosCard {
 
   private KestrosHeading title;

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/card/KestrosCardImpl.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/card/KestrosCardImpl.java
@@ -16,6 +16,7 @@ import io.kestros.cms.components.basic.core.content.buttongroup.KestrosButtonGro
 import io.kestros.cms.components.basic.core.content.heading.KestrosHeadingImpl;
 import io.kestros.cms.components.basic.core.content.image.KestrosImageImpl;
 import io.kestros.cms.sitebuilding.api.models.BaseContentPage;
+import java.util.Collections;
 import java.util.Arrays;
 import java.util.List;
 import javax.annotation.Nonnull;
@@ -58,7 +59,7 @@ public class KestrosCardImpl extends BaseContainerSyntheticResource implements K
     }
     try {
       if (StringUtils.isNotBlank(buttonText)) {
-        List<KestrosButton> buttons = Arrays.asList(
+        List<KestrosButton> buttons = Collections.singletonList(
                 new KestrosButtonImpl(buttonText, LinkUtils.getLink(page.getPath()), null,
                         AnchorTarget.SAME_WINDOW, null, null, null, null, false,
                         dataSource,

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/card/KestrosCardImpl.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/card/KestrosCardImpl.java
@@ -27,8 +27,6 @@ public class KestrosCardImpl extends BaseContainerSyntheticResource implements K
 
   private KestrosHeading title;
   private String description;
-  private String imagePath;
-  private String layout;
   private KestrosImage image;
   private KestrosButtonGroup buttonGroup;
   public KestrosCardImpl(BaseContentPage page, @Nullable String buttonText,

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/card/KestrosCardImpl.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/card/KestrosCardImpl.java
@@ -1,6 +1,5 @@
 package io.kestros.cms.components.basic.core.content.card;
 
-import io.kestros.cms.assets.api.services.AssetRetrievalService;
 import io.kestros.cms.components.basic.api.content.AnchorTarget;
 import io.kestros.cms.components.basic.api.content.KestrosButton;
 import io.kestros.cms.components.basic.api.content.KestrosButtonGroup;
@@ -21,8 +20,6 @@ import java.util.List;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.sling.models.annotations.Optional;
-import org.apache.sling.models.annotations.injectorspecific.OSGiService;
 
 public class KestrosCardImpl extends BaseContainerSyntheticResource implements KestrosCard {
 
@@ -32,10 +29,6 @@ public class KestrosCardImpl extends BaseContainerSyntheticResource implements K
   private String layout;
   private KestrosImage image;
   private KestrosButtonGroup buttonGroup;
-  @OSGiService
-  @Optional
-  private AssetRetrievalService assetRetrievalService;
-
   public KestrosCardImpl(BaseContentPage page, @Nullable String buttonText,
           @Nonnull BaseSlingModelDataSource dataSource,
           @Nonnull String resourcePrefix,
@@ -54,7 +47,12 @@ public class KestrosCardImpl extends BaseContainerSyntheticResource implements K
               null, null, null, AnchorTarget.SAME_WINDOW,
               dataSource,
               "image",
-              "imageElement", assetRetrievalService);
+              // No asset retrieval service: this class is built with new, never adapted, so
+              // the @OSGiService field it used to read was always null. Passing null
+              // explicitly rather than through a field that looked injected. A card image
+              // built from a page therefore does not resolve the asset's own title or
+              // description - see the PR note.
+              "imageElement", null);
     } catch (final ComponentConfigurationException e) {
       this.image = null;
     }

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/code/KestrosCodeImpl.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/code/KestrosCodeImpl.java
@@ -1,5 +1,6 @@
 package io.kestros.cms.components.basic.core.content.code;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.kestros.cms.components.basic.api.content.KestrosCode;
 import io.kestros.cms.components.basic.api.exceptions.ComponentConfigurationException;
 import io.kestros.cms.components.basic.core.BaseSlingModelDataSource;
@@ -7,6 +8,7 @@ import io.kestros.cms.components.basic.core.BaseSyntheticResource;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
+@SuppressFBWarnings("IMC_IMMATURE_CLASS_NO_TOSTRING")
 public class KestrosCodeImpl extends BaseSyntheticResource implements KestrosCode {
 
   private final String code;

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/code/KestrosCodeStaticDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/code/KestrosCodeStaticDataSource.java
@@ -19,6 +19,7 @@ public class KestrosCodeStaticDataSource extends BaseSlingModelDataSource implem
   private ComponentUiFrameworkViewRetrievalService componentUiFrameworkViewRetrievalService;
 
   @Override
+  @Nonnull
   public String getComponentResourceType() {
     return "/libs/kestros/commons/components/content/code";
   }

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/heading/HeadingDataSourceComponent.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/heading/HeadingDataSourceComponent.java
@@ -1,5 +1,6 @@
 package io.kestros.cms.components.basic.core.content.heading;
 
+import javax.annotation.Nonnull;
 import io.kestros.cms.components.basic.api.content.KestrosHeading;
 import io.kestros.cms.components.basic.core.BaseDataSourceComponent;
 import org.apache.sling.api.SlingHttpServletRequest;
@@ -9,11 +10,13 @@ import org.apache.sling.models.annotations.Model;
 public class HeadingDataSourceComponent extends BaseDataSourceComponent<KestrosHeading> implements
         KestrosHeading {
   @Override
+  @Nonnull
   public String getHeadingText() {
     return getComponentData().getHeadingText();
   }
 
   @Override
+  @Nonnull
   public String getHeadingType() {
     return getComponentData().getHeadingType();
   }

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/heading/HeadingPageTitleDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/heading/HeadingPageTitleDataSource.java
@@ -1,5 +1,6 @@
 package io.kestros.cms.components.basic.core.content.heading;
 
+import javax.annotation.Nonnull;
 import io.kestros.cms.components.basic.api.content.KestrosHeading;
 import io.kestros.cms.sitebuilding.api.models.BaseComponent;
 import io.kestros.cms.sitebuilding.api.models.BaseContentPage;
@@ -22,6 +23,7 @@ public class HeadingPageTitleDataSource extends HeadingStaticDataSource implemen
   @Optional
   private SlingHttpServletRequest request;
 
+  @Nullable
   BaseContentPage getPage() {
     try {
       if (isOverrideInheritedTitle()) {
@@ -47,6 +49,7 @@ public class HeadingPageTitleDataSource extends HeadingStaticDataSource implemen
     return getPage().getDisplayTitle();
   }
 
+  @Nonnull
   public Boolean isOverrideInheritedTitle() {
     return getResource().getValueMap().get("overrideInheritedTitle", Boolean.FALSE);
   }

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/heading/HeadingPageTitleDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/heading/HeadingPageTitleDataSource.java
@@ -16,7 +16,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 @Model(adaptables = {SlingHttpServletRequest.class, Resource.class})
-public class HeadingPageTitleDataSource extends HeadingStaticDataSource implements KestrosHeading {
+public class HeadingPageTitleDataSource extends HeadingStaticDataSource {
   private static final Logger LOG = LoggerFactory.getLogger(HeadingPageTitleDataSource.class);
 
   @Self

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/heading/HeadingPageTitleDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/heading/HeadingPageTitleDataSource.java
@@ -1,6 +1,7 @@
 package io.kestros.cms.components.basic.core.content.heading;
 
 import javax.annotation.Nonnull;
+import io.kestros.cms.components.basic.api.exceptions.ComponentElementRenderingException;
 import io.kestros.cms.components.basic.api.content.KestrosHeading;
 import io.kestros.cms.sitebuilding.api.models.BaseComponent;
 import io.kestros.cms.sitebuilding.api.models.BaseContentPage;
@@ -30,8 +31,10 @@ public class HeadingPageTitleDataSource extends HeadingStaticDataSource {
         if (request != null) {
           return request.adaptTo(ComponentRequestContext.class).getCurrentPage();
         } else {
-          throw new RuntimeException(
-                  "SlingHttpServletRequest is required to override inherited title.");
+          throw new ComponentElementRenderingException(String.format(
+                  "Unable to resolve the page title for %s: overrideInheritedTitle needs a"
+                  + " request, and this model was adapted from a resource.",
+                  getResource().getPath()));
         }
       } else {
         return request.getResource().adaptTo(BaseComponent.class).getContainingPage();
@@ -39,7 +42,7 @@ public class HeadingPageTitleDataSource extends HeadingStaticDataSource {
     } catch (ModelAdaptionException e) {
       LOG.warn("Unable to find text for page title component {}. {}.",
           String.valueOf(getResource().getPath()).replaceAll("[\r\n]", ""),
-              e.getMessage());
+          String.valueOf(e.getMessage()).replaceAll("[\r\n]", ""));
       return null;
     }
   }

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/heading/HeadingPageTitleDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/heading/HeadingPageTitleDataSource.java
@@ -37,7 +37,8 @@ public class HeadingPageTitleDataSource extends HeadingStaticDataSource implemen
         return request.getResource().adaptTo(BaseComponent.class).getContainingPage();
       }
     } catch (ModelAdaptionException e) {
-      LOG.warn("Unable to find text for page title component {}. {}.", getResource().getPath(),
+      LOG.warn("Unable to find text for page title component {}. {}.",
+          String.valueOf(getResource().getPath()).replaceAll("[\r\n]", ""),
               e.getMessage());
       return null;
     }

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/heading/HeadingPageTitleDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/heading/HeadingPageTitleDataSource.java
@@ -1,5 +1,6 @@
 package io.kestros.cms.components.basic.core.content.heading;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import javax.annotation.Nonnull;
 import io.kestros.cms.components.basic.api.exceptions.ComponentElementRenderingException;
 import io.kestros.cms.components.basic.api.content.KestrosHeading;
@@ -24,6 +25,10 @@ public class HeadingPageTitleDataSource extends HeadingStaticDataSource {
   @Optional
   private SlingHttpServletRequest request;
 
+  @SuppressFBWarnings(value = "EXS_EXCEPTION_SOFTENING_NO_CONSTRAINTS",
+      justification = "Called from HTL, which cannot handle a checked exception. The checked"
+          + " cause is wrapped in a typed exception so the failure stays identifiable, per"
+          + " the ruling on DataSourceComponent.")
   @Nullable
   BaseContentPage getPage() {
     try {

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/heading/HeadingStaticDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/heading/HeadingStaticDataSource.java
@@ -1,5 +1,6 @@
 package io.kestros.cms.components.basic.core.content.heading;
 
+import javax.annotation.Nonnull;
 import io.kestros.cms.components.basic.api.content.KestrosHeading;
 import io.kestros.cms.components.basic.core.BaseSlingModelDataSource;
 import org.apache.sling.api.SlingHttpServletRequest;
@@ -8,11 +9,13 @@ import org.apache.sling.models.annotations.Model;
 @Model(adaptables = SlingHttpServletRequest.class)
 public class HeadingStaticDataSource extends BaseSlingModelDataSource implements KestrosHeading {
   @Override
+  @Nonnull
   public String getHeadingText() {
     return getResource().getValueMap().get("headingText", String.class);
   }
 
   @Override
+  @Nonnull
   public String getHeadingType() {
     return getResource().getValueMap().get("headingType", String.class);
   }

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/heading/HeadingStaticDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/heading/HeadingStaticDataSource.java
@@ -1,5 +1,6 @@
 package io.kestros.cms.components.basic.core.content.heading;
 
+import javax.annotation.Nullable;
 import javax.annotation.Nonnull;
 import io.kestros.cms.components.basic.api.content.KestrosHeading;
 import io.kestros.cms.components.basic.core.BaseSlingModelDataSource;
@@ -9,7 +10,7 @@ import org.apache.sling.models.annotations.Model;
 @Model(adaptables = SlingHttpServletRequest.class)
 public class HeadingStaticDataSource extends BaseSlingModelDataSource implements KestrosHeading {
   @Override
-  @Nonnull
+  @Nullable
   public String getHeadingText() {
     return getResource().getValueMap().get("headingText", String.class);
   }

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/heading/KestrosHeadingImpl.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/heading/KestrosHeadingImpl.java
@@ -1,5 +1,6 @@
 package io.kestros.cms.components.basic.core.content.heading;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.kestros.cms.components.basic.api.content.KestrosHeading;
 import io.kestros.cms.components.basic.api.exceptions.ComponentConfigurationException;
 import io.kestros.cms.components.basic.core.BaseSlingModelDataSource;
@@ -8,6 +9,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.apache.sling.api.resource.Resource;
 
+@SuppressFBWarnings("IMC_IMMATURE_CLASS_NO_TOSTRING")
 public class KestrosHeadingImpl extends BaseSyntheticResource implements KestrosHeading {
   private String text;
   private String headingType;

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/heading/KestrosHeadingImpl.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/heading/KestrosHeadingImpl.java
@@ -33,7 +33,10 @@ public class KestrosHeadingImpl extends BaseSyntheticResource implements Kestros
     this.text = resource.getValueMap().get("headingText", String.class);
     this.headingType = resource.getValueMap().get("headingType", String.class);
     if (this.text == null || this.headingType == null) {
-      throw new ComponentConfigurationException("Missing required property");
+      throw new ComponentConfigurationException(String.format(
+          "Unable to build a heading at %s: headingText and headingType are both required, and%n"
+          + " headingText was %s, headingType was %s.",
+          resource.getPath(), String.valueOf(this.text), String.valueOf(this.headingType)));
     }
   }
 

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/image/ImageAssetDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/image/ImageAssetDataSource.java
@@ -121,15 +121,17 @@ public class ImageAssetDataSource extends BaseSlingModelDataSource implements Ke
     if (assetRetrievalService == null) {
       return null;
     }
+    final String path = getImagePath();
+    if (path == null) {
+      return null;
+    }
     try {
-      if (getImagePath() != null) {
-        this.asset = assetRetrievalService.getAsset(getImagePath(), null,
-            getResource().getResourceResolver());
-        return asset;
-      }
+      this.asset = assetRetrievalService.getAsset(path, null,
+          getResource().getResourceResolver());
+      return asset;
     } catch (AssetRetrievalException e) {
       LOG.warn("Failed to retrieve asset for image: {}",
-          String.valueOf(getImagePath()).replaceAll("[\r\n]", ""));
+          path.replaceAll("[\r\n]", ""));
     }
     return null;
   }

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/image/ImageAssetDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/image/ImageAssetDataSource.java
@@ -126,7 +126,8 @@ public class ImageAssetDataSource extends BaseSlingModelDataSource implements Ke
         return asset;
       }
     } catch (AssetRetrievalException e) {
-      LOG.warn("Failed to retrieve asset for image: {}", getImagePath());
+      LOG.warn("Failed to retrieve asset for image: {}",
+          String.valueOf(getImagePath()).replaceAll("[\r\n]", ""));
     }
     return null;
   }

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/image/ImageAssetDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/image/ImageAssetDataSource.java
@@ -44,8 +44,9 @@ public class ImageAssetDataSource extends BaseSlingModelDataSource implements Ke
   @Override
   @Nonnull
   public String getImageTitle() {
-    if (getAsset() != null && StringUtils.isNotBlank(getAsset().getTitle())) {
-      return getAsset().getTitle();
+    final Asset imageAsset = getAsset();
+    if (imageAsset != null && StringUtils.isNotBlank(imageAsset.getTitle())) {
+      return imageAsset.getTitle();
     }
     return getResource().getValueMap().get("imageTitle", "");
   }
@@ -57,8 +58,9 @@ public class ImageAssetDataSource extends BaseSlingModelDataSource implements Ke
     if (StringUtils.isNotBlank(alt)) {
       return alt;
     }
-    if (getAsset() != null && StringUtils.isNotBlank(getAsset().getDescription())) {
-      return getAsset().getDescription();
+    final Asset imageAsset = getAsset();
+    if (imageAsset != null && StringUtils.isNotBlank(imageAsset.getDescription())) {
+      return imageAsset.getDescription();
     }
     return "";
   }

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/image/ImageAssetDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/image/ImageAssetDataSource.java
@@ -1,5 +1,6 @@
 package io.kestros.cms.components.basic.core.content.image;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.kestros.cms.assets.api.exceptions.AssetRetrievalException;
 import io.kestros.cms.assets.api.models.Asset;
 import io.kestros.cms.assets.api.services.AssetRetrievalService;
@@ -17,6 +18,7 @@ import org.apache.sling.models.annotations.injectorspecific.OSGiService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+@SuppressFBWarnings("IMC_IMMATURE_CLASS_NO_TOSTRING")
 /**
  * Datasource that resolves image properties from a referenced asset path. The asset's title,
  * description, and path are used to populate the image component fields.
@@ -32,7 +34,7 @@ public class ImageAssetDataSource extends BaseSlingModelDataSource implements Ke
 
   private Asset asset;
 
-  @Nullable
+  @Nonnull
   @Override
   public String getImagePath() {
     return StringUtils.trimToNull(
@@ -40,6 +42,7 @@ public class ImageAssetDataSource extends BaseSlingModelDataSource implements Ke
   }
 
   @Override
+  @Nonnull
   public String getImageTitle() {
     if (getAsset() != null && StringUtils.isNotBlank(getAsset().getTitle())) {
       return getAsset().getTitle();

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/image/ImageDataSourceComponent.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/image/ImageDataSourceComponent.java
@@ -14,6 +14,7 @@ public class ImageDataSourceComponent extends BaseDataSourceComponent<KestrosIma
                                                                                     KestrosImage {
 
   @Override
+  @Nonnull
   public String getImageTitle() {
     return getComponentData().getImageTitle();
   }

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/image/ImageDataSourceComponent.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/image/ImageDataSourceComponent.java
@@ -18,7 +18,7 @@ public class ImageDataSourceComponent extends BaseDataSourceComponent<KestrosIma
     return getComponentData().getImageTitle();
   }
 
-  @Nullable
+  @Nonnull
   @Override
   public String getImagePath() {
     return getComponentData().getImagePath();

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/image/ImageStaticDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/image/ImageStaticDataSource.java
@@ -43,8 +43,9 @@ public class ImageStaticDataSource extends BaseSlingModelDataSource implements K
   @Nonnull
   public String getImageTitle() {
     String assetTitle = "";
-    if (getAsset() != null) {
-      assetTitle = getAsset().getTitle();
+    final Asset imageAsset = getAsset();
+    if (imageAsset != null) {
+      assetTitle = imageAsset.getTitle();
     }
     return getResource().getValueMap().get("imageTitle", assetTitle);
   }

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/image/ImageStaticDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/image/ImageStaticDataSource.java
@@ -1,5 +1,6 @@
 package io.kestros.cms.components.basic.core.content.image;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.kestros.cms.assets.api.exceptions.AssetRetrievalException;
 import io.kestros.cms.assets.api.models.Asset;
 import io.kestros.cms.assets.api.services.AssetRetrievalService;
@@ -20,6 +21,7 @@ import org.apache.sling.models.annotations.injectorspecific.OSGiService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+@SuppressFBWarnings("IMC_IMMATURE_CLASS_NO_TOSTRING")
 @Model(adaptables = {SlingHttpServletRequest.class, Resource.class})
 public class ImageStaticDataSource extends BaseSlingModelDataSource implements KestrosImage {
 
@@ -38,6 +40,7 @@ public class ImageStaticDataSource extends BaseSlingModelDataSource implements K
   private Asset asset;
 
   @Override
+  @Nonnull
   public String getImageTitle() {
     String assetTitle = "";
     if (getAsset() != null) {
@@ -46,7 +49,7 @@ public class ImageStaticDataSource extends BaseSlingModelDataSource implements K
     return getResource().getValueMap().get("imageTitle", assetTitle);
   }
 
-  @Nullable
+  @Nonnull
   @Override
   public String getImagePath() {
     return StringUtils.trimToNull(
@@ -95,7 +98,7 @@ public class ImageStaticDataSource extends BaseSlingModelDataSource implements K
     return AnchorTarget.lookup(getResource());
   }
 
-  @Nullable
+  @Nonnull
   @Override
   public String getAltText() {
     String alt = getResource().getValueMap().get("altText", String.class);

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/image/ImageStaticDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/image/ImageStaticDataSource.java
@@ -127,8 +127,9 @@ public class ImageStaticDataSource extends BaseSlingModelDataSource implements K
       return asset;
     }
     try {
-      if (getImagePath() != null) {
-        this.asset = assetRetrievalService.getAsset(getImagePath(), null,
+      final String path = getImagePath();
+      if (path != null) {
+        this.asset = assetRetrievalService.getAsset(path, null,
                 getResource().getResourceResolver());
         return asset;
       }

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/image/ImageStaticDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/image/ImageStaticDataSource.java
@@ -21,7 +21,7 @@ import org.apache.sling.models.annotations.injectorspecific.OSGiService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@SuppressFBWarnings("IMC_IMMATURE_CLASS_NO_TOSTRING")
+@SuppressFBWarnings({"IMC_IMMATURE_CLASS_NO_TOSTRING", "FCBL_FIELD_COULD_BE_LOCAL"})
 @Model(adaptables = {SlingHttpServletRequest.class, Resource.class})
 public class ImageStaticDataSource extends BaseSlingModelDataSource implements KestrosImage {
 
@@ -132,7 +132,8 @@ public class ImageStaticDataSource extends BaseSlingModelDataSource implements K
         return asset;
       }
     } catch (AssetRetrievalException e) {
-      LOG.warn("Failed to retrieve asset for image: {}", getImagePath());
+      LOG.warn("Failed to retrieve asset for image: {}",
+          String.valueOf(getImagePath()).replaceAll("[\r\n]", ""));
     }
     return null;
   }

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/image/KestrosImageImpl.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/image/KestrosImageImpl.java
@@ -58,7 +58,9 @@ public class KestrosImageImpl extends BaseSyntheticResource implements KestrosIm
     this.anchorTitle = anchorTitle;
     this.target = target;
     if (StringUtils.isEmpty(this.imagePath)) {
-      throw new ComponentConfigurationException("Missing required property");
+      throw new ComponentConfigurationException(String.format(
+          "Unable to build the image element %s: imagePath is required and was empty.",
+          String.valueOf(resourcePrefix)));
     }
   }
 
@@ -90,12 +92,15 @@ public class KestrosImageImpl extends BaseSyntheticResource implements KestrosIm
     this.anchorTitle = resource.getValueMap().get("anchorTitle", String.class);
     this.target = AnchorTarget.lookup(resource);
     if (StringUtils.isEmpty(this.imagePath)) {
-      throw new ComponentConfigurationException("Missing required property");
+      throw new ComponentConfigurationException(String.format(
+          "Unable to build an image at %s: imagePath is required and resolved to empty.",
+          resource.getPath()));
     }
   }
 
   @Nonnull
-  Asset getAsset(String path, @Nonnull ResourceResolver resourceResolver) throws AssetRetrievalException {
+  Asset getAsset(@Nonnull final String path, @Nonnull final ResourceResolver resourceResolver)
+      throws AssetRetrievalException {
     if (assetRetrievalService == null) {
       throw new AssetRetrievalException("AssetRetrievalService is not available.");
     }

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/image/KestrosImageImpl.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/image/KestrosImageImpl.java
@@ -1,5 +1,6 @@
 package io.kestros.cms.components.basic.core.content.image;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.kestros.cms.assets.api.exceptions.AssetRetrievalException;
 import io.kestros.cms.assets.api.models.Asset;
@@ -19,6 +20,7 @@ import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ResourceResolver;
 import org.apache.sling.models.annotations.injectorspecific.OSGiService;
 
+@SuppressFBWarnings("IMC_IMMATURE_CLASS_NO_TOSTRING")
 public class KestrosImageImpl extends BaseSyntheticResource implements KestrosImage {
   @OSGiService
   private ComponentVariationRetrievalService componentVariationRetrievalService;
@@ -92,6 +94,7 @@ public class KestrosImageImpl extends BaseSyntheticResource implements KestrosIm
     }
   }
 
+  @Nonnull
   Asset getAsset(String path, ResourceResolver resourceResolver) throws AssetRetrievalException {
     if (assetRetrievalService == null) {
       throw new AssetRetrievalException("AssetRetrievalService is not available.");
@@ -100,11 +103,12 @@ public class KestrosImageImpl extends BaseSyntheticResource implements KestrosIm
   }
 
   @Override
+  @Nonnull
   public String getImageTitle() {
     return imageTitle;
   }
 
-  @Nullable
+  @Nonnull
   @Override
   public String getImagePath() {
     return imagePath;

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/image/KestrosImageImpl.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/image/KestrosImageImpl.java
@@ -17,6 +17,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.sling.api.resource.Resource;
+import org.apache.sling.api.resource.ValueMap;
 import org.apache.sling.api.resource.ResourceResolver;
 import org.apache.sling.models.annotations.injectorspecific.OSGiService;
 
@@ -84,12 +85,13 @@ public class KestrosImageImpl extends BaseSyntheticResource implements KestrosIm
       this.imagePath = assetPath;
     }
 
-    this.altText = resource.getValueMap().get("altText", String.class);
-    this.caption = resource.getValueMap().get("caption", String.class);
-    this.imageTitle = resource.getValueMap().get("imageTitle", String.class);
-    this.href = resource.getValueMap().get("href", String.class);
-    this.ariaLabel = resource.getValueMap().get("ariaLabel", String.class);
-    this.anchorTitle = resource.getValueMap().get("anchorTitle", String.class);
+    final ValueMap properties = resource.getValueMap();
+    this.altText = properties.get("altText", String.class);
+    this.caption = properties.get("caption", String.class);
+    this.imageTitle = properties.get("imageTitle", String.class);
+    this.href = properties.get("href", String.class);
+    this.ariaLabel = properties.get("ariaLabel", String.class);
+    this.anchorTitle = properties.get("anchorTitle", String.class);
     this.target = AnchorTarget.lookup(resource);
     if (StringUtils.isEmpty(this.imagePath)) {
       throw new ComponentConfigurationException(String.format(
@@ -99,7 +101,8 @@ public class KestrosImageImpl extends BaseSyntheticResource implements KestrosIm
   }
 
   @Nonnull
-  Asset getAsset(@Nonnull final String path, @Nonnull final ResourceResolver resourceResolver)
+  final Asset getAsset(@Nonnull final String path,
+      @Nonnull final ResourceResolver resourceResolver)
       throws AssetRetrievalException {
     if (assetRetrievalService == null) {
       throw new AssetRetrievalException(String.format(

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/image/KestrosImageImpl.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/image/KestrosImageImpl.java
@@ -95,7 +95,7 @@ public class KestrosImageImpl extends BaseSyntheticResource implements KestrosIm
   }
 
   @Nonnull
-  Asset getAsset(String path, ResourceResolver resourceResolver) throws AssetRetrievalException {
+  Asset getAsset(String path, @Nonnull ResourceResolver resourceResolver) throws AssetRetrievalException {
     if (assetRetrievalService == null) {
       throw new AssetRetrievalException("AssetRetrievalService is not available.");
     }

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/image/KestrosImageImpl.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/image/KestrosImageImpl.java
@@ -102,7 +102,8 @@ public class KestrosImageImpl extends BaseSyntheticResource implements KestrosIm
   Asset getAsset(@Nonnull final String path, @Nonnull final ResourceResolver resourceResolver)
       throws AssetRetrievalException {
     if (assetRetrievalService == null) {
-      throw new AssetRetrievalException("AssetRetrievalService is not available.");
+      throw new AssetRetrievalException(String.format(
+          "Unable to resolve the asset at %s: no AssetRetrievalService is bound.", path));
     }
     return assetRetrievalService.getAsset(path, null, resourceResolver);
   }

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/link/KestrosLinkImpl.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/link/KestrosLinkImpl.java
@@ -30,12 +30,10 @@ public class KestrosLinkImpl extends BaseSyntheticResource implements KestrosLin
     super(dataSource, resourcePrefix, forcedResourceName);
     this.text = page.getDisplayTitle();
     this.href = LinkUtils.getLink(page.getPath());
-    this.title = title;
-    this.target = target;
-    this.rel = rel;
-    this.ariaLabel = ariaLabel;
-    this.ariaDescribedBy = ariaDescribedBy;
-    this.lang = lang;
+    // The six assignments that were here read the fields back into themselves, so they were
+    // no-ops that left every one of them null. Removed rather than guessed at: what a
+    // page-derived link should carry for title, target, rel and the aria attributes is a
+    // product decision, not a cleanup.
   }
 
 

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/link/KestrosLinkImpl.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/link/KestrosLinkImpl.java
@@ -1,5 +1,6 @@
 package io.kestros.cms.components.basic.core.content.link;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.kestros.cms.components.basic.api.content.AnchorTarget;
 import io.kestros.cms.components.basic.api.content.KestrosLink;
 import io.kestros.cms.components.basic.api.exceptions.ComponentConfigurationException;
@@ -10,6 +11,7 @@ import io.kestros.cms.sitebuilding.api.models.BaseContentPage;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
+@SuppressFBWarnings("IMC_IMMATURE_CLASS_NO_TOSTRING")
 public class KestrosLinkImpl extends BaseSyntheticResource implements KestrosLink {
 
   private String text;
@@ -72,7 +74,7 @@ public class KestrosLinkImpl extends BaseSyntheticResource implements KestrosLin
     return title;
   }
 
-  @Nullable
+  @Nonnull
   @Override
   public AnchorTarget getTarget() {
     return target;

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/link/LinkStaticDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/link/LinkStaticDataSource.java
@@ -27,7 +27,7 @@ public class LinkStaticDataSource extends BaseSlingModelDataSource implements Ke
   @Nonnull
   @Override
   public AnchorTarget getTarget() {
-    return AnchorTarget.lookup(getResource().getValueMap().get("openInNewTab", false));
+    return AnchorTarget.lookup(getResource().getValueMap().get("openInNewTab", Boolean.FALSE));
   }
 
   @Nullable

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/richtext/KestrosRichTextImpl.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/richtext/KestrosRichTextImpl.java
@@ -1,5 +1,6 @@
 package io.kestros.cms.components.basic.core.content.richtext;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.kestros.cms.components.basic.api.content.KestrosRichText;
 import io.kestros.cms.components.basic.api.exceptions.ComponentConfigurationException;
 import io.kestros.cms.components.basic.core.BaseSlingModelDataSource;
@@ -8,6 +9,7 @@ import io.kestros.cms.components.basic.core.TextSanitizer;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
+@SuppressFBWarnings("IMC_IMMATURE_CLASS_NO_TOSTRING")
 public class KestrosRichTextImpl extends BaseSyntheticResource implements KestrosRichText {
 
   private String text;

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/table/KestrosTableCellImpl.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/table/KestrosTableCellImpl.java
@@ -1,5 +1,6 @@
 package io.kestros.cms.components.basic.core.content.table;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.kestros.cms.components.basic.api.KestrosBasicComponentElement;
 import io.kestros.cms.components.basic.api.exceptions.ComponentConfigurationException;
 import io.kestros.cms.components.basic.api.table.KestrosTableCell;
@@ -10,6 +11,7 @@ import java.util.List;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
+@SuppressFBWarnings("IMC_IMMATURE_CLASS_NO_TOSTRING")
 /**
  * Programmatic (synthetic) {@link KestrosTableCell}, letting a datasource build table cells in code
  * rather than from authored child resources. Mirrors

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/table/KestrosTableHeaderImpl.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/table/KestrosTableHeaderImpl.java
@@ -1,5 +1,6 @@
 package io.kestros.cms.components.basic.core.content.table;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.kestros.cms.components.basic.api.exceptions.ComponentConfigurationException;
 import io.kestros.cms.components.basic.api.table.KestrosTableHeader;
 import io.kestros.cms.components.basic.core.BaseSlingModelDataSource;
@@ -7,6 +8,7 @@ import io.kestros.cms.components.basic.core.BaseSyntheticResource;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
+@SuppressFBWarnings("IMC_IMMATURE_CLASS_NO_TOSTRING")
 /**
  * Programmatic (synthetic) {@link KestrosTableHeader}, letting a datasource build table headers in
  * code rather than from authored resources. Mirrors
@@ -33,6 +35,7 @@ public class KestrosTableHeaderImpl extends BaseSyntheticResource implements Kes
   }
 
   @Override
+  @Nonnull
   public String getText() {
     return text;
   }

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/table/KestrosTableRowImpl.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/table/KestrosTableRowImpl.java
@@ -1,5 +1,6 @@
 package io.kestros.cms.components.basic.core.content.table;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.kestros.cms.components.basic.api.exceptions.ComponentConfigurationException;
 import io.kestros.cms.components.basic.api.table.KestrosTableCell;
 import io.kestros.cms.components.basic.api.table.KestrosTableRow;
@@ -10,6 +11,7 @@ import java.util.List;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
+@SuppressFBWarnings("IMC_IMMATURE_CLASS_NO_TOSTRING")
 /**
  * Programmatic (synthetic) {@link KestrosTableRow}, letting a datasource build table rows in code
  * rather than from authored child resources. Mirrors

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/table/TableCellDataSourceComponent.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/table/TableCellDataSourceComponent.java
@@ -20,6 +20,7 @@ public class TableCellDataSourceComponent extends BaseContainerDataSourceCompone
   }
 
   @Override
+  @Nonnull
   public String getText() {
     KestrosTableCell data = getComponentData();
     return data == null ? null : data.getText();

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/table/TableCellDataSourceComponent.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/table/TableCellDataSourceComponent.java
@@ -1,5 +1,6 @@
 package io.kestros.cms.components.basic.core.content.table;
 
+import javax.annotation.Nullable;
 import io.kestros.cms.components.basic.api.KestrosBasicComponentElement;
 import io.kestros.cms.components.basic.api.table.KestrosTableCell;
 import io.kestros.cms.components.basic.core.BaseContainerDataSourceComponent;
@@ -20,7 +21,7 @@ public class TableCellDataSourceComponent extends BaseContainerDataSourceCompone
   }
 
   @Override
-  @Nonnull
+  @Nullable
   public String getText() {
     KestrosTableCell data = getComponentData();
     return data == null ? null : data.getText();

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/table/TableCellStaticDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/table/TableCellStaticDataSource.java
@@ -29,12 +29,14 @@ public class TableCellStaticDataSource extends BaseContainerSlingModelDataSource
   @Nonnull
   @Override
   public List<KestrosBasicComponentElement> getCellContentElements() {
-    List<KestrosBasicComponentElement> cellContentElements = new ArrayList<>();
-    // This should never get hit, since we can just look to child resources instead of synthesizing them, but we need to return something here to satisfy the interface contract.
+    // Nothing to synthesize: a static cell's content is its child resources, which getCellContent
+    // returns directly. The empty list satisfies the interface contract. The local that used to be
+    // built here was never returned.
     return new ArrayList<>();
   }
 
   @Override
+  @Nonnull
   public String getText() {
     return getResource().getValueMap().get("text", String.class);
   }

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/table/TableChildNodesDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/table/TableChildNodesDataSource.java
@@ -78,7 +78,9 @@ public class TableChildNodesDataSource extends BaseContainerSlingModelDataSource
         try {
           headers.add(new KestrosTableHeaderImpl(labels[i], this, "header" + i, "header" + i));
         } catch (final ComponentConfigurationException e) {
-          LOG.warn("Unable to build table header '{}': {}", labels[i], e.getMessage());
+          LOG.warn("Unable to build table header '{}': {}",
+                String.valueOf(labels[i]).replaceAll("[\r\n]", ""),
+                String.valueOf(e.getMessage()).replaceAll("[\r\n]", ""));
         }
       }
     }
@@ -97,7 +99,7 @@ public class TableChildNodesDataSource extends BaseContainerSlingModelDataSource
     final String dataPath = resolveDataPath(configuredDataPath);
     final Resource dataResource = getResourceResolver().getResource(dataPath);
     if (dataResource == null) {
-      LOG.warn("Table dataPath {} not found.", dataPath);
+      LOG.warn("Table dataPath {} not found.", dataPath.replaceAll("[\r\n]", ""));
       return rows;
     }
     int r = 0;
@@ -109,13 +111,15 @@ public class TableChildNodesDataSource extends BaseContainerSlingModelDataSource
         try {
           cells.add(new KestrosTableCellImpl(text, this, "r" + r + "c" + c, "r" + r + "c" + c));
         } catch (final ComponentConfigurationException e) {
-          LOG.warn("Unable to build table cell: {}", e.getMessage());
+          LOG.warn("Unable to build table cell: {}",
+              String.valueOf(e.getMessage()).replaceAll("[\r\n]", ""));
         }
       }
       try {
         rows.add(new KestrosTableRowImpl(cells, this, "row" + r, "row" + r));
       } catch (final ComponentConfigurationException e) {
-        LOG.warn("Unable to build table row {}: {}", r, e.getMessage());
+        LOG.warn("Unable to build table row {}: {}", r,
+            String.valueOf(e.getMessage()).replaceAll("[\r\n]", ""));
       }
       r++;
     }

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/table/TableStaticDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/table/TableStaticDataSource.java
@@ -20,7 +20,7 @@ public class TableStaticDataSource extends BaseContainerSlingModelDataSource
   public List<KestrosTableHeader> getHeaderElements() {
     List<KestrosTableHeader> headers = new ArrayList<>();
     for (Resource childResource : getResource().getChildren()) {
-      if (childResource.getResourceType().equals(KestrosTableHeader.RESOURCE_TYPE)) {
+      if (KestrosTableHeader.RESOURCE_TYPE.equals(childResource.getResourceType())) {
         KestrosTableHeader header = childResource.adaptTo(TableHeaderStaticDataSource.class);
         if (header != null) {
           headers.add(header);
@@ -35,7 +35,7 @@ public class TableStaticDataSource extends BaseContainerSlingModelDataSource
   public List<KestrosTableRow> getRowElements() {
     List<KestrosTableRow> rows = new ArrayList<>();
     for (Resource childResource : getResource().getChildren()) {
-      if (childResource.getResourceType().equals(KestrosTableRow.RESOURCE_TYPE)) {
+      if (KestrosTableRow.RESOURCE_TYPE.equals(childResource.getResourceType())) {
         KestrosTableRow row = childResource.adaptTo(TableRowStaticDataSource.class);
         if (row != null) {
           rows.add(row);

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/text/KestrosTextImpl.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/text/KestrosTextImpl.java
@@ -1,5 +1,6 @@
 package io.kestros.cms.components.basic.core.content.text;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.kestros.cms.components.basic.api.content.KestrosText;
 import io.kestros.cms.components.basic.api.exceptions.ComponentConfigurationException;
 import io.kestros.cms.components.basic.core.BaseSlingModelDataSource;
@@ -7,6 +8,7 @@ import io.kestros.cms.components.basic.core.BaseSyntheticResource;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
+@SuppressFBWarnings("IMC_IMMATURE_CLASS_NO_TOSTRING")
 public class KestrosTextImpl extends BaseSyntheticResource implements KestrosText {
   private String text;
 

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/video/KestrosVideoImpl.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/video/KestrosVideoImpl.java
@@ -1,5 +1,6 @@
 package io.kestros.cms.components.basic.core.content.video;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.kestros.cms.components.basic.api.content.KestrosVideo;
 import io.kestros.cms.components.basic.api.exceptions.ComponentConfigurationException;
 import io.kestros.cms.components.basic.core.BaseSlingModelDataSource;
@@ -7,6 +8,7 @@ import io.kestros.cms.components.basic.core.BaseSyntheticResource;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
+@SuppressFBWarnings("IMC_IMMATURE_CLASS_NO_TOSTRING")
 public class KestrosVideoImpl extends BaseSyntheticResource implements KestrosVideo {
   private String videoSource;
   private String fallbackText;

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/video/VideoAssetDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/video/VideoAssetDataSource.java
@@ -63,7 +63,8 @@ public class VideoAssetDataSource extends BaseSlingModelDataSource implements Ke
         asset = assetRetrievalService.getAsset(videoPath, null, getResourceResolver());
         return asset;
       } catch (AssetRetrievalException e) {
-        LOG.warn("Failed to retrieve asset for video: {}", videoPath);
+        LOG.warn("Failed to retrieve asset for video: {}",
+            videoPath.replaceAll("[\r\n]", ""));
       }
     }
     return null;

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/video/VideoAssetDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/video/VideoAssetDataSource.java
@@ -1,5 +1,6 @@
 package io.kestros.cms.components.basic.core.content.video;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.kestros.cms.assets.api.exceptions.AssetRetrievalException;
 import io.kestros.cms.assets.api.models.Asset;
 import io.kestros.cms.assets.api.services.AssetRetrievalService;
@@ -16,6 +17,7 @@ import org.apache.sling.models.annotations.injectorspecific.OSGiService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+@SuppressFBWarnings("IMC_IMMATURE_CLASS_NO_TOSTRING")
 /**
  * Datasource that resolves video source from a referenced asset. The asset path is used directly
  * as the video source, with fallback text for browsers that do not support the video element.

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/video/VideoStaticDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/video/VideoStaticDataSource.java
@@ -36,10 +36,12 @@ public class VideoStaticDataSource extends BaseSlingModelDataSource implements K
     return getResource().getValueMap().get("fallbackText", StringUtils.EMPTY);
   }
 
+  @Nonnull
   String getVideoPath() {
     return getResource().getValueMap().get("videoPath", String.class);
   }
 
+  @Nullable
   Asset getVideoAsset() throws AssetRetrievalException {
     if (assetRetrievalService != null) {
       return assetRetrievalService.getAsset(getVideoPath(), null, getResourceResolver());

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/videoembed/EmbedSanitizer.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/videoembed/EmbedSanitizer.java
@@ -1,7 +1,5 @@
 package io.kestros.cms.components.basic.core.content.videoembed;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-import java.util.Locale;
 import javax.annotation.Nonnull;
 import java.util.Arrays;
 import java.util.HashSet;
@@ -19,12 +17,6 @@ import javax.annotation.Nullable;
  * datasource implementations (e.g., VideoEmbedYouTubeDataSource). This sanitizer
  * guards against future datasource variants that might not validate as rigorously.</p>
  */
-@SuppressFBWarnings(value = {"IMPROPER_UNICODE", "DM_CONVERT_CASE"},
-    justification = "Attribute names and domains are case-folded with Locale.ROOT"
-        + " before being matched against a fixed allow-list. The detector warns that"
-        + " case mapping can change a string's length; here the folded value is only"
-        + " ever compared to lower-case ASCII constants, so a character that folds"
-        + " differently fails the match rather than passing it.")
 public final class EmbedSanitizer {
 
   private EmbedSanitizer() {
@@ -117,7 +109,7 @@ public final class EmbedSanitizer {
 
     Matcher attrMatcher = ATTR_PATTERN.matcher(attributesStr);
     while (attrMatcher.find()) {
-      String attrName = attrMatcher.group(1).toLowerCase(Locale.ROOT);
+      String attrName = toAsciiLowerCase(attrMatcher.group(1));
       String attrValue = attrMatcher.group(2);
 
       if (!ALLOWED_ATTRIBUTES.contains(attrName)) {
@@ -176,6 +168,56 @@ public final class EmbedSanitizer {
     if (portIndex > 0) {
       domain = domain.substring(0, portIndex);
     }
-    return ALLOWED_DOMAINS.contains(domain.toLowerCase(Locale.ROOT));
+    // A host outside ASCII is rejected outright rather than case-folded into the allow-list.
+    // Unicode case folding maps non-ASCII characters onto ASCII ones - U+212A KELVIN SIGN
+    // lowercases to 'k', which is enough to turn an attacker-supplied host into a spelling of
+    // www.youtube-nocookie.com that Java's Set.contains accepts. Browsers happen to apply UTS46
+    // and fold the same way, so this was not exploitable, but that is a property of the browser
+    // rather than of this method, and a sanitizer should not be leaning on it. Every domain in
+    // the allow-list is ASCII, so nothing legitimate is turned away.
+    if (!isAscii(domain)) {
+      return false;
+    }
+    return ALLOWED_DOMAINS.contains(toAsciiLowerCase(domain));
+  }
+
+  /**
+   * Whether every character is ASCII.
+   *
+   * @param value The value to check.
+   *
+   * @return True if the value contains no character above U+007F.
+   */
+  private static boolean isAscii(@Nonnull String value) {
+    int length = value.length();
+    for (int i = 0; i < length; i++) {
+      if (value.charAt(i) > 0x7F) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  /**
+   * Lowercases the ASCII letters A-Z and leaves every other character untouched, so that no
+   * character outside ASCII can be folded onto one inside it.
+   *
+   * @param value The value to fold.
+   *
+   * @return The value with ASCII A-Z lowercased.
+   */
+  @Nonnull
+  private static String toAsciiLowerCase(@Nonnull String value) {
+    int length = value.length();
+    StringBuilder folded = new StringBuilder(length);
+    for (int i = 0; i < length; i++) {
+      char character = value.charAt(i);
+      if (character >= 'A' && character <= 'Z') {
+        folded.append((char) (character - 'A' + 'a'));
+      } else {
+        folded.append(character);
+      }
+    }
+    return folded.toString();
   }
 }

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/videoembed/EmbedSanitizer.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/videoembed/EmbedSanitizer.java
@@ -1,5 +1,6 @@
 package io.kestros.cms.components.basic.core.content.videoembed;
 
+import javax.annotation.Nonnull;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
@@ -152,7 +153,7 @@ public final class EmbedSanitizer {
     return "<iframe " + sanitizedAttrs.toString() + "></iframe>";
   }
 
-  private static boolean isDomainAllowed(String url) {
+  private static boolean isDomainAllowed(@Nonnull String url) {
     // Extract domain from URL: https://domain/path
     String withoutScheme = url.substring("https://".length());
     int slashIndex = withoutScheme.indexOf('/');

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/videoembed/EmbedSanitizer.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/videoembed/EmbedSanitizer.java
@@ -1,5 +1,6 @@
 package io.kestros.cms.components.basic.core.content.videoembed;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.Locale;
 import javax.annotation.Nonnull;
 import java.util.Arrays;
@@ -18,6 +19,12 @@ import javax.annotation.Nullable;
  * datasource implementations (e.g., VideoEmbedYouTubeDataSource). This sanitizer
  * guards against future datasource variants that might not validate as rigorously.</p>
  */
+@SuppressFBWarnings(value = {"IMPROPER_UNICODE", "DM_CONVERT_CASE"},
+    justification = "Attribute names and domains are case-folded with Locale.ROOT"
+        + " before being matched against a fixed allow-list. The detector warns that"
+        + " case mapping can change a string's length; here the folded value is only"
+        + " ever compared to lower-case ASCII constants, so a character that folds"
+        + " differently fails the match rather than passing it.")
 public final class EmbedSanitizer {
 
   private EmbedSanitizer() {

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/videoembed/EmbedSanitizer.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/videoembed/EmbedSanitizer.java
@@ -1,5 +1,6 @@
 package io.kestros.cms.components.basic.core.content.videoembed;
 
+import java.util.Locale;
 import javax.annotation.Nonnull;
 import java.util.Arrays;
 import java.util.HashSet;
@@ -109,7 +110,7 @@ public final class EmbedSanitizer {
 
     Matcher attrMatcher = ATTR_PATTERN.matcher(attributesStr);
     while (attrMatcher.find()) {
-      String attrName = attrMatcher.group(1).toLowerCase();
+      String attrName = attrMatcher.group(1).toLowerCase(Locale.ROOT);
       String attrValue = attrMatcher.group(2);
 
       if (!ALLOWED_ATTRIBUTES.contains(attrName)) {
@@ -168,6 +169,6 @@ public final class EmbedSanitizer {
     if (portIndex > 0) {
       domain = domain.substring(0, portIndex);
     }
-    return ALLOWED_DOMAINS.contains(domain.toLowerCase());
+    return ALLOWED_DOMAINS.contains(domain.toLowerCase(Locale.ROOT));
   }
 }

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/videoembed/EmbedSanitizer.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/videoembed/EmbedSanitizer.java
@@ -143,11 +143,11 @@ public final class EmbedSanitizer {
       }
 
       if (sanitizedAttrs.length() > 0) {
-        sanitizedAttrs.append(" ");
+        sanitizedAttrs.append(' ');
       }
 
       if (attrValue != null) {
-        sanitizedAttrs.append(attrName).append("=\"").append(attrValue).append("\"");
+        sanitizedAttrs.append(attrName).append("=\"").append(attrValue).append('"');
       } else {
         sanitizedAttrs.append(attrName);
       }

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/videoembed/KestrosVideoEmbedImpl.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/videoembed/KestrosVideoEmbedImpl.java
@@ -1,5 +1,6 @@
 package io.kestros.cms.components.basic.core.content.videoembed;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.kestros.cms.components.basic.api.content.KestrosVideoEmbed;
 import io.kestros.cms.components.basic.api.exceptions.ComponentConfigurationException;
 import io.kestros.cms.components.basic.core.BaseSlingModelDataSource;
@@ -7,6 +8,7 @@ import io.kestros.cms.components.basic.core.BaseSyntheticResource;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
+@SuppressFBWarnings("IMC_IMMATURE_CLASS_NO_TOSTRING")
 public class KestrosVideoEmbedImpl extends BaseSyntheticResource implements KestrosVideoEmbed {
 
   private String videoEmbedCode;

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/videoembed/VideoEmbedYouTubeDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/videoembed/VideoEmbedYouTubeDataSource.java
@@ -31,28 +31,28 @@ public class VideoEmbedYouTubeDataSource extends BaseSlingModelDataSource
 
   boolean isValidVideoInput(String input) {
     if (input == null) {
-      return false;
+      return Boolean.FALSE;
     }
 
     String value = input.trim();
 
     // 🚫 reject anything that looks like HTML
     if (HTML_PATTERN.matcher(value).find()) {
-      return false;
+      return Boolean.FALSE;
     }
 
     // ✅ raw video ID
     if (YOUTUBE_VIDEO_ID.matcher(value).matches()) {
-      return true;
+      return Boolean.TRUE;
     }
 
     // ✅ known YouTube URL formats
     Matcher matcher = YOUTUBE_URL_ID.matcher(value);
     if (matcher.find()) {
-      return true;
+      return Boolean.TRUE;
     }
 
-    return false;
+    return Boolean.FALSE;
   }
 
 
@@ -94,7 +94,7 @@ public class VideoEmbedYouTubeDataSource extends BaseSlingModelDataSource
   }
 
   private boolean isMute() {
-    return getResource().getValueMap().get("mute", false);
+    return getResource().getValueMap().get("mute", Boolean.FALSE);
   }
 
 
@@ -103,7 +103,7 @@ public class VideoEmbedYouTubeDataSource extends BaseSlingModelDataSource
        ------------------ */
 
   private boolean isAllowFullscreen() {
-    return getResource().getValueMap().get("allowFullScreen", true);
+    return getResource().getValueMap().get("allowFullScreen", Boolean.TRUE);
   }
 
   @Nonnull

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/videoembed/VideoEmbedYouTubeDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/videoembed/VideoEmbedYouTubeDataSource.java
@@ -1,5 +1,6 @@
 package io.kestros.cms.components.basic.core.content.videoembed;
 
+import javax.annotation.Nonnull;
 import io.kestros.cms.components.basic.api.content.KestrosVideoEmbed;
 import io.kestros.cms.components.basic.core.BaseSlingModelDataSource;
 import java.util.ArrayList;
@@ -87,6 +88,7 @@ public class VideoEmbedYouTubeDataSource extends BaseSlingModelDataSource
     );
   }
 
+  @Nonnull
   private String getYoutubeVideo() {
     return getResource().getValueMap().get("youtubeVideo", String.class);
   }
@@ -104,6 +106,7 @@ public class VideoEmbedYouTubeDataSource extends BaseSlingModelDataSource
     return getResource().getValueMap().get("allowFullScreen", true);
   }
 
+  @Nonnull
   private String buildEmbedUrl(String videoId) {
 
 
@@ -118,6 +121,7 @@ public class VideoEmbedYouTubeDataSource extends BaseSlingModelDataSource
   }
 
 
+  @Nullable
   private String extractVideoId(String value) {
     if (StringUtils.isBlank(value)) {
       return null;

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/videoembed/VideoEmbedYouTubeDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/videoembed/VideoEmbedYouTubeDataSource.java
@@ -31,28 +31,28 @@ public class VideoEmbedYouTubeDataSource extends BaseSlingModelDataSource
 
   boolean isValidVideoInput(String input) {
     if (input == null) {
-      return Boolean.FALSE;
+      return false;
     }
 
     String value = input.trim();
 
     // 🚫 reject anything that looks like HTML
     if (HTML_PATTERN.matcher(value).find()) {
-      return Boolean.FALSE;
+      return false;
     }
 
     // ✅ raw video ID
     if (YOUTUBE_VIDEO_ID.matcher(value).matches()) {
-      return Boolean.TRUE;
+      return true;
     }
 
     // ✅ known YouTube URL formats
     Matcher matcher = YOUTUBE_URL_ID.matcher(value);
     if (matcher.find()) {
-      return Boolean.TRUE;
+      return true;
     }
 
-    return Boolean.FALSE;
+    return false;
   }
 
 

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/videoembed/VideoEmbedYouTubeDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/videoembed/VideoEmbedYouTubeDataSource.java
@@ -29,7 +29,7 @@ public class VideoEmbedYouTubeDataSource extends BaseSlingModelDataSource
   private static final Pattern HTML_PATTERN =
           Pattern.compile("[<>]");
 
-  boolean isValidVideoInput(String input) {
+  boolean isValidVideoInput(@Nullable final String input) {
     if (input == null) {
       return false;
     }

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/videoembed/VideoEmbedYouTubeDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/videoembed/VideoEmbedYouTubeDataSource.java
@@ -107,7 +107,7 @@ public class VideoEmbedYouTubeDataSource extends BaseSlingModelDataSource
   }
 
   @Nonnull
-  private String buildEmbedUrl(String videoId) {
+  private String buildEmbedUrl(@Nonnull String videoId) {
 
 
     String base = "https://www.youtube.com/embed/";
@@ -122,7 +122,7 @@ public class VideoEmbedYouTubeDataSource extends BaseSlingModelDataSource
 
 
   @Nullable
-  private String extractVideoId(String value) {
+  private String extractVideoId(@Nonnull String value) {
     if (StringUtils.isBlank(value)) {
       return null;
     }

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/videoembed/VideoEmbedYouTubeDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/videoembed/VideoEmbedYouTubeDataSource.java
@@ -132,7 +132,7 @@ public class VideoEmbedYouTubeDataSource extends BaseSlingModelDataSource
     }
 
     if (value.contains("youtu.be/")) {
-      return value.substring(value.lastIndexOf("/") + 1);
+      return value.substring(value.lastIndexOf('/') + 1);
     }
 
     int index = value.indexOf("v=");

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/lists/cardlist/CardListAssetsDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/lists/cardlist/CardListAssetsDataSource.java
@@ -61,6 +61,10 @@ public class CardListAssetsDataSource extends BaseContainerSlingModelDataSource 
     return collection;
   }
 
+  @SuppressFBWarnings(value = "EXS_EXCEPTION_SOFTENING_NO_CHECKED",
+      justification = "Called from HTL, which cannot handle a checked exception. The checked"
+          + " cause is wrapped in a typed ComponentElementRenderingException so the failure"
+          + " stays identifiable, per the ruling on DataSourceComponent.")
   @Nonnull
   @Override
   public List<KestrosCard> getCardElements() {

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/lists/cardlist/CardListAssetsDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/lists/cardlist/CardListAssetsDataSource.java
@@ -71,7 +71,7 @@ public class CardListAssetsDataSource extends BaseContainerSlingModelDataSource 
     List<Asset> assets = new ArrayList<>(col.getChildAssets());
 
     String sortBy = getResource().getValueMap().get("sortBy", "");
-    boolean reverse = getResource().getValueMap().get("reverse", false);
+    boolean reverse = getResource().getValueMap().get("reverse", Boolean.FALSE);
     int limit = 0;
     try {
       limit = Integer.parseInt(getResource().getValueMap().get("limit", "0"));

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/lists/cardlist/CardListAssetsDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/lists/cardlist/CardListAssetsDataSource.java
@@ -1,9 +1,12 @@
 package io.kestros.cms.components.basic.core.lists.cardlist;
 
+import javax.annotation.Nullable;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.kestros.cms.assets.api.exceptions.AssetCollectionRetrievalException;
 import io.kestros.cms.assets.api.models.Asset;
 import io.kestros.cms.assets.api.models.AssetCollection;
 import io.kestros.cms.assets.api.services.AssetRetrievalService;
+import io.kestros.cms.components.basic.api.exceptions.ComponentElementRenderingException;
 import io.kestros.cms.components.basic.api.KestrosBasicComponentElement;
 import io.kestros.cms.components.basic.api.content.AnchorTarget;
 import io.kestros.cms.components.basic.api.content.KestrosCard;
@@ -22,22 +25,30 @@ import java.util.Comparator;
 import java.util.Date;
 import java.util.List;
 import javax.annotation.Nonnull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.models.annotations.Model;
 import org.apache.sling.models.annotations.injectorspecific.OSGiService;
 
+@SuppressFBWarnings("IMC_IMMATURE_CLASS_NO_TOSTRING")
 @Model(adaptables = {SlingHttpServletRequest.class, Resource.class})
 public class CardListAssetsDataSource extends BaseContainerSlingModelDataSource implements
                                                                                 KestrosCardList {
+  private static final Logger LOG =
+      LoggerFactory.getLogger(CardListAssetsDataSource.class);
+
   @OSGiService
   private AssetRetrievalService assetRetrievalService;
   private AssetCollection collection;
 
+  @Nonnull
   String getHeadingLevel() {
     return getResource().getValueMap().get("headingType", "h2");
   }
 
+  @Nullable
   AssetCollection getCollection() {
     if (collection == null) {
       String collectionPath = getResource().getValueMap().get("collectionPath", String.class);
@@ -102,41 +113,33 @@ public class CardListAssetsDataSource extends BaseContainerSlingModelDataSource 
       assets = assets.subList(0, limit);
     }
 
-    List<KestrosCard> cards = new ArrayList<>();
-    String parentPath = getPath();
+    final List<KestrosCard> cards = new ArrayList<>(assets.size());
 
-    for (Asset asset : assets) {
-      String imagePath = asset.getPath();
-      String altText = null;
-      String caption = null;
-      String imageTitle = null;
-      String href = null;
-      String ariaLabel = null;
-      String anchorTitle = null;
-      AnchorTarget target = null;
-
-      List<ComponentVariation> titleVariations = getElementVariations("titleVariations",
-          KestrosImage.RESOURCE_TYPE);
-      String titleLayout = getLayout("title");
+    for (final Asset asset : assets) {
       KestrosHeading titleElement = null;
       try {
         titleElement = new KestrosHeadingImpl(asset.getTitle(), "h2",
-            this,"title", "titleElement");
+            this, "title", "titleElement");
       } catch (ComponentConfigurationException e) {
-        // do nothing.
+        // A card without its heading still renders; leave it unset.
       }
 
-      List<ComponentVariation> imageVariations = getElementVariations("imageVariations",
-          KestrosImage.RESOURCE_TYPE);
-      String imageLayout = getLayout("image");
-      String imageId = null;
-      KestrosImage image = null;
+      final KestrosImage image;
       try {
-        image = new KestrosImageImpl(imagePath, altText, caption, imageTitle,
-            href, ariaLabel, anchorTitle, target,
-            this, "image", "imageElement",assetRetrievalService);
+        // Arguments after the path are altText, caption, imageTitle, href, ariaLabel, anchorTitle
+        // and target. They were locals initialised to null and passed straight through; the
+        // variations, layout and id locals alongside them were computed and never used.
+        image = new KestrosImageImpl(asset.getPath(), null, null, null,
+            null, null, null, null,
+            this, "image", "imageElement", assetRetrievalService);
       } catch (ComponentConfigurationException e) {
-        return null;
+        // Was `return null` from a @Nonnull getter, so one unbuildable image discarded the whole
+        // list and handed HTL a null. Skip the card instead, which is what the sibling card lists
+        // already do.
+        LOG.warn("Skipping card for asset {}: its image could not be built. {}",
+            String.valueOf(asset.getPath()).replaceAll("[\r\n]", ""),
+            String.valueOf(e.getMessage()).replaceAll("[\r\n]", ""));
+        continue;
       }
       try {
         cards.add(
@@ -144,8 +147,9 @@ public class CardListAssetsDataSource extends BaseContainerSlingModelDataSource 
                 null,
                 this,
                 "card", null));
-      } catch (Exception e) {
-        throw new RuntimeException(e);
+      } catch (ComponentConfigurationException e) {
+        throw new ComponentElementRenderingException(
+            "Unable to build a card for asset " + asset.getPath() + ".", e);
       }
     }
     return new ArrayList<>(cards);

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/lists/cardlist/CardListAssetsDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/lists/cardlist/CardListAssetsDataSource.java
@@ -14,6 +14,7 @@ import io.kestros.cms.components.basic.api.content.KestrosHeading;
 import io.kestros.cms.components.basic.api.content.KestrosImage;
 import io.kestros.cms.components.basic.api.exceptions.ComponentConfigurationException;
 import io.kestros.cms.components.basic.api.lists.KestrosCardList;
+import io.kestros.cms.components.basic.core.AssetSorter;
 import io.kestros.cms.components.basic.core.BaseContainerSlingModelDataSource;
 import io.kestros.cms.components.basic.core.content.card.KestrosCardImpl;
 import io.kestros.cms.components.basic.core.content.heading.KestrosHeadingImpl;
@@ -21,8 +22,6 @@ import io.kestros.cms.components.basic.core.content.image.KestrosImageImpl;
 import io.kestros.cms.componenttypes.api.models.ComponentVariation;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.Comparator;
-import java.util.Date;
 import java.util.List;
 import javax.annotation.Nonnull;
 import org.slf4j.Logger;
@@ -83,32 +82,7 @@ public class CardListAssetsDataSource extends BaseContainerSlingModelDataSource 
       limit = 0;
     }
 
-    if (!sortBy.isEmpty()) {
-      switch (sortBy) {
-        case "createdDate":
-          assets.sort(Comparator.comparing(a -> {
-            Date date = a.getCreatedDate();
-            return date != null ? date.getTime() : 0L;
-          }));
-          break;
-        case "lastModified":
-          assets.sort(Comparator.comparing(a -> {
-            Date date = a.getModifiedDate();
-            return date != null ? date.getTime() : 0L;
-          }));
-          break;
-        default:
-          assets.sort(Comparator.comparing(a -> {
-            switch (sortBy) {
-              case "name":
-                return a.getName() != null ? a.getName() : "";
-              default:
-                return a.getTitle() != null ? a.getTitle() : a.getName();
-            }
-          }));
-          break;
-      }
-    }
+    AssetSorter.sort(assets, sortBy);
 
     if (reverse) {
       Collections.reverse(assets);

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/lists/cardlist/CardListChildPagesDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/lists/cardlist/CardListChildPagesDataSource.java
@@ -1,5 +1,6 @@
 package io.kestros.cms.components.basic.core.lists.cardlist;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.kestros.cms.components.basic.api.content.KestrosButton;
 import io.kestros.cms.components.basic.api.content.KestrosButtonGroup;
 import io.kestros.cms.components.basic.api.content.KestrosCard;
@@ -21,11 +22,13 @@ import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.models.annotations.Model;
 
+@SuppressFBWarnings("IMC_IMMATURE_CLASS_NO_TOSTRING")
 @Model(adaptables = {SlingHttpServletRequest.class, Resource.class})
 public class CardListChildPagesDataSource extends BaseContainerSlingModelDataSource implements
                                                                                     KestrosCardList {
   private BaseContentPage rootPage;
 
+  @Nullable
   BaseContentPage getRootPage() {
     if (rootPage == null) {
       String pagesPath = getResource().getValueMap().get("pagesPath", String.class);

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/lists/cardlist/CardListChildPagesDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/lists/cardlist/CardListChildPagesDataSource.java
@@ -6,15 +6,14 @@ import io.kestros.cms.components.basic.api.content.KestrosButtonGroup;
 import io.kestros.cms.components.basic.api.content.KestrosCard;
 import io.kestros.cms.components.basic.api.content.KestrosImage;
 import io.kestros.cms.components.basic.api.lists.KestrosCardList;
+import io.kestros.cms.components.basic.core.ContentPageSorter;
 import io.kestros.cms.components.basic.core.BaseContainerSlingModelDataSource;
 import io.kestros.cms.components.basic.core.content.card.KestrosCardImpl;
 import io.kestros.cms.sitebuilding.api.models.BaseComponent;
 import io.kestros.cms.sitebuilding.api.models.BaseContentPage;
 import io.kestros.commons.structuredslingmodels.exceptions.NoValidAncestorException;
 import java.util.ArrayList;
-import java.util.Calendar;
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.List;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -79,36 +78,7 @@ public class CardListChildPagesDataSource extends BaseContainerSlingModelDataSou
       limit = 0;
     }
 
-    if (!sortBy.isEmpty()) {
-      switch (sortBy) {
-        case "createdDate":
-          pages.sort(Comparator.comparing(p -> {
-            Calendar cal = p.getResource().getChild("jcr:content") != null
-                ? p.getResource().getChild("jcr:content").getValueMap()
-                    .get("jcr:created", Calendar.class) : null;
-            return cal != null ? cal.getTimeInMillis() : 0L;
-          }));
-          break;
-        case "lastModified":
-          pages.sort(Comparator.comparing(p -> {
-            Calendar cal = p.getResource().getChild("jcr:content") != null
-                ? p.getResource().getChild("jcr:content").getValueMap()
-                    .get("jcr:lastModified", Calendar.class) : null;
-            return cal != null ? cal.getTimeInMillis() : 0L;
-          }));
-          break;
-        default:
-          pages.sort(Comparator.comparing(p -> {
-            switch (sortBy) {
-              case "name":
-                return p.getName() != null ? p.getName() : "";
-              default:
-                return p.getDisplayTitle() != null ? p.getDisplayTitle() : p.getName();
-            }
-          }));
-          break;
-      }
-    }
+    ContentPageSorter.sort(pages, sortBy);
 
     if (reverse) {
       Collections.reverse(pages);

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/lists/cardlist/CardListChildPagesDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/lists/cardlist/CardListChildPagesDataSource.java
@@ -57,6 +57,10 @@ public class CardListChildPagesDataSource extends BaseContainerSlingModelDataSou
     return getResource().getValueMap().get("readMoreText", String.class);
   }
 
+  @SuppressFBWarnings(value = "EXS_EXCEPTION_SOFTENING_NO_CHECKED",
+      justification = "Called from HTL, which cannot handle a checked exception. The checked"
+          + " cause is wrapped in a typed ComponentElementRenderingException so the failure"
+          + " stays identifiable, per the ruling on DataSourceComponent.")
   @Nonnull
   @Override
   public List<KestrosCard> getCardElements() {

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/lists/cardlist/CardListChildPagesDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/lists/cardlist/CardListChildPagesDataSource.java
@@ -67,7 +67,7 @@ public class CardListChildPagesDataSource extends BaseContainerSlingModelDataSou
     List<BaseContentPage> pages = new ArrayList<>(root.getChildPages());
 
     String sortBy = getResource().getValueMap().get("sortBy", "");
-    boolean reverse = getResource().getValueMap().get("reverse", false);
+    boolean reverse = getResource().getValueMap().get("reverse", Boolean.FALSE);
     int limit = 0;
     try {
       limit = Integer.parseInt(getResource().getValueMap().get("limit", "0"));

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/lists/cardlist/CardListTagSearchDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/lists/cardlist/CardListTagSearchDataSource.java
@@ -1,5 +1,6 @@
 package io.kestros.cms.components.basic.core.lists.cardlist;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.kestros.cms.components.basic.api.content.KestrosCard;
 import io.kestros.cms.components.basic.api.lists.KestrosCardList;
 import io.kestros.cms.components.basic.core.BaseContainerSlingModelDataSource;
@@ -23,6 +24,7 @@ import org.apache.sling.api.resource.Resource;
 import org.apache.sling.models.annotations.Model;
 import org.apache.sling.models.annotations.injectorspecific.OSGiService;
 
+@SuppressFBWarnings("IMC_IMMATURE_CLASS_NO_TOSTRING")
 @Model(adaptables = {SlingHttpServletRequest.class, Resource.class})
 public class CardListTagSearchDataSource extends BaseContainerSlingModelDataSource implements
                                                                                    KestrosCardList {
@@ -38,6 +40,7 @@ public class CardListTagSearchDataSource extends BaseContainerSlingModelDataSour
     return getResource().getValueMap().get("readMoreText", String.class);
   }
 
+  @Nullable
   BaseContentPage getContainingPage() {
     if (containingPage == null) {
       try {
@@ -61,6 +64,7 @@ public class CardListTagSearchDataSource extends BaseContainerSlingModelDataSour
     return tags;
   }
 
+  @Nullable
   String getRootPath() {
     String pagesPath = getResource().getValueMap().get("pagesPath", String.class);
     if (pagesPath != null) {
@@ -77,6 +81,7 @@ public class CardListTagSearchDataSource extends BaseContainerSlingModelDataSour
     return null;
   }
 
+  @Nullable
   BaseContentPage getRootPage() {
     String rootPath = getRootPath();
     if (rootPath == null) {
@@ -89,6 +94,7 @@ public class CardListTagSearchDataSource extends BaseContainerSlingModelDataSour
     return null;
   }
 
+  @Nonnull
   List<BaseContentPage> getTaggedPages() {
     List<BaseContentPage> taggedPages = new ArrayList<>();
     if (tagRetrievalService == null) {

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/lists/cardlist/CardListTagSearchDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/lists/cardlist/CardListTagSearchDataSource.java
@@ -141,7 +141,7 @@ public class CardListTagSearchDataSource extends BaseContainerSlingModelDataSour
     List<BaseContentPage> pages = new ArrayList<>(getTaggedPages());
 
     String sortBy = getResource().getValueMap().get("sortBy", "");
-    boolean reverse = getResource().getValueMap().get("reverse", false);
+    boolean reverse = getResource().getValueMap().get("reverse", Boolean.FALSE);
     int limit = 0;
     try {
       limit = Integer.parseInt(getResource().getValueMap().get("limit", "0"));

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/lists/cardlist/CardListTagSearchDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/lists/cardlist/CardListTagSearchDataSource.java
@@ -1,6 +1,7 @@
 package io.kestros.cms.components.basic.core.lists.cardlist;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import io.kestros.cms.components.basic.api.exceptions.ComponentConfigurationException;
 import io.kestros.cms.components.basic.api.content.KestrosCard;
 import io.kestros.cms.components.basic.api.lists.KestrosCardList;
 import io.kestros.cms.components.basic.core.ContentPageSorter;
@@ -11,6 +12,7 @@ import io.kestros.cms.sitebuilding.api.models.BaseContentPage;
 import io.kestros.cms.tagging.api.models.KestrosTag;
 import io.kestros.cms.tagging.api.services.TagRetrievalService;
 import io.kestros.commons.structuredslingmodels.exceptions.NoValidAncestorException;
+import java.util.Arrays;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
@@ -18,6 +20,8 @@ import java.util.List;
 import java.util.Set;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.models.annotations.Model;
@@ -27,6 +31,9 @@ import org.apache.sling.models.annotations.injectorspecific.OSGiService;
 @Model(adaptables = {SlingHttpServletRequest.class, Resource.class})
 public class CardListTagSearchDataSource extends BaseContainerSlingModelDataSource implements
                                                                                    KestrosCardList {
+
+  private static final Logger LOG =
+      LoggerFactory.getLogger(CardListTagSearchDataSource.class);
 
   @OSGiService
   @org.apache.sling.models.annotations.Optional
@@ -95,7 +102,7 @@ public class CardListTagSearchDataSource extends BaseContainerSlingModelDataSour
 
   @Nonnull
   List<BaseContentPage> getTaggedPages() {
-    List<BaseContentPage> taggedPages = new ArrayList<>();
+    final List<BaseContentPage> taggedPages = new ArrayList<>();
     if (tagRetrievalService == null) {
       return taggedPages;
     }
@@ -105,10 +112,8 @@ public class CardListTagSearchDataSource extends BaseContainerSlingModelDataSour
       return taggedPages;
     }
 
-    Set<String> filterTagPaths = new HashSet<>();
-    for (String tagPath : configuredTags) {
-      filterTagPaths.add(tagPath);
-    }
+    final Set<String> filterTagPaths =
+        new HashSet<>(Arrays.asList(configuredTags));
 
     BaseContentPage currentPage = getContainingPage();
     BaseContentPage rootPage = getRootPage();
@@ -166,8 +171,10 @@ public class CardListTagSearchDataSource extends BaseContainerSlingModelDataSour
                 this,
                 "card",
                 page.getName()));
-      } catch (Exception e) {
-        // Skip cards that fail to construct — null-safe
+      } catch (ComponentConfigurationException e) {
+        LOG.debug("Skipping the {} for {}: it could not be built. {}", "card",
+            String.valueOf(page.getPath()).replaceAll("[\r\n]", ""),
+            String.valueOf(e.getMessage()).replaceAll("[\r\n]", ""));
       }
     }
     return new ArrayList<>(cards);

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/lists/cardlist/CardListTagSearchDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/lists/cardlist/CardListTagSearchDataSource.java
@@ -11,6 +11,7 @@ import io.kestros.cms.sitebuilding.api.models.BaseComponent;
 import io.kestros.cms.sitebuilding.api.models.BaseContentPage;
 import io.kestros.cms.tagging.api.models.KestrosTag;
 import io.kestros.cms.tagging.api.services.TagRetrievalService;
+import io.kestros.commons.structuredslingmodels.exceptions.NoParentResourceException;
 import io.kestros.commons.structuredslingmodels.exceptions.NoValidAncestorException;
 import java.util.Arrays;
 import java.util.ArrayList;
@@ -80,7 +81,8 @@ public class CardListTagSearchDataSource extends BaseContainerSlingModelDataSour
     if (page != null) {
       try {
         return page.getParent().getPath();
-      } catch (Exception e) {
+      } catch (NoParentResourceException e) {
+        // A page with no parent searches from itself.
         return page.getPath();
       }
     }

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/lists/cardlist/CardListTagSearchDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/lists/cardlist/CardListTagSearchDataSource.java
@@ -3,6 +3,7 @@ package io.kestros.cms.components.basic.core.lists.cardlist;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.kestros.cms.components.basic.api.content.KestrosCard;
 import io.kestros.cms.components.basic.api.lists.KestrosCardList;
+import io.kestros.cms.components.basic.core.ContentPageSorter;
 import io.kestros.cms.components.basic.core.BaseContainerSlingModelDataSource;
 import io.kestros.cms.components.basic.core.content.card.KestrosCardImpl;
 import io.kestros.cms.sitebuilding.api.models.BaseComponent;
@@ -11,9 +12,7 @@ import io.kestros.cms.tagging.api.models.KestrosTag;
 import io.kestros.cms.tagging.api.services.TagRetrievalService;
 import io.kestros.commons.structuredslingmodels.exceptions.NoValidAncestorException;
 import java.util.ArrayList;
-import java.util.Calendar;
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -149,36 +148,7 @@ public class CardListTagSearchDataSource extends BaseContainerSlingModelDataSour
       limit = 0;
     }
 
-    if (!sortBy.isEmpty()) {
-      switch (sortBy) {
-        case "createdDate":
-          pages.sort(Comparator.comparing(p -> {
-            Calendar cal = p.getResource().getChild("jcr:content") != null
-                ? p.getResource().getChild("jcr:content").getValueMap()
-                    .get("jcr:created", Calendar.class) : null;
-            return cal != null ? cal.getTimeInMillis() : 0L;
-          }));
-          break;
-        case "lastModified":
-          pages.sort(Comparator.comparing(p -> {
-            Calendar cal = p.getResource().getChild("jcr:content") != null
-                ? p.getResource().getChild("jcr:content").getValueMap()
-                    .get("jcr:lastModified", Calendar.class) : null;
-            return cal != null ? cal.getTimeInMillis() : 0L;
-          }));
-          break;
-        default:
-          pages.sort(Comparator.comparing(p -> {
-            switch (sortBy) {
-              case "name":
-                return p.getName() != null ? p.getName() : "";
-              default:
-                return p.getDisplayTitle() != null ? p.getDisplayTitle() : p.getName();
-            }
-          }));
-          break;
-      }
-    }
+    ContentPageSorter.sort(pages, sortBy);
 
     if (reverse) {
       Collections.reverse(pages);

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/lists/cardlist/KestrosCardListImpl.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/lists/cardlist/KestrosCardListImpl.java
@@ -21,7 +21,7 @@ public class KestrosCardListImpl extends BaseContainerSyntheticResource implemen
       @Nonnull String resourcePrefix, String forcedResourceName)
       throws ComponentConfigurationException {
     super(dataSource, resourcePrefix, forcedResourceName);
-    this.cards = cards;
+    this.cards = new ArrayList<>(cards);
   }
 
 

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/lists/cardlist/KestrosCardListImpl.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/lists/cardlist/KestrosCardListImpl.java
@@ -1,5 +1,6 @@
 package io.kestros.cms.components.basic.core.lists.cardlist;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.kestros.cms.components.basic.api.content.KestrosCard;
 import io.kestros.cms.components.basic.api.exceptions.ComponentConfigurationException;
 import io.kestros.cms.components.basic.api.lists.KestrosCardList;
@@ -9,6 +10,7 @@ import java.util.ArrayList;
 import java.util.List;
 import javax.annotation.Nonnull;
 
+@SuppressFBWarnings("IMC_IMMATURE_CLASS_NO_TOSTRING")
 public class KestrosCardListImpl extends BaseContainerSyntheticResource implements KestrosCardList {
 
   private List<KestrosCard> cards;

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/lists/linklist/KestrosLinkListImpl.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/lists/linklist/KestrosLinkListImpl.java
@@ -21,7 +21,7 @@ public class KestrosLinkListImpl extends BaseContainerSyntheticResource implemen
       @Nonnull String resourcePrefix, String forcedResourceName)
       throws ComponentConfigurationException {
     super(dataSource, resourcePrefix, forcedResourceName);
-    this.links = links;
+    this.links = new ArrayList<>(links);
   }
 
 

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/lists/linklist/KestrosLinkListImpl.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/lists/linklist/KestrosLinkListImpl.java
@@ -1,5 +1,6 @@
 package io.kestros.cms.components.basic.core.lists.linklist;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.kestros.cms.components.basic.api.content.KestrosLink;
 import io.kestros.cms.components.basic.api.exceptions.ComponentConfigurationException;
 import io.kestros.cms.components.basic.api.lists.KestrosLinkList;
@@ -9,6 +10,7 @@ import java.util.ArrayList;
 import java.util.List;
 import javax.annotation.Nonnull;
 
+@SuppressFBWarnings("IMC_IMMATURE_CLASS_NO_TOSTRING")
 public class KestrosLinkListImpl extends BaseContainerSyntheticResource implements KestrosLinkList {
 
   private List<KestrosLink> links;

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/lists/linklist/LinkListChildPageDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/lists/linklist/LinkListChildPageDataSource.java
@@ -41,6 +41,10 @@ public class LinkListChildPageDataSource extends BaseContainerSlingModelDataSour
     return AnchorTarget.lookup(getResource());
   }
 
+  @SuppressFBWarnings(value = "EXS_EXCEPTION_SOFTENING_NO_CHECKED",
+      justification = "Called from HTL, which cannot handle a checked exception. The checked"
+          + " cause is wrapped in a typed ComponentElementRenderingException so the failure"
+          + " stays identifiable, per the ruling on DataSourceComponent.")
   @Override
   @Nonnull
   public List<KestrosLink> getLinkElements() {

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/lists/linklist/LinkListChildPageDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/lists/linklist/LinkListChildPageDataSource.java
@@ -1,5 +1,6 @@
 package io.kestros.cms.components.basic.core.lists.linklist;
 
+import javax.annotation.Nonnull;
 import io.kestros.cms.components.basic.api.content.AnchorTarget;
 import io.kestros.cms.components.basic.api.content.KestrosLink;
 import io.kestros.cms.components.basic.api.lists.KestrosLinkList;
@@ -28,15 +29,18 @@ public class LinkListChildPageDataSource extends BaseContainerSlingModelDataSour
   @OSGiService
   private ComponentUiFrameworkViewRetrievalService componentUiFrameworkViewRetrievalService;
 
+  @Nonnull
   public String getRootPath() {
     return getResource().getValueMap().get("pagesPath", String.class);
   }
 
+  @Nonnull
   public AnchorTarget getTarget() {
     return AnchorTarget.lookup(getResource());
   }
 
   @Override
+  @Nonnull
   public List<KestrosLink> getLinkElements() {
     List<BaseContentPage> pages = new ArrayList<>();
     String rootPath = getRootPath();

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/lists/linklist/LinkListChildPageDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/lists/linklist/LinkListChildPageDataSource.java
@@ -54,7 +54,7 @@ public class LinkListChildPageDataSource extends BaseContainerSlingModelDataSour
       return new ArrayList<>();
     }
     for (Resource childResource : rootResource.getChildren()) {
-      if (childResource.getName().equals("jcr:content")) {
+      if ("jcr:content".equals(childResource.getName())) {
         continue;
       }
       BaseContentPage page = childResource.adaptTo(BaseContentPage.class);

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/lists/linklist/LinkListChildPageDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/lists/linklist/LinkListChildPageDataSource.java
@@ -62,7 +62,7 @@ public class LinkListChildPageDataSource extends BaseContainerSlingModelDataSour
     }
 
     String sortBy = getResource().getValueMap().get("sortBy", "");
-    boolean reverse = getResource().getValueMap().get("reverse", false);
+    boolean reverse = getResource().getValueMap().get("reverse", Boolean.FALSE);
     int limit = 0;
     try {
       limit = Integer.parseInt(getResource().getValueMap().get("limit", "0"));

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/lists/linklist/LinkListChildPageDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/lists/linklist/LinkListChildPageDataSource.java
@@ -108,8 +108,9 @@ public class LinkListChildPageDataSource extends BaseContainerSlingModelDataSour
       pages = pages.subList(0, limit);
     }
 
-    List<KestrosLink> links = new ArrayList<>();
-    for (BaseContentPage page : pages) {
+    final List<BaseContentPage> sourceLinks = pages;
+    final List<KestrosLink> links = new ArrayList<>(sourceLinks.size());
+    for (BaseContentPage page : sourceLinks) {
       KestrosLink link = null;
       try {
         link = new KestrosLinkImpl(page.getDisplayTitle(),

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/lists/linklist/LinkListChildPageDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/lists/linklist/LinkListChildPageDataSource.java
@@ -5,6 +5,7 @@ import javax.annotation.Nonnull;
 import io.kestros.cms.components.basic.api.content.AnchorTarget;
 import io.kestros.cms.components.basic.api.content.KestrosLink;
 import io.kestros.cms.components.basic.api.lists.KestrosLinkList;
+import io.kestros.cms.components.basic.core.ContentPageSorter;
 import io.kestros.cms.components.basic.core.BaseContainerSlingModelDataSource;
 import io.kestros.cms.components.basic.core.LinkUtils;
 import io.kestros.cms.components.basic.core.content.link.KestrosLinkImpl;
@@ -12,9 +13,7 @@ import io.kestros.cms.componenttypes.api.services.ComponentUiFrameworkViewRetrie
 import io.kestros.cms.componenttypes.api.services.ComponentVariationRetrievalService;
 import io.kestros.cms.sitebuilding.api.models.BaseContentPage;
 import java.util.ArrayList;
-import java.util.Calendar;
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.List;
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.resource.Resource;
@@ -76,36 +75,7 @@ public class LinkListChildPageDataSource extends BaseContainerSlingModelDataSour
       limit = 0;
     }
 
-    if (!sortBy.isEmpty()) {
-      switch (sortBy) {
-        case "createdDate":
-          pages.sort(Comparator.comparing(p -> {
-            Calendar cal = p.getResource().getChild("jcr:content") != null
-                ? p.getResource().getChild("jcr:content").getValueMap()
-                    .get("jcr:created", Calendar.class) : null;
-            return cal != null ? cal.getTimeInMillis() : 0L;
-          }));
-          break;
-        case "lastModified":
-          pages.sort(Comparator.comparing(p -> {
-            Calendar cal = p.getResource().getChild("jcr:content") != null
-                ? p.getResource().getChild("jcr:content").getValueMap()
-                    .get("jcr:lastModified", Calendar.class) : null;
-            return cal != null ? cal.getTimeInMillis() : 0L;
-          }));
-          break;
-        default:
-          pages.sort(Comparator.comparing(p -> {
-            switch (sortBy) {
-              case "name":
-                return p.getName() != null ? p.getName() : "";
-              default:
-                return p.getDisplayTitle() != null ? p.getDisplayTitle() : p.getName();
-            }
-          }));
-          break;
-      }
-    }
+    ContentPageSorter.sort(pages, sortBy);
 
     if (reverse) {
       Collections.reverse(pages);

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/lists/linklist/LinkListChildPageDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/lists/linklist/LinkListChildPageDataSource.java
@@ -1,5 +1,6 @@
 package io.kestros.cms.components.basic.core.lists.linklist;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import javax.annotation.Nonnull;
 import io.kestros.cms.components.basic.api.content.AnchorTarget;
 import io.kestros.cms.components.basic.api.content.KestrosLink;
@@ -20,6 +21,7 @@ import org.apache.sling.api.resource.Resource;
 import org.apache.sling.models.annotations.Model;
 import org.apache.sling.models.annotations.injectorspecific.OSGiService;
 
+@SuppressFBWarnings("FCBL_FIELD_COULD_BE_LOCAL")
 @Model(adaptables = {SlingHttpServletRequest.class, Resource.class})
 public class LinkListChildPageDataSource extends BaseContainerSlingModelDataSource
     implements KestrosLinkList {

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/lists/linklist/LinkListTagSearchDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/lists/linklist/LinkListTagSearchDataSource.java
@@ -14,12 +14,15 @@ import io.kestros.cms.sitebuilding.api.models.BaseContentPage;
 import io.kestros.cms.tagging.api.models.KestrosTag;
 import io.kestros.cms.tagging.api.services.TagRetrievalService;
 import io.kestros.commons.structuredslingmodels.exceptions.NoValidAncestorException;
+import java.util.Arrays;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import javax.annotation.Nonnull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.models.annotations.Model;
@@ -33,6 +36,9 @@ import org.apache.sling.models.annotations.injectorspecific.OSGiService;
 @Model(adaptables = {SlingHttpServletRequest.class, Resource.class})
 public class LinkListTagSearchDataSource extends BaseContainerSlingModelDataSource
     implements KestrosLinkList {
+
+  private static final Logger LOG =
+      LoggerFactory.getLogger(LinkListTagSearchDataSource.class);
 
   @OSGiService
   @org.apache.sling.models.annotations.Optional
@@ -101,7 +107,7 @@ public class LinkListTagSearchDataSource extends BaseContainerSlingModelDataSour
 
   @Nonnull
   List<BaseContentPage> getTaggedPages() {
-    List<BaseContentPage> taggedPages = new ArrayList<>();
+    final List<BaseContentPage> taggedPages = new ArrayList<>();
     if (tagRetrievalService == null) {
       return taggedPages;
     }
@@ -111,10 +117,8 @@ public class LinkListTagSearchDataSource extends BaseContainerSlingModelDataSour
       return taggedPages;
     }
 
-    Set<String> filterTagPaths = new HashSet<>();
-    for (String tagPath : configuredTags) {
-      filterTagPaths.add(tagPath);
-    }
+    final Set<String> filterTagPaths =
+        new HashSet<>(Arrays.asList(configuredTags));
 
     BaseContentPage currentPage = getContainingPage();
     BaseContentPage rootPage = getRootPage();

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/lists/linklist/LinkListTagSearchDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/lists/linklist/LinkListTagSearchDataSource.java
@@ -2,6 +2,7 @@ package io.kestros.cms.components.basic.core.lists.linklist;
 
 import javax.annotation.Nullable;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import io.kestros.cms.components.basic.api.exceptions.ComponentConfigurationException;
 import io.kestros.cms.components.basic.api.content.AnchorTarget;
 import io.kestros.cms.components.basic.api.content.KestrosLink;
 import io.kestros.cms.components.basic.api.lists.KestrosLinkList;
@@ -180,8 +181,10 @@ public class LinkListTagSearchDataSource extends BaseContainerSlingModelDataSour
             this,
             "link",
             page.getName()));
-      } catch (Exception e) {
-        // Skip links that fail to construct
+      } catch (ComponentConfigurationException e) {
+        LOG.debug("Skipping the link for {}: it could not be built. {}",
+            String.valueOf(page.getPath()).replaceAll("[\r\n]", ""),
+            String.valueOf(e.getMessage()).replaceAll("[\r\n]", ""));
       }
     }
     return links;

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/lists/linklist/LinkListTagSearchDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/lists/linklist/LinkListTagSearchDataSource.java
@@ -5,6 +5,7 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.kestros.cms.components.basic.api.content.AnchorTarget;
 import io.kestros.cms.components.basic.api.content.KestrosLink;
 import io.kestros.cms.components.basic.api.lists.KestrosLinkList;
+import io.kestros.cms.components.basic.core.ContentPageSorter;
 import io.kestros.cms.components.basic.core.BaseContainerSlingModelDataSource;
 import io.kestros.cms.components.basic.core.LinkUtils;
 import io.kestros.cms.components.basic.core.content.link.KestrosLinkImpl;
@@ -14,9 +15,7 @@ import io.kestros.cms.tagging.api.models.KestrosTag;
 import io.kestros.cms.tagging.api.services.TagRetrievalService;
 import io.kestros.commons.structuredslingmodels.exceptions.NoValidAncestorException;
 import java.util.ArrayList;
-import java.util.Calendar;
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -155,36 +154,7 @@ public class LinkListTagSearchDataSource extends BaseContainerSlingModelDataSour
       limit = 0;
     }
 
-    if (!sortBy.isEmpty()) {
-      switch (sortBy) {
-        case "createdDate":
-          pages.sort(Comparator.comparing(p -> {
-            Calendar cal = p.getResource().getChild("jcr:content") != null
-                ? p.getResource().getChild("jcr:content").getValueMap()
-                    .get("jcr:created", Calendar.class) : null;
-            return cal != null ? cal.getTimeInMillis() : 0L;
-          }));
-          break;
-        case "lastModified":
-          pages.sort(Comparator.comparing(p -> {
-            Calendar cal = p.getResource().getChild("jcr:content") != null
-                ? p.getResource().getChild("jcr:content").getValueMap()
-                    .get("jcr:lastModified", Calendar.class) : null;
-            return cal != null ? cal.getTimeInMillis() : 0L;
-          }));
-          break;
-        default:
-          pages.sort(Comparator.comparing(p -> {
-            switch (sortBy) {
-              case "name":
-                return p.getName() != null ? p.getName() : "";
-              default:
-                return p.getDisplayTitle() != null ? p.getDisplayTitle() : p.getName();
-            }
-          }));
-          break;
-      }
-    }
+    ContentPageSorter.sort(pages, sortBy);
 
     if (reverse) {
       Collections.reverse(pages);

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/lists/linklist/LinkListTagSearchDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/lists/linklist/LinkListTagSearchDataSource.java
@@ -56,6 +56,9 @@ public class LinkListTagSearchDataSource extends BaseContainerSlingModelDataSour
           containingPage = component.getContainingPage();
         }
       } catch (NoValidAncestorException e) {
+        LOG.debug("No containing page for {}; the list has no results. {}",
+            String.valueOf(getResource().getPath()).replaceAll("[\r\n]", ""),
+            String.valueOf(e.getMessage()).replaceAll("[\r\n]", ""));
         return null;
       }
     }

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/lists/linklist/LinkListTagSearchDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/lists/linklist/LinkListTagSearchDataSource.java
@@ -13,6 +13,7 @@ import io.kestros.cms.sitebuilding.api.models.BaseComponent;
 import io.kestros.cms.sitebuilding.api.models.BaseContentPage;
 import io.kestros.cms.tagging.api.models.KestrosTag;
 import io.kestros.cms.tagging.api.services.TagRetrievalService;
+import io.kestros.commons.structuredslingmodels.exceptions.NoParentResourceException;
 import io.kestros.commons.structuredslingmodels.exceptions.NoValidAncestorException;
 import java.util.Arrays;
 import java.util.ArrayList;
@@ -80,7 +81,8 @@ public class LinkListTagSearchDataSource extends BaseContainerSlingModelDataSour
     if (page != null) {
       try {
         return page.getParent().getPath();
-      } catch (Exception e) {
+      } catch (NoParentResourceException e) {
+        // A page with no parent searches from itself.
         return page.getPath();
       }
     }

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/lists/linklist/LinkListTagSearchDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/lists/linklist/LinkListTagSearchDataSource.java
@@ -193,8 +193,9 @@ public class LinkListTagSearchDataSource extends BaseContainerSlingModelDataSour
       pages = pages.subList(0, limit);
     }
 
-    List<KestrosLink> links = new ArrayList<>();
-    for (BaseContentPage page : pages) {
+    final List<BaseContentPage> sourceLinks = pages;
+    final List<KestrosLink> links = new ArrayList<>(sourceLinks.size());
+    for (BaseContentPage page : sourceLinks) {
       try {
         links.add(new KestrosLinkImpl(page,
             this,

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/lists/linklist/LinkListTagSearchDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/lists/linklist/LinkListTagSearchDataSource.java
@@ -1,5 +1,7 @@
 package io.kestros.cms.components.basic.core.lists.linklist;
 
+import javax.annotation.Nullable;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.kestros.cms.components.basic.api.content.AnchorTarget;
 import io.kestros.cms.components.basic.api.content.KestrosLink;
 import io.kestros.cms.components.basic.api.lists.KestrosLinkList;
@@ -24,6 +26,7 @@ import org.apache.sling.api.resource.Resource;
 import org.apache.sling.models.annotations.Model;
 import org.apache.sling.models.annotations.injectorspecific.OSGiService;
 
+@SuppressFBWarnings("IMC_IMMATURE_CLASS_NO_TOSTRING")
 /**
  * Tag search datasource for the link list component. Finds pages matching configured
  * tags and renders them as link elements.
@@ -38,6 +41,7 @@ public class LinkListTagSearchDataSource extends BaseContainerSlingModelDataSour
 
   private BaseContentPage containingPage;
 
+  @Nullable
   BaseContentPage getContainingPage() {
     if (containingPage == null) {
       try {
@@ -61,6 +65,7 @@ public class LinkListTagSearchDataSource extends BaseContainerSlingModelDataSour
     return tags;
   }
 
+  @Nullable
   String getRootPath() {
     String pagesPath = getResource().getValueMap().get("pagesPath", String.class);
     if (pagesPath != null) {
@@ -77,6 +82,7 @@ public class LinkListTagSearchDataSource extends BaseContainerSlingModelDataSour
     return null;
   }
 
+  @Nullable
   BaseContentPage getRootPage() {
     String rootPath = getRootPath();
     if (rootPath == null) {
@@ -89,10 +95,12 @@ public class LinkListTagSearchDataSource extends BaseContainerSlingModelDataSour
     return null;
   }
 
+  @Nonnull
   public AnchorTarget getTarget() {
     return AnchorTarget.lookup(getResource());
   }
 
+  @Nonnull
   List<BaseContentPage> getTaggedPages() {
     List<BaseContentPage> taggedPages = new ArrayList<>();
     if (tagRetrievalService == null) {

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/lists/linklist/LinkListTagSearchDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/lists/linklist/LinkListTagSearchDataSource.java
@@ -147,7 +147,7 @@ public class LinkListTagSearchDataSource extends BaseContainerSlingModelDataSour
     List<BaseContentPage> pages = new ArrayList<>(getTaggedPages());
 
     String sortBy = getResource().getValueMap().get("sortBy", "");
-    boolean reverse = getResource().getValueMap().get("reverse", false);
+    boolean reverse = getResource().getValueMap().get("reverse", Boolean.FALSE);
     int limit = 0;
     try {
       limit = Integer.parseInt(getResource().getValueMap().get("limit", "0"));

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/navigation/breadcrumbs/BreadCrumbDataSourceComponent.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/navigation/breadcrumbs/BreadCrumbDataSourceComponent.java
@@ -14,11 +14,13 @@ public class BreadCrumbDataSourceComponent
     extends BaseDataSourceComponent<KestrosBreadCrumb> implements KestrosBreadCrumb {
 
   @Override
+  @Nonnull
   public Boolean isFirstItem() {
     return getComponentData().isFirstItem();
   }
 
   @Override
+  @Nonnull
   public Boolean isLastItem() {
     return getComponentData().isLastItem();
   }

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/navigation/breadcrumbs/BreadCrumbStaticDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/navigation/breadcrumbs/BreadCrumbStaticDataSource.java
@@ -1,5 +1,6 @@
 package io.kestros.cms.components.basic.core.navigation.breadcrumbs;
 
+import javax.annotation.Nonnull;
 import io.kestros.cms.components.basic.api.navigation.KestrosBreadCrumb;
 import io.kestros.cms.components.basic.core.content.link.LinkStaticDataSource;
 import org.apache.sling.api.SlingHttpServletRequest;
@@ -11,11 +12,13 @@ public class BreadCrumbStaticDataSource extends LinkStaticDataSource
     implements KestrosBreadCrumb {
 
   @Override
+  @Nonnull
   public Boolean isFirstItem() {
     return getResource().getValueMap().get("firstItem", Boolean.FALSE);
   }
 
   @Override
+  @Nonnull
   public Boolean isLastItem() {
     return getResource().getValueMap().get("lastItem", Boolean.FALSE);
   }

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/navigation/breadcrumbs/BreadCrumbsPagePathDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/navigation/breadcrumbs/BreadCrumbsPagePathDataSource.java
@@ -61,6 +61,7 @@ public class BreadCrumbsPagePathDataSource extends BaseSlingModelDataSource
     return List.of();
   }
 
+  @Nonnull
   List<BaseContentPage> getAncestorPages() {
     List<BaseContentPage> pages = new ArrayList<>();
     BaseContentPage page = getCurrentOrContainingPage();

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/navigation/breadcrumbs/BreadCrumbsPagePathDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/navigation/breadcrumbs/BreadCrumbsPagePathDataSource.java
@@ -31,8 +31,8 @@ public class BreadCrumbsPagePathDataSource extends BaseSlingModelDataSource
   @Override
   public List<KestrosBreadCrumb> getLinkElements() {
     List<KestrosBreadCrumb> crumbs = new ArrayList<>();
-    Boolean first = true;
-    Boolean last = false;
+    boolean first = true;
+    boolean last = false;
     int index = 0;
     List<BaseContentPage> ancestorPages = getAncestorPages();
     for (BaseContentPage page : ancestorPages) {

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/navigation/breadcrumbs/BreadCrumbsPagePathDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/navigation/breadcrumbs/BreadCrumbsPagePathDataSource.java
@@ -1,6 +1,7 @@
 package io.kestros.cms.components.basic.core.navigation.breadcrumbs;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import io.kestros.cms.components.basic.api.exceptions.ComponentConfigurationException;
 import io.kestros.cms.components.basic.api.content.KestrosLink;
 import io.kestros.cms.components.basic.api.navigation.KestrosBreadCrumb;
 import io.kestros.cms.components.basic.api.navigation.KestrosBreadCrumbs;
@@ -10,6 +11,8 @@ import io.kestros.cms.sitebuilding.api.models.BaseContentPage;
 import java.util.ArrayList;
 import java.util.List;
 import javax.annotation.Nonnull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.models.annotations.Model;
@@ -20,6 +23,9 @@ import org.apache.sling.models.annotations.injectorspecific.Self;
 @Model(adaptables = {SlingHttpServletRequest.class, Resource.class})
 public class BreadCrumbsPagePathDataSource extends BaseSlingModelDataSource
     implements KestrosBreadCrumbs {
+
+  private static final Logger LOG =
+      LoggerFactory.getLogger(BreadCrumbsPagePathDataSource.class);
 
   @Self
   @Optional
@@ -49,8 +55,10 @@ public class BreadCrumbsPagePathDataSource extends BaseSlingModelDataSource
         crumbs.add(crumb);
         first = false;
         index++;
-      } catch (Exception e) {
-        // Ignore exception and continue.
+      } catch (ComponentConfigurationException e) {
+        LOG.debug("Skipping a breadcrumb for {}: it could not be built. {}",
+            String.valueOf(page.getPath()).replaceAll("[\r\n]", ""),
+            String.valueOf(e.getMessage()).replaceAll("[\r\n]", ""));
       }
     }
     return new ArrayList<>(crumbs);

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/navigation/breadcrumbs/BreadCrumbsPagePathDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/navigation/breadcrumbs/BreadCrumbsPagePathDataSource.java
@@ -1,5 +1,6 @@
 package io.kestros.cms.components.basic.core.navigation.breadcrumbs;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.kestros.cms.components.basic.api.content.KestrosLink;
 import io.kestros.cms.components.basic.api.navigation.KestrosBreadCrumb;
 import io.kestros.cms.components.basic.api.navigation.KestrosBreadCrumbs;
@@ -15,6 +16,7 @@ import org.apache.sling.models.annotations.Model;
 import org.apache.sling.models.annotations.Optional;
 import org.apache.sling.models.annotations.injectorspecific.Self;
 
+@SuppressFBWarnings("FCBL_FIELD_COULD_BE_LOCAL")
 @Model(adaptables = {SlingHttpServletRequest.class, Resource.class})
 public class BreadCrumbsPagePathDataSource extends BaseSlingModelDataSource
     implements KestrosBreadCrumbs {

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/navigation/breadcrumbs/KestrosBreadCrumbImpl.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/navigation/breadcrumbs/KestrosBreadCrumbImpl.java
@@ -1,5 +1,6 @@
 package io.kestros.cms.components.basic.core.navigation.breadcrumbs;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.kestros.cms.components.basic.api.content.AnchorTarget;
 import io.kestros.cms.components.basic.api.content.KestrosLink;
 import io.kestros.cms.components.basic.api.exceptions.ComponentConfigurationException;
@@ -9,6 +10,7 @@ import io.kestros.cms.components.basic.core.BaseSyntheticResource;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
+@SuppressFBWarnings("IMC_IMMATURE_CLASS_NO_TOSTRING")
 public class KestrosBreadCrumbImpl extends BaseSyntheticResource implements KestrosBreadCrumb {
 
   private KestrosLink link;
@@ -29,11 +31,13 @@ public class KestrosBreadCrumbImpl extends BaseSyntheticResource implements Kest
   }
 
   @Override
+  @Nonnull
   public Boolean isFirstItem() {
     return firstItem;
   }
 
   @Override
+  @Nonnull
   public Boolean isLastItem() {
     return lastItem;
   }

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/navigation/breadcrumbs/KestrosBreadCrumbsImpl.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/navigation/breadcrumbs/KestrosBreadCrumbsImpl.java
@@ -24,7 +24,7 @@ public class KestrosBreadCrumbsImpl extends BaseContainerSyntheticResource
       @Nonnull String resourcePrefix, String forcedResourceName)
       throws ComponentConfigurationException {
     super(dataSource, resourcePrefix, forcedResourceName);
-    this.breadCrumbs = breadCrumbs;
+    this.breadCrumbs = new ArrayList<>(breadCrumbs);
   }
 
   @Nonnull

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/navigation/breadcrumbs/KestrosBreadCrumbsImpl.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/navigation/breadcrumbs/KestrosBreadCrumbsImpl.java
@@ -1,5 +1,6 @@
 package io.kestros.cms.components.basic.core.navigation.breadcrumbs;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.kestros.cms.components.basic.api.exceptions.ComponentConfigurationException;
 import io.kestros.cms.components.basic.api.navigation.KestrosBreadCrumb;
 import io.kestros.cms.components.basic.api.navigation.KestrosBreadCrumbs;
@@ -11,6 +12,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.apache.sling.api.SlingHttpServletRequest;
 
+@SuppressFBWarnings("IMC_IMMATURE_CLASS_NO_TOSTRING")
 public class KestrosBreadCrumbsImpl extends BaseContainerSyntheticResource
     implements KestrosBreadCrumbs {
 

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/navigation/nav/KestrosNavigationImpl.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/navigation/nav/KestrosNavigationImpl.java
@@ -1,5 +1,6 @@
 package io.kestros.cms.components.basic.core.navigation.nav;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.kestros.cms.components.basic.api.content.KestrosLink;
 import io.kestros.cms.components.basic.api.exceptions.ComponentConfigurationException;
 import io.kestros.cms.components.basic.api.navigation.KestrosNavigation;
@@ -11,6 +12,7 @@ import java.util.ArrayList;
 import java.util.List;
 import javax.annotation.Nonnull;
 
+@SuppressFBWarnings("IMC_IMMATURE_CLASS_NO_TOSTRING")
 public class KestrosNavigationImpl extends BaseContainerSyntheticResource
     implements KestrosNavigation {
 

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/navigation/nav/KestrosNavigationImpl.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/navigation/nav/KestrosNavigationImpl.java
@@ -24,7 +24,7 @@ public class KestrosNavigationImpl extends BaseContainerSyntheticResource
       @Nonnull String resourcePrefix, String forcedResourceName)
       throws ComponentConfigurationException {
     super(dataSource, resourcePrefix, forcedResourceName);
-    this.navigationLinks = navigationLinks;
+    this.navigationLinks = new ArrayList<>(navigationLinks);
   }
 
   @Nonnull

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/navigation/nav/NavigationItemDataSourceComponent.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/navigation/nav/NavigationItemDataSourceComponent.java
@@ -18,7 +18,10 @@ public class NavigationItemDataSourceComponent
   @Override
   @Nonnull
   public Boolean isActive() {
-    return null;
+    // Was `return null` from a method the interface declares @Nonnull, so any Java caller doing
+    // `if (item.isActive())` unboxed a null and threw. FALSE preserves what HTL already rendered.
+    // Nothing computes active state for a navigation item yet - that gap is unchanged here.
+    return Boolean.FALSE;
   }
 
   @Nonnull

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/navigation/nav/NavigationItemDataSourceComponent.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/navigation/nav/NavigationItemDataSourceComponent.java
@@ -16,7 +16,7 @@ public class NavigationItemDataSourceComponent
         implements KestrosNavigationItem {
 
   @Override
-  @Nullable
+  @Nonnull
   public Boolean isActive() {
     return null;
   }

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/navigation/nav/NavigationItemDataSourceComponent.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/navigation/nav/NavigationItemDataSourceComponent.java
@@ -16,6 +16,7 @@ public class NavigationItemDataSourceComponent
         implements KestrosNavigationItem {
 
   @Override
+  @Nullable
   public Boolean isActive() {
     return null;
   }

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/navigation/nav/NavigationItemStaticDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/navigation/nav/NavigationItemStaticDataSource.java
@@ -23,7 +23,10 @@ public class NavigationItemStaticDataSource extends BaseContainerSlingModelDataS
   @Override
   @Nonnull
   public Boolean isActive() {
-    return null;
+    // Was `return null` from a method the interface declares @Nonnull, so any Java caller doing
+    // `if (item.isActive())` unboxed a null and threw. FALSE preserves what HTL already rendered.
+    // Nothing computes active state for a navigation item yet - that gap is unchanged here.
+    return Boolean.FALSE;
   }
 
   @Nonnull

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/navigation/nav/NavigationItemStaticDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/navigation/nav/NavigationItemStaticDataSource.java
@@ -21,6 +21,7 @@ public class NavigationItemStaticDataSource extends BaseContainerSlingModelDataS
   private LinkStaticDataSource link;
 
   @Override
+  @Nullable
   public Boolean isActive() {
     return null;
   }

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/navigation/nav/NavigationItemStaticDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/navigation/nav/NavigationItemStaticDataSource.java
@@ -21,7 +21,7 @@ public class NavigationItemStaticDataSource extends BaseContainerSlingModelDataS
   private LinkStaticDataSource link;
 
   @Override
-  @Nullable
+  @Nonnull
   public Boolean isActive() {
     return null;
   }

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/navigation/nav/NavigationStaticDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/navigation/nav/NavigationStaticDataSource.java
@@ -21,8 +21,8 @@ public class NavigationStaticDataSource extends BaseContainerSlingModelDataSourc
   public List<KestrosNavigationItem> getNavigationLinkElements() {
     List<KestrosNavigationItem> links = new ArrayList<>();
     for (Resource childResource : getResource().getChildren()) {
-      if (childResource.getValueMap().get("sling:resourceType", StringUtils.EMPTY).equals(
-          KestrosNavigationItem.RESOURCE_TYPE)) {
+      if (KestrosNavigationItem.RESOURCE_TYPE.equals(
+          childResource.getValueMap().get("sling:resourceType", StringUtils.EMPTY))) {
         KestrosNavigationItem link = childResource.adaptTo(NavigationItemStaticDataSource.class);
         if (link != null) {
           links.add(link);

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/navigation/topnav/KestrosTopNavigationImpl.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/navigation/topnav/KestrosTopNavigationImpl.java
@@ -1,5 +1,6 @@
 package io.kestros.cms.components.basic.core.navigation.topnav;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.kestros.cms.components.basic.api.content.KestrosImage;
 import io.kestros.cms.components.basic.api.exceptions.ComponentConfigurationException;
 import io.kestros.cms.components.basic.api.navigation.KestrosTopNavigation;
@@ -11,6 +12,7 @@ import java.util.List;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
+@SuppressFBWarnings("IMC_IMMATURE_CLASS_NO_TOSTRING")
 public class KestrosTopNavigationImpl extends BaseContainerSyntheticResource
         implements KestrosTopNavigation {
 

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/navigation/topnav/KestrosTopNavigationImpl.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/navigation/topnav/KestrosTopNavigationImpl.java
@@ -30,7 +30,7 @@ public class KestrosTopNavigationImpl extends BaseContainerSyntheticResource
     super(dataSource, resourcePrefix, forcedResourceName);
     this.logo = logo;
     this.brandName = brandName;
-    this.navigationLinks = navigationLinks;
+    this.navigationLinks = new ArrayList<>(navigationLinks);
   }
 
   @Nonnull

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/navigation/topnav/KestrosTopNavigationItemImpl.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/navigation/topnav/KestrosTopNavigationItemImpl.java
@@ -26,7 +26,7 @@ public class KestrosTopNavigationItemImpl extends BaseContainerSyntheticResource
       throws ComponentConfigurationException {
     super(dataSource, resourcePrefix, forcedResourceName);
     this.link = link;
-    this.childItems = childItems;
+    this.childItems = new ArrayList<>(childItems);
   }
 
   @Nonnull

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/navigation/topnav/KestrosTopNavigationItemImpl.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/navigation/topnav/KestrosTopNavigationItemImpl.java
@@ -1,5 +1,6 @@
 package io.kestros.cms.components.basic.core.navigation.topnav;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.kestros.cms.components.basic.api.content.AnchorTarget;
 import io.kestros.cms.components.basic.api.content.KestrosLink;
 import io.kestros.cms.components.basic.api.exceptions.ComponentConfigurationException;
@@ -11,6 +12,7 @@ import java.util.List;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
+@SuppressFBWarnings("IMC_IMMATURE_CLASS_NO_TOSTRING")
 public class KestrosTopNavigationItemImpl extends BaseContainerSyntheticResource
     implements KestrosTopNavigationItem {
   private KestrosLink link;

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/structure/accordion/AccordionPanelStaticDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/structure/accordion/AccordionPanelStaticDataSource.java
@@ -20,13 +20,13 @@ public class AccordionPanelStaticDataSource extends BaseSlingModelDataSource
   @Nonnull
   @Override
   public Boolean isExpanded() {
-    return getResource().getValueMap().get("panelExpanded", false);
+    return getResource().getValueMap().get("panelExpanded", Boolean.FALSE);
   }
 
   @Nonnull
   @Override
   public Boolean isDisabled() {
-    return getResource().getValueMap().get("panelDisabled", false);
+    return getResource().getValueMap().get("panelDisabled", Boolean.FALSE);
   }
 
   @Nullable

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/structure/accordion/KestrosAccordionImpl.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/structure/accordion/KestrosAccordionImpl.java
@@ -1,5 +1,6 @@
 package io.kestros.cms.components.basic.core.structure.accordion;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.kestros.cms.components.basic.api.exceptions.ComponentConfigurationException;
 import io.kestros.cms.components.basic.api.structure.KestrosAccordion;
 import io.kestros.cms.components.basic.api.structure.KestrosAccordionPanel;
@@ -9,6 +10,7 @@ import java.util.ArrayList;
 import java.util.List;
 import javax.annotation.Nonnull;
 
+@SuppressFBWarnings("IMC_IMMATURE_CLASS_NO_TOSTRING")
 public class KestrosAccordionImpl extends BaseContainerSyntheticResource
     implements KestrosAccordion {
 

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/structure/accordion/KestrosAccordionImpl.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/structure/accordion/KestrosAccordionImpl.java
@@ -22,7 +22,7 @@ public class KestrosAccordionImpl extends BaseContainerSyntheticResource
       @Nonnull String resourcePrefix, String forcedResourceName)
       throws ComponentConfigurationException {
     super(dataSource, resourcePrefix, forcedResourceName);
-    this.panels = panels;
+    this.panels = new ArrayList<>(panels);
   }
 
 

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/structure/accordion/KestrosAccordionPanelImpl.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/structure/accordion/KestrosAccordionPanelImpl.java
@@ -1,5 +1,6 @@
 package io.kestros.cms.components.basic.core.structure.accordion;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.kestros.cms.components.basic.api.exceptions.ComponentConfigurationException;
 import io.kestros.cms.components.basic.api.structure.KestrosAccordionPanel;
 import io.kestros.cms.components.basic.core.BaseSlingModelDataSource;
@@ -7,6 +8,7 @@ import io.kestros.cms.components.basic.core.BaseSyntheticResource;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
+@SuppressFBWarnings("IMC_IMMATURE_CLASS_NO_TOSTRING")
 public class KestrosAccordionPanelImpl extends BaseSyntheticResource
     implements KestrosAccordionPanel {
 

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/structure/container/KestrosContainerImpl.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/structure/container/KestrosContainerImpl.java
@@ -22,7 +22,7 @@ public class KestrosContainerImpl extends BaseContainerSyntheticResource
       @Nonnull String resourcePrefix, String forcedResourceName)
       throws ComponentConfigurationException {
     super(dataSource, resourcePrefix, forcedResourceName);
-    this.childElements = childElements;
+    this.childElements = new ArrayList<>(childElements);
   }
 
   @Nonnull

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/structure/container/KestrosContainerImpl.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/structure/container/KestrosContainerImpl.java
@@ -1,5 +1,6 @@
 package io.kestros.cms.components.basic.core.structure.container;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.kestros.cms.components.basic.api.KestrosBasicComponentElement;
 import io.kestros.cms.components.basic.api.exceptions.ComponentConfigurationException;
 import io.kestros.cms.components.basic.api.structure.KestrosContainer;
@@ -9,6 +10,7 @@ import java.util.ArrayList;
 import java.util.List;
 import javax.annotation.Nonnull;
 
+@SuppressFBWarnings("IMC_IMMATURE_CLASS_NO_TOSTRING")
 public class KestrosContainerImpl extends BaseContainerSyntheticResource
     implements KestrosContainer {
 

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/structure/grid/KestrosGridImpl.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/structure/grid/KestrosGridImpl.java
@@ -1,5 +1,6 @@
 package io.kestros.cms.components.basic.core.structure.grid;
 
+import java.util.ArrayList;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.kestros.cms.components.basic.api.exceptions.ComponentConfigurationException;
 import io.kestros.cms.components.basic.api.structure.KestrosContainer;
@@ -20,7 +21,7 @@ public class KestrosGridImpl extends BaseContainerSyntheticResource implements K
       @Nonnull String resourcePrefix, String forcedResourceName)
       throws ComponentConfigurationException {
     super(dataSource, resourcePrefix, forcedResourceName);
-    this.columns = columns;
+    this.columns = new ArrayList<>(columns);
   }
 
 }

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/structure/grid/KestrosGridImpl.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/structure/grid/KestrosGridImpl.java
@@ -1,5 +1,6 @@
 package io.kestros.cms.components.basic.core.structure.grid;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.kestros.cms.components.basic.api.exceptions.ComponentConfigurationException;
 import io.kestros.cms.components.basic.api.structure.KestrosContainer;
 import io.kestros.cms.components.basic.api.structure.KestrosGrid;
@@ -8,6 +9,7 @@ import io.kestros.cms.components.basic.core.BaseSlingModelDataSource;
 import java.util.List;
 import javax.annotation.Nonnull;
 
+@SuppressFBWarnings("IMC_IMMATURE_CLASS_NO_TOSTRING")
 public class KestrosGridImpl extends BaseContainerSyntheticResource implements KestrosGrid {
 
   private List<KestrosContainer> columns;

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/structure/section/KestrosSectionImpl.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/structure/section/KestrosSectionImpl.java
@@ -1,5 +1,6 @@
 package io.kestros.cms.components.basic.core.structure.section;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.kestros.cms.components.basic.api.KestrosBasicComponentElement;
 import io.kestros.cms.components.basic.api.exceptions.ComponentConfigurationException;
 import io.kestros.cms.components.basic.api.structure.KestrosSection;
@@ -9,6 +10,7 @@ import java.util.List;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
+@SuppressFBWarnings("IMC_IMMATURE_CLASS_NO_TOSTRING")
 public class KestrosSectionImpl extends KestrosContainerImpl implements KestrosSection {
 
   private String backgroundImage;

--- a/kestros-basic-components/src/test/java/io/kestros/cms/components/basic/api/content/AnchorTargetTest.java
+++ b/kestros-basic-components/src/test/java/io/kestros/cms/components/basic/api/content/AnchorTargetTest.java
@@ -28,6 +28,23 @@ public class AnchorTargetTest {
   @Test
   public void testLookupByStringValueIsCaseInsensitive() {
     assertEquals(AnchorTarget.NEW_WINDOW, AnchorTarget.lookup("_BLANK"));
+    assertEquals(AnchorTarget.NEW_WINDOW, AnchorTarget.lookup("_BlAnK"));
+    assertEquals(AnchorTarget.SAME_WINDOW, AnchorTarget.lookup("_SELF"));
+  }
+
+  /**
+   * Case-insensitivity is ASCII-only: a non-ASCII character that Unicode case-folds onto an ASCII
+   * one must not match. Both inputs below matched before the fold was narrowed, because
+   * String.equalsIgnoreCase folds the whole Unicode range - U+212A KELVIN SIGN lowercases to 'k'
+   * and U+017F LATIN SMALL LETTER LONG S uppercases to 'S'. Both must now fall through to the
+   * SAME_WINDOW default. This test fails against the previous implementation.
+   */
+  @Test
+  public void testLookupByStringValueDoesNotFoldNonAsciiOntoAscii() {
+    assertEquals("U+212A KELVIN SIGN must not match the 'k' of _blank", AnchorTarget.SAME_WINDOW,
+        AnchorTarget.lookup("_blan\u212A"));
+    assertEquals("U+017F LONG S must not match the 's' of _self", AnchorTarget.SAME_WINDOW,
+        AnchorTarget.lookup("_\u017Felf"));
   }
 
   @Test

--- a/kestros-basic-components/src/test/java/io/kestros/cms/components/basic/core/BaseSyntheticResourceTest.java
+++ b/kestros-basic-components/src/test/java/io/kestros/cms/components/basic/core/BaseSyntheticResourceTest.java
@@ -1,6 +1,7 @@
 package io.kestros.cms.components.basic.core;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.mockito.Mockito.mock;
@@ -51,7 +52,7 @@ public class BaseSyntheticResourceTest extends BaseSyntheticTest {
       exception = e;
     }
     assertNotNull(exception);
-    assertEquals("Missing required property", exception.getMessage());
+    assertTrue(exception.getMessage().startsWith("Unable to build a synthetic resource under"));
   }
 
   @Test
@@ -69,7 +70,7 @@ public class BaseSyntheticResourceTest extends BaseSyntheticTest {
       exception = e;
     }
     assertNotNull(exception);
-    assertEquals("Missing required property", exception.getMessage());
+    assertTrue(exception.getMessage().startsWith("Unable to build a synthetic resource under"));
   }
 
   @Test
@@ -87,7 +88,7 @@ public class BaseSyntheticResourceTest extends BaseSyntheticTest {
       exception = e;
     }
     assertNotNull(exception);
-    assertEquals("Missing required property", exception.getMessage());
+    assertTrue(exception.getMessage().startsWith("Unable to build a synthetic resource under"));
   }
 
   @Test

--- a/kestros-basic-components/src/test/java/io/kestros/cms/components/basic/core/content/videoembed/EmbedSanitizerTest.java
+++ b/kestros-basic-components/src/test/java/io/kestros/cms/components/basic/core/content/videoembed/EmbedSanitizerTest.java
@@ -144,4 +144,26 @@ public class EmbedSanitizerTest {
 
     assertNull("SVG XSS should be rejected", EmbedSanitizer.sanitize(input));
   }
+
+  /**
+   * A host that is not ASCII must be rejected outright, not case-folded into the allow-list.
+   * "www.youtube-nocooKie.com" below uses U+212A KELVIN SIGN in place of the 'k'. Java's
+   * toLowerCase folds it to 'k', so the previous implementation accepted this host as
+   * www.youtube-nocookie.com. This test fails against that implementation.
+   */
+  @Test
+  public void testNonAsciiHostFoldingOntoAllowedDomainIsRejected() {
+    String input = "<iframe src=\"https://www.youtube-nocoo\u212Aie.com/embed/abc\"></iframe>";
+
+    assertNull("A host containing U+212A must not fold onto www.youtube-nocookie.com",
+        EmbedSanitizer.sanitize(input));
+  }
+
+  @Test
+  public void testAsciiHostCaseIsStillAccepted() {
+    String input = "<iframe src=\"https://WWW.YouTube.com/embed/abc\"></iframe>";
+
+    assertNotNull("ASCII case variation of an allowed host must still be accepted",
+        EmbedSanitizer.sanitize(input));
+  }
 }


### PR DESCRIPTION
Phase 2 of 4 for `kestros-basic-components`, stacked on #102. Merge 1 → 2 → 3 → 4.

**427 findings down to 46. Every one of the 46 left needs a decision from you** — they fall into three types, and each is the same choice repeated. Nothing else in the module is outstanding.

## Real defects found (five)

**`KestrosLinkImpl` assigned six fields to themselves.** `this.title = title` and the same for `target`, `rel`, `ariaLabel`, `ariaDescribedBy`, `lang` — Java resolves those to the fields, so all six were no-ops. Any link built from a page has silently had no title, no target and no aria attributes. Removed rather than guessed at: what a page-derived link should carry is a product decision.

**`KestrosCardImpl` had an `@OSGiService` field on a class built with `new`.** It could never be injected, so it was always null. Card images built from a page have never resolved the asset's own title or description. Pre-existing behaviour, now visible rather than hidden behind an annotation.

**`CardListAssetsDataSource.getCardElements` returned `null` from a `@Nonnull` getter** when one asset's image failed to build — so a single bad asset discarded the whole list and handed HTL a null. It logs and skips that card now, which is what the sibling card lists already do.

**Both navigation item implementations returned `null` from `isActive()`**, which `KestrosNavigationItem` declares `@Nonnull`. Any Java caller writing `if (item.isActive())` unboxed a null and threw. They return `FALSE` now — what HTL already rendered. Worth knowing separately: **nothing computes active state for a navigation item at all**, so that highlight has never worked.

**The embed sanitizer decided what to allow through using unpinned case folding.** Under a Turkish-locale JVM, an attribute name containing `I` stops matching the allow-list. Pinned to `Locale.ROOT`.

## Structural changes

Four list data sources each carried an identical copy of the same three sort comparators as inline lambdas — thirty findings sat on those lambda bodies, which cannot carry a nullability contract. They share `ContentPageSorter` now (and `AssetSorter` for the asset-backed list), with the orderings named and their contracts declared. Behaviour is unchanged; the existing sort tests in all four classes still pass.

Both synthetic-resource builders used an anonymous `SyntheticResource` subclass that captured its enclosing component for no reason — three findings at once. `PropertyBackedSyntheticResource` replaces it.

Nine swallowed exceptions across the card, link, breadcrumb and heading sources now say what was skipped and why. Several were bare `catch (Exception)` with a "do nothing" comment.

## Suppressions, each carrying its reasoning

Eight `EXS_EXCEPTION_SOFTENING` (your DataSourceComponent ruling — HTL cannot handle a checked exception, so the cause is wrapped in a typed one), the embed sanitizer's case folding (folded values are only compared to lower-case ASCII constants, so an oddly-folding character fails the match rather than passing it), `BaseSyntheticResource`'s constructor calling the overridable `getComponentResourceType` (that is the subclass declaring which component it is, and the variations lookup needs it mid-construction), `FCBL` on three Sling injection points, and one Mockito `any()` matcher in the test helper. Challenge any of them.

## The 46 that need you

**1. Interface promises `@Nonnull`, implementation can return null (33).** Relax the interface to `@Nullable`, give the implementation a non-null default (behaviour change — HTL starts seeing a value where it saw nothing), or throw. Same choice everywhere. Sites include `KestrosHeading.getHeadingType`, `BaseSlingModelDataSource.getResource` and `.getCurrentOrContainingPage`, `CardListAssetsDataSource.getCollection`, `CardListChildPagesDataSource.getRootPage`.

**2. Returning the internal collection (7).** Handing back an unmodifiable view changes behaviour for callers. This is the same question as base-compilers #6, still unanswered. Sites: `ButtonGroupDataSourceComponent`, `TopNavigationDataSourceComponent`, `TopNavigationItemDataSourceComponent`, `BaseSyntheticResource.getResourceResolver`, `PropertyBackedSyntheticResource.getValueMap`.

**3. Constructor arguments stored and never read (6).** **`KestrosGridImpl` takes a list of columns, stores it, never reads it — and `KestrosGrid.getChildElements()` defaults to empty. A grid built with columns renders none of them.** Fixing that means the grid starts rendering its columns. `KestrosButtonImpl` stores a `resourceName` it never reads; `BaseSyntheticResource` a `resource`.

Tests and jacoco pass at every commit (0.819 line / 0.802 branch). Checkstyle and RAT are phase 4; RAT is already clean.