### PR TITLE
Strict build 3/4: cover the lines phase 2 changed

### DIFF
--- a/kestros-basic-components/src/test/java/io/kestros/cms/components/basic/core/AssetSorterTest.java
+++ b/kestros-basic-components/src/test/java/io/kestros/cms/components/basic/core/AssetSorterTest.java
@@ -1,0 +1,84 @@
+package io.kestros.cms.components.basic.core;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.kestros.cms.assets.api.models.Asset;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Calendar;
+import java.util.List;
+import org.junit.Test;
+
+/**
+ * Mirrors ContentPageSorterTest for the asset-backed card list.
+ */
+public class AssetSorterTest {
+
+  private Asset asset(final String name, final String title, final boolean dated) {
+    final Asset asset = mock(Asset.class);
+    when(asset.getName()).thenReturn(name);
+    when(asset.getTitle()).thenReturn(title);
+    if (dated) {
+      when(asset.getCreatedDate()).thenReturn(Calendar.getInstance().getTime());
+      when(asset.getModifiedDate()).thenReturn(Calendar.getInstance().getTime());
+    }
+    return asset;
+  }
+
+  private List<Asset> assets() {
+    return new ArrayList<>(Arrays.asList(
+        asset("zulu", "Apple", true),
+        asset("alpha", "Zebra", false),
+        asset("mike", null, false)));
+  }
+
+  @Test
+  public void testSortByName() {
+    final List<Asset> assets = assets();
+    AssetSorter.sort(assets, "name");
+
+    assertEquals("alpha", assets.get(0).getName());
+    assertEquals("mike", assets.get(1).getName());
+    assertEquals("zulu", assets.get(2).getName());
+  }
+
+  /** An asset with no title sorts by its node name instead. */
+  @Test
+  public void testSortByAnythingElseUsesTheTitle() {
+    final List<Asset> assets = assets();
+    AssetSorter.sort(assets, "title");
+
+    // "Apple", "Zebra", then "mike" - the titleless asset falls back to its node name, and
+    // lower-case sorts after upper-case.
+    assertEquals("zulu", assets.get(0).getName());
+    assertEquals("alpha", assets.get(1).getName());
+    assertEquals("mike", assets.get(2).getName());
+  }
+
+  /** An asset with no dates scores 0 rather than throwing. */
+  @Test
+  public void testSortByCreatedDateToleratesAnAssetWithNoDates() {
+    final List<Asset> assets = assets();
+    AssetSorter.sort(assets, "createdDate");
+
+    assertEquals("zulu", assets.get(2).getName());
+  }
+
+  @Test
+  public void testSortByLastModifiedToleratesAnAssetWithNoDates() {
+    final List<Asset> assets = assets();
+    AssetSorter.sort(assets, "lastModified");
+
+    assertEquals("zulu", assets.get(2).getName());
+  }
+
+  @Test
+  public void testSortByEmptyLeavesTheOrderAlone() {
+    final List<Asset> assets = assets();
+    AssetSorter.sort(assets, "");
+
+    assertEquals("zulu", assets.get(0).getName());
+  }
+}

--- a/kestros-basic-components/src/test/java/io/kestros/cms/components/basic/core/ContentPageSorterTest.java
+++ b/kestros-basic-components/src/test/java/io/kestros/cms/components/basic/core/ContentPageSorterTest.java
@@ -1,0 +1,104 @@
+package io.kestros.cms.components.basic.core;
+
+import static org.junit.Assert.assertEquals;
+
+import io.kestros.cms.components.basic.BaseComponentTest;
+import io.kestros.cms.sitebuilding.api.models.BaseContentPage;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Calendar;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.Test;
+
+/**
+ * The four page-backed list data sources shared an identical copy of these comparators as inline
+ * lambdas. Tested directly now that they live in one place.
+ */
+public class ContentPageSorterTest extends BaseComponentTest {
+
+  @Override
+  public void doComponentSetup() {
+    final Map<String, Object> pageProperties = new HashMap<>();
+    pageProperties.put("jcr:primaryType", "kes:Page");
+
+    final Map<String, Object> titled = new HashMap<>();
+    titled.put("jcr:primaryType", "nt:unstructured");
+    titled.put("jcr:title", "Zebra");
+    context.create().resource("/content/alpha", pageProperties);
+    context.create().resource("/content/alpha/jcr:content", titled);
+
+    final Map<String, Object> dated = new HashMap<>();
+    dated.put("jcr:primaryType", "nt:unstructured");
+    dated.put("jcr:title", "Apple");
+    dated.put("jcr:created", Calendar.getInstance());
+    dated.put("jcr:lastModified", Calendar.getInstance());
+    context.create().resource("/content/zulu", pageProperties);
+    context.create().resource("/content/zulu/jcr:content", dated);
+
+    // No jcr:content at all: the date comparators must treat this as 0 rather than throwing.
+    context.create().resource("/content/mike", pageProperties);
+  }
+
+  @Override
+  public void testToSyntheticResource() {
+    // Not a component; nothing to synthesize.
+  }
+
+  private List<BaseContentPage> pages() {
+    final List<BaseContentPage> pages = new ArrayList<>();
+    for (final String name : Arrays.asList("zulu", "alpha", "mike")) {
+      pages.add(context.resourceResolver().getResource("/content/" + name)
+          .adaptTo(BaseContentPage.class));
+    }
+    return pages;
+  }
+
+  @Test
+  public void testSortByName() {
+    final List<BaseContentPage> pages = pages();
+    ContentPageSorter.sort(pages, "name");
+
+    assertEquals("alpha", pages.get(0).getName());
+    assertEquals("mike", pages.get(1).getName());
+    assertEquals("zulu", pages.get(2).getName());
+  }
+
+  /** An unrecognised key falls back to the display title, which is what the lambdas did. */
+  @Test
+  public void testSortByAnythingElseUsesTheDisplayTitle() {
+    final List<BaseContentPage> pages = pages();
+    ContentPageSorter.sort(pages, "title");
+
+    assertEquals("zulu", pages.get(0).getName());
+  }
+
+  @Test
+  public void testSortByCreatedDateToleratesAPageWithNoContent() {
+    final List<BaseContentPage> pages = pages();
+    ContentPageSorter.sort(pages, "createdDate");
+
+    // The two pages without a created date sort first, both scoring 0.
+    assertEquals(3, pages.size());
+    assertEquals("zulu", pages.get(2).getName());
+  }
+
+  @Test
+  public void testSortByLastModifiedToleratesAPageWithNoContent() {
+    final List<BaseContentPage> pages = pages();
+    ContentPageSorter.sort(pages, "lastModified");
+
+    assertEquals(3, pages.size());
+    assertEquals("zulu", pages.get(2).getName());
+  }
+
+  @Test
+  public void testSortByEmptyLeavesTheOrderAlone() {
+    final List<BaseContentPage> pages = pages();
+    ContentPageSorter.sort(pages, "");
+
+    assertEquals("zulu", pages.get(0).getName());
+    assertEquals("alpha", pages.get(1).getName());
+  }
+}

--- a/kestros-basic-components/src/test/java/io/kestros/cms/components/basic/core/PropertyBackedSyntheticResourceTest.java
+++ b/kestros-basic-components/src/test/java/io/kestros/cms/components/basic/core/PropertyBackedSyntheticResourceTest.java
@@ -1,0 +1,73 @@
+package io.kestros.cms.components.basic.core;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.sling.api.resource.ResourceMetadata;
+import org.apache.sling.testing.mock.sling.junit.SlingContext;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * Replaced an anonymous SyntheticResource subclass that both synthetic-resource builders declared
+ * inline.
+ */
+public class PropertyBackedSyntheticResourceTest {
+
+  @Rule
+  public SlingContext context = new SlingContext();
+
+  private ResourceMetadata metadata;
+  private Map<String, Object> properties;
+
+  @Before
+  public void setUp() {
+    metadata = new ResourceMetadata();
+    metadata.setResolutionPath("/synthetics/content/page/element");
+    properties = new HashMap<>();
+    properties.put("jcr:title", "A title");
+  }
+
+  @Test
+  public void testGetValueMapExposesTheSuppliedProperties() {
+    final PropertyBackedSyntheticResource resource = new PropertyBackedSyntheticResource(
+        context.resourceResolver(), metadata, "kestros/components/basic/text", properties);
+
+    assertEquals("A title", resource.getValueMap().get("jcr:title", String.class));
+  }
+
+  @Test
+  public void testGetResourceType() {
+    final PropertyBackedSyntheticResource resource = new PropertyBackedSyntheticResource(
+        context.resourceResolver(), metadata, "kestros/components/basic/text", properties);
+
+    assertEquals("kestros/components/basic/text", resource.getResourceType());
+  }
+
+  /**
+   * The properties are copied on the way in, so a caller changing its own map afterwards cannot
+   * rewrite what the resource reports.
+   */
+  @Test
+  public void testTheSuppliedPropertiesAreCopied() {
+    final PropertyBackedSyntheticResource resource = new PropertyBackedSyntheticResource(
+        context.resourceResolver(), metadata, "kestros/components/basic/text", properties);
+
+    properties.put("jcr:title", "Changed after construction");
+    properties.put("added", "later");
+
+    assertEquals("A title", resource.getValueMap().get("jcr:title", String.class));
+    assertNull(resource.getValueMap().get("added", String.class));
+  }
+
+  @Test
+  public void testEmptyProperties() {
+    final PropertyBackedSyntheticResource resource = new PropertyBackedSyntheticResource(
+        context.resourceResolver(), metadata, "kestros/components/basic/text", new HashMap<>());
+
+    assertNull(resource.getValueMap().get("jcr:title", String.class));
+  }
+}

--- a/kestros-basic-components/src/test/java/io/kestros/cms/components/basic/core/content/card/CardAssetDataSourceTest.java
+++ b/kestros-basic-components/src/test/java/io/kestros/cms/components/basic/core/content/card/CardAssetDataSourceTest.java
@@ -78,4 +78,39 @@ public class CardAssetDataSourceTest extends BaseDataSourceTest {
     assertNotNull(cardAssetDataSource.getAsset());
   }
 
+  /**
+   * Both element getters were rewritten to a single exit. They return null when there is no asset
+   * behind the card rather than partially building an element.
+   */
+  @Test
+  public void testGetImageElementWhenThereIsNoAsset() {
+    final Map<String, Object> props = new HashMap<>();
+    props.put("imagePath", "/content/assets/collection/missing");
+    props.put("sling:resourceType", KestrosCard.RESOURCE_TYPE);
+    final Resource componentResource =
+        context.create().resource("/content/page/card/no-asset", props);
+    context.request().setResource(componentResource);
+
+    assertNull(context.request().adaptTo(CardAssetDataSource.class).getImageElement());
+  }
+
+  @Test
+  public void testGetTitleElementWhenThereIsNoAsset() {
+    final Map<String, Object> props = new HashMap<>();
+    props.put("imagePath", "/content/assets/collection/missing");
+    props.put("sling:resourceType", KestrosCard.RESOURCE_TYPE);
+    final Resource componentResource =
+        context.create().resource("/content/page/card/no-asset-title", props);
+    context.request().setResource(componentResource);
+
+    assertNull(context.request().adaptTo(CardAssetDataSource.class).getTitleElement());
+  }
+
+  /** getButtonGroupElement has always returned null for this data source. */
+  @Test
+  public void testGetButtonGroupElementIsAlwaysNull() {
+    registerAssetRetrievalService();
+
+    assertNull(context.request().adaptTo(CardAssetDataSource.class).getButtonGroupElement());
+  }
 }

--- a/kestros-basic-components/src/test/java/io/kestros/cms/components/basic/core/content/heading/HeadingPageTitleDataSourceTest.java
+++ b/kestros-basic-components/src/test/java/io/kestros/cms/components/basic/core/content/heading/HeadingPageTitleDataSourceTest.java
@@ -1,0 +1,78 @@
+package io.kestros.cms.components.basic.core.content.heading;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import io.kestros.cms.components.basic.api.exceptions.ComponentElementRenderingException;
+import io.kestros.cms.components.basic.core.BaseDataSourceTest;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.sling.api.resource.Resource;
+import org.junit.Test;
+
+public class HeadingPageTitleDataSourceTest extends BaseDataSourceTest {
+
+  private final Map<String, Object> properties = new HashMap<>();
+
+  @Override
+  public void doComponentSetup() {
+    final Map<String, Object> pageProperties = new HashMap<>();
+    pageProperties.put("jcr:primaryType", "kes:Page");
+    final Map<String, Object> contentProperties = new HashMap<>();
+    contentProperties.put("jcr:primaryType", "nt:unstructured");
+    contentProperties.put("jcr:title", "The Page Title");
+    context.create().resource("/content/page", pageProperties);
+    context.create().resource("/content/page/jcr:content", contentProperties);
+  }
+
+  @Override
+  public void testToSyntheticResource() {
+    final Resource resource =
+        context.create().resource("/content/page/jcr:content/heading", properties);
+    context.request().setResource(resource);
+
+    assertNotNull(context.request().adaptTo(HeadingPageTitleDataSource.class)
+        .toSyntheticResource(context.resourceResolver(), "/content/page/jcr:content"));
+  }
+
+  @Test
+  public void testGetHeadingTextComesFromTheContainingPage() {
+    final Resource resource =
+        context.create().resource("/content/page/jcr:content/heading-inherited", properties);
+    context.request().setResource(resource);
+
+    assertEquals("The Page Title",
+        context.request().adaptTo(HeadingPageTitleDataSource.class).getHeadingText());
+  }
+
+  /**
+   * Overriding the inherited title needs the current page, which only a request can supply. This
+   * used to throw a bare RuntimeException; it now names the component that could not resolve.
+   */
+  @Test
+  public void testOverrideInheritedTitleWithoutARequestNamesTheComponent() {
+    properties.put("overrideInheritedTitle", true);
+    final Resource resource =
+        context.create().resource("/content/page/jcr:content/heading-override", properties);
+
+    try {
+      resource.adaptTo(HeadingPageTitleDataSource.class).getPage();
+      fail("Expected a ComponentElementRenderingException.");
+    } catch (final ComponentElementRenderingException e) {
+      assertTrue(e.getMessage().contains("/content/page/jcr:content/heading-override"));
+      assertTrue(e.getMessage().contains("overrideInheritedTitle"));
+    }
+  }
+
+  @Test
+  public void testIsOverrideInheritedTitleDefaultsToFalse() {
+    final Resource resource =
+        context.create().resource("/content/page/jcr:content/heading-default", properties);
+    context.request().setResource(resource);
+
+    assertEquals(Boolean.FALSE,
+        context.request().adaptTo(HeadingPageTitleDataSource.class).isOverrideInheritedTitle());
+  }
+}

--- a/kestros-basic-components/src/test/java/io/kestros/cms/components/basic/core/content/link/KestrosLinkImplTest.java
+++ b/kestros-basic-components/src/test/java/io/kestros/cms/components/basic/core/content/link/KestrosLinkImplTest.java
@@ -25,6 +25,9 @@ import io.kestros.cms.components.basic.api.content.AnchorTarget;
 import io.kestros.cms.components.basic.api.exceptions.ComponentConfigurationException;
 import io.kestros.cms.components.basic.core.BaseSyntheticTest;
 import io.kestros.cms.components.basic.core.lists.cardlist.CardListStaticDataSource;
+import io.kestros.cms.sitebuilding.api.models.BaseContentPage;
+import java.util.HashMap;
+import java.util.Map;
 import org.apache.sling.api.resource.Resource;
 import org.junit.Test;
 
@@ -88,5 +91,40 @@ public class KestrosLinkImplTest extends BaseSyntheticTest {
   @Test
   public void testGetLang() {
     assertEquals("en", link.getLang());
+  }
+
+  /**
+   * The page constructor used to assign six fields to themselves, so title, target, rel and the
+   * aria attributes were silently always null. The assignments are gone; this asserts what the
+   * constructor actually provides, so that changing it is a deliberate act rather than a surprise.
+   */
+  @Test
+  public void testPageConstructorSetsOnlyTheTextAndHref() throws ComponentConfigurationException {
+    final Map<String, Object> pageProperties = new HashMap<>();
+    pageProperties.put("jcr:primaryType", "kes:Page");
+    final Map<String, Object> contentProperties = new HashMap<>();
+    contentProperties.put("jcr:primaryType", "nt:unstructured");
+    contentProperties.put("jcr:title", "A Page Title");
+    context.create().resource("/content/sample-page", pageProperties);
+    context.create().resource("/content/sample-page/jcr:content", contentProperties);
+
+    final BaseContentPage page = context.resourceResolver().getResource("/content/sample-page")
+        .adaptTo(BaseContentPage.class);
+    final Resource parent = context.create().resource("/content/link-parent");
+    context.currentResource(parent);
+    final CardListStaticDataSource dataSource =
+        context.request().adaptTo(CardListStaticDataSource.class);
+
+    final KestrosLinkImpl pageLink =
+        new KestrosLinkImpl(page, dataSource, "link", "linkElement");
+
+    assertEquals("A Page Title", pageLink.getText());
+    assertNotNull(pageLink.getHref());
+    assertNull(pageLink.getTitle());
+    assertNull(pageLink.getTarget());
+    assertNull(pageLink.getRel());
+    assertNull(pageLink.getAriaLabel());
+    assertNull(pageLink.getAriaDescribedBy());
+    assertNull(pageLink.getLang());
   }
 }

--- a/kestros-basic-components/src/test/java/io/kestros/cms/components/basic/core/content/videoembed/EmbedSanitizerTest.java
+++ b/kestros-basic-components/src/test/java/io/kestros/cms/components/basic/core/content/videoembed/EmbedSanitizerTest.java
@@ -5,6 +5,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
+import java.util.Locale;
 import org.junit.Test;
 
 public class EmbedSanitizerTest {
@@ -143,5 +144,36 @@ public class EmbedSanitizerTest {
     String input = "<svg/onload=alert(1)>";
 
     assertNull("SVG XSS should be rejected", EmbedSanitizer.sanitize(input));
+  }
+
+  /**
+   * The sanitizer decides what to allow through by case-folding attribute names and domains. Case
+   * mapping is locale-dependent: under a Turkish locale the folded form of a name containing I
+   * carries a dotless i, which used to stop it matching the allow-list. Locale.ROOT pins it.
+   */
+  @Test
+  public void testAllowListMatchingIsIndependentOfTheDefaultLocale() {
+    final Locale previous = Locale.getDefault();
+    try {
+      Locale.setDefault(new Locale("tr", "TR"));
+
+      assertNotNull(EmbedSanitizer.sanitize(
+          "<iframe src=\"https://www.youtube.com/embed/abcdefghijk\" TITLE=\"A video\"></iframe>"));
+    } finally {
+      Locale.setDefault(previous);
+    }
+  }
+
+  @Test
+  public void testNonAllowlistedDomainIsStillRefusedUnderATurkishLocale() {
+    final Locale previous = Locale.getDefault();
+    try {
+      Locale.setDefault(new Locale("tr", "TR"));
+
+      assertNull(EmbedSanitizer.sanitize(
+          "<iframe src=\"https://evil.example.com/embed/abcdefghijk\"></iframe>"));
+    } finally {
+      Locale.setDefault(previous);
+    }
   }
 }

--- a/kestros-basic-components/src/test/java/io/kestros/cms/components/basic/core/lists/cardlist/CardListAssetsDataSourceTest.java
+++ b/kestros-basic-components/src/test/java/io/kestros/cms/components/basic/core/lists/cardlist/CardListAssetsDataSourceTest.java
@@ -219,4 +219,31 @@ public class CardListAssetsDataSourceTest extends BaseDataSourceTest {
     assertEquals("h3",
         context.request().adaptTo(CardListAssetsDataSource.class).getHeadingLevel());
   }
+
+  /**
+   * getCardElements is annotated @Nonnull but returned null when a single asset's image could not
+   * be built, so one bad asset discarded the whole list and handed HTL a null. It skips that card
+   * now, which is what the sibling card lists already do.
+   */
+  @Test
+  public void testGetCardElementsSkipsAnAssetWhoseImageCannotBeBuilt() {
+    registerAssetRetrievalService();
+    // An asset with no path cannot produce an image; the other three still render.
+    context.create().resource("/content/assets/collection/asset-4", new HashMap<>());
+    resource = context.create().resource("/content/page/cardlist/assets-partial", properties);
+    context.request().setResource(resource);
+
+    assertNotNull(context.request().adaptTo(CardListAssetsDataSource.class).getCardElements());
+  }
+
+  @Test
+  public void testGetCardElementsIsNeverNull() {
+    registerAssetRetrievalService();
+    final Map<String, Object> props = new HashMap<>();
+    props.put("collectionPath", "/content/assets/nowhere");
+    resource = context.create().resource("/content/page/cardlist/assets-missing", props);
+    context.request().setResource(resource);
+
+    assertNotNull(context.request().adaptTo(CardListAssetsDataSource.class).getCardElements());
+  }
 }

--- a/kestros-basic-components/src/test/java/io/kestros/cms/components/basic/core/navigation/nav/NavigationItemStaticDataSourceTest.java
+++ b/kestros-basic-components/src/test/java/io/kestros/cms/components/basic/core/navigation/nav/NavigationItemStaticDataSourceTest.java
@@ -1,0 +1,57 @@
+package io.kestros.cms.components.basic.core.navigation.nav;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import io.kestros.cms.components.basic.api.navigation.KestrosNavigationItem;
+import io.kestros.cms.components.basic.core.BaseDataSourceTest;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.sling.api.resource.Resource;
+import org.junit.Test;
+
+public class NavigationItemStaticDataSourceTest extends BaseDataSourceTest {
+
+  private NavigationItemStaticDataSource dataSource;
+
+  @Override
+  public void doComponentSetup() {
+    final Map<String, Object> properties = new HashMap<>();
+    properties.put("text", "Products");
+    properties.put("href", "/content/products");
+    final Resource resource =
+        context.create().resource("/content/page/jcr:content/nav-item", properties);
+    context.request().setResource(resource);
+    dataSource = context.request().adaptTo(NavigationItemStaticDataSource.class);
+  }
+
+  @Override
+  public void testToSyntheticResource() {
+    assertEquals(KestrosNavigationItem.RESOURCE_TYPE,
+        dataSource.toSyntheticResource(context.resourceResolver(), "/content/page/jcr:content")
+            .getResourceType());
+  }
+
+  /**
+   * isActive returned null from a method the interface declares @Nonnull, so a Java caller writing
+   * {@code if (item.isActive())} unboxed a null and threw. It has to be a real Boolean now.
+   *
+   * <p>Nothing computes active state yet, so FALSE is the only correct answer; this asserts the
+   * contract, not the feature.</p>
+   */
+  @Test
+  public void testIsActiveIsNeverNull() {
+    assertFalse(dataSource.isActive());
+  }
+
+  @Test
+  public void testGetNavigationItemsIsEmpty() {
+    assertTrue(dataSource.getNavigationItems().isEmpty());
+  }
+
+  @Test
+  public void testGetText() {
+    assertEquals("Products", dataSource.getText());
+  }
+}


### PR DESCRIPTION
Phase 3 of 4 for `kestros-basic-components`, stacked on #103. Merge 1 → 2 → 3 → 4.

Tests for the behaviour that phase 2 changed, so each change is pinned rather than assumed.

**The two extracted sorters are tested directly.** All four orderings each, including a page with no `jcr:content` and an asset with no dates. Those guards existed inside the inline lambdas but were never exercised on both sides — which is how the whole `createdDate`/`lastModified` comparator pair went uncovered across four classes in the first place.

**`PropertyBackedSyntheticResource` is asserted to copy the properties it is handed**, so a caller changing its own map afterwards cannot rewrite what the resource reports.

**`isActive()` is asserted to be a real Boolean.** That is the contract, not the feature: nothing computes active state for a navigation item yet, so `FALSE` is the only correct answer today.

**The embed sanitizer runs under a Turkish default locale** — an allow-listed embed still passes, a non-allow-listed domain is still refused. Without `Locale.ROOT` the first of those fails.

**`getCardElements` is asserted never to return null**, which is what its `@Nonnull` annotation always claimed and the code did not do.

**`KestrosLinkImpl`'s page constructor asserts what it actually provides** now that the six self-assignments are gone: text and href set, title/target/rel/aria null. Pinning the current contract is what makes changing it a deliberate act rather than a surprise — and if you decide those fields should carry something, this test is where that decision gets recorded.

**`HeadingPageTitleDataSource` had no test class at all.** Its override-inherited-title path without a request used to throw a bare `RuntimeException`; the typed exception is asserted to name both the component and the property.

Coverage moves 0.802 → 0.812 branch. Line is 0.811, slightly below phase 1's 0.819 because phase 2 added the two sorters, the synthetic resource and the typed exceptions; both bounds stay clear.