### PR TITLE
Bump basic-components to 0.3.2-SNAPSHOT

### DIFF
--- a/kestros-basic-components/pom.xml
+++ b/kestros-basic-components/pom.xml
@@ -31,7 +31,7 @@
 
     <groupId>io.kestros.cms</groupId>
     <artifactId>kestros-basic-components</artifactId>
-    <version>0.3.1</version>
+    <version>0.3.2-SNAPSHOT</version>
 
     <name>Kestros Basic Components</name>
     <description>Basic content components (navigation, lists, structure, media) for Kestros sites.</description>

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
 
     <groupId>io.kestros.cms</groupId>
     <artifactId>kestros-basic-components-parent</artifactId>
-    <version>0.3.1</version>
+    <version>0.3.2-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Kestros Basic Components (Reactor)</name>


### PR DESCRIPTION
The bundle was sitting at 0.3.1 — a released version — with two behaviour changes merged on top of it today: the authorable link component (#93) and the top-navigation brand href (#94).

A released version must not be edited in place, so this moves the bundle and its reactor parent to 0.3.2-SNAPSHOT. Anything consuming 0.3.1 keeps resolving the artifact that was actually released, and the new work lands on a snapshot that can be built and tested.

kestros-basic-components-testing is versioned independently and did not change, so it stays at 0.3.2.

Needed so a starter jar can be built that actually contains those two fixes — the published 0.9.0 image predates them.