### PR TITLE
SpotBugs 1/5: return unmodifiable views instead of internal lists

### DIFF
--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/api/content/KestrosButtonGroup.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/api/content/KestrosButtonGroup.java
@@ -20,8 +20,9 @@ public interface KestrosButtonGroup extends KestrosContainerElement {
 
   @Nonnull
   default List<Resource> getButtons() {
-    List<Resource> buttons = new ArrayList<>();
-    for (KestrosButton button : getButtonsElements()) {
+    final List<KestrosButton> sourceButtons = getButtonsElements();
+    final List<Resource> buttons = new ArrayList<>(sourceButtons.size());
+    for (KestrosButton button : sourceButtons) {
       buttons.add(button.getResource());
     }
     return buttons;

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/api/exceptions/ComponentElementRenderingException.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/api/exceptions/ComponentElementRenderingException.java
@@ -1,0 +1,39 @@
+
+package io.kestros.cms.components.basic.api.exceptions;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import javax.annotation.Nonnull;
+
+/**
+ * Thrown when a basic component cannot build one of its child elements for rendering.
+ *
+ * <p>Unchecked, because these getters are called from HTL, which cannot handle a checked
+ * exception. Typed rather than a bare {@code RuntimeException} so a rendering failure can be told
+ * apart from any other runtime failure, and so the message names the component and the element
+ * that failed rather than surfacing a bare cause.</p>
+ */
+@SuppressFBWarnings("IMC_IMMATURE_CLASS_NO_EQUALS")
+public class ComponentElementRenderingException extends RuntimeException {
+
+  private static final long serialVersionUID = 1L;
+
+  /**
+   * Thrown when a basic component cannot build one of its child elements for rendering.
+   *
+   * @param message Which element could not be built, and for which component.
+   * @param cause Underlying failure.
+   */
+  public ComponentElementRenderingException(@Nonnull final String message,
+      @Nonnull final Throwable cause) {
+    super(message, cause);
+  }
+
+  /**
+   * Thrown when a basic component cannot build one of its child elements for rendering.
+   *
+   * @param message Which element could not be built, and for which component.
+   */
+  public ComponentElementRenderingException(@Nonnull final String message) {
+    super(message);
+  }
+}

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/api/exceptions/ComponentElementRenderingException.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/api/exceptions/ComponentElementRenderingException.java
@@ -12,7 +12,9 @@ import javax.annotation.Nonnull;
  * apart from any other runtime failure, and so the message names the component and the element
  * that failed rather than surfacing a bare cause.</p>
  */
-@SuppressFBWarnings("IMC_IMMATURE_CLASS_NO_EQUALS")
+@SuppressFBWarnings(value = "IMC_IMMATURE_CLASS_NO_EQUALS",
+    justification = "An exception type. Throwable compares by identity, nothing here compares"
+        + " two of these, and value equality on a thrown exception is not meaningful.")
 public class ComponentElementRenderingException extends RuntimeException {
 
   private static final long serialVersionUID = 1L;

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/api/lists/KestrosCardList.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/api/lists/KestrosCardList.java
@@ -13,14 +13,16 @@ public interface KestrosCardList extends KestrosContainerElement {
   String RESOURCE_TYPE = "/libs/kestros/commons/components/lists/card-list";
 
   @Override
+  @Nonnull
   default String getComponentResourceType() {
     return RESOURCE_TYPE;
   }
 
   @Nonnull
   default List<Resource> getCards() {
-    List<Resource> cards = new ArrayList<>();
-    for (KestrosCard card : getCardElements()) {
+    final List<KestrosCard> sourceCards = getCardElements();
+    final List<Resource> cards = new ArrayList<>(sourceCards.size());
+    for (KestrosCard card : sourceCards) {
       cards.add(card.getResource());
     }
     return cards;

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/api/lists/KestrosLinkList.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/api/lists/KestrosLinkList.java
@@ -19,8 +19,9 @@ public interface KestrosLinkList extends KestrosContainerElement {
 
   @Nonnull
   default List<Resource> getLinks() {
-    List<Resource> links = new ArrayList<>();
-    for (KestrosLink link : getLinkElements()) {
+    final List<KestrosLink> sourceLinks = getLinkElements();
+    final List<Resource> links = new ArrayList<>(sourceLinks.size());
+    for (KestrosLink link : sourceLinks) {
       links.add(link.getResource());
     }
     return links;

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/api/navigation/KestrosBreadCrumbs.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/api/navigation/KestrosBreadCrumbs.java
@@ -19,8 +19,9 @@ public interface KestrosBreadCrumbs extends KestrosContainerElement {
 
   @Nonnull
   default List<Resource> getLinks() {
-    List<Resource> links = new ArrayList<>();
-    for (KestrosBreadCrumb link : getLinkElements()) {
+    final List<KestrosBreadCrumb> sourceLinks = getLinkElements();
+    final List<Resource> links = new ArrayList<>(sourceLinks.size());
+    for (KestrosBreadCrumb link : sourceLinks) {
       links.add(link.getResource());
     }
     return links;

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/api/navigation/KestrosNavigation.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/api/navigation/KestrosNavigation.java
@@ -19,8 +19,9 @@ public interface KestrosNavigation extends KestrosContainerElement {
 
   @Nonnull
   default List<Resource> getNavigationLinks() {
-    List<Resource> resources = new ArrayList<>();
-    for (KestrosNavigationItem item : getNavigationLinkElements()) {
+    final List<KestrosNavigationItem> sourceResources = getNavigationLinkElements();
+    final List<Resource> resources = new ArrayList<>(sourceResources.size());
+    for (KestrosNavigationItem item : sourceResources) {
       resources.add(item.getResource());
     }
     return resources;

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/api/navigation/KestrosNavigationItem.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/api/navigation/KestrosNavigationItem.java
@@ -24,8 +24,9 @@ public interface KestrosNavigationItem extends KestrosLink, KestrosContainerElem
 
   @Nonnull
   default List<Resource> getNavigationItemLinks() {
-    List<Resource> resources = new ArrayList<>();
-    for (KestrosNavigationItem item : getNavigationItems()) {
+    final List<KestrosNavigationItem> sourceResources = getNavigationItems();
+    final List<Resource> resources = new ArrayList<>(sourceResources.size());
+    for (KestrosNavigationItem item : sourceResources) {
       resources.add(item.getResource());
     }
     return resources;

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/api/navigation/KestrosTopNavigation.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/api/navigation/KestrosTopNavigation.java
@@ -21,8 +21,9 @@ public interface KestrosTopNavigation extends KestrosContainerElement {
 
   @Nonnull
   default List<Resource> getNavigationLinks() {
-    List<Resource> resources = new ArrayList<>();
-    for (KestrosTopNavigationItem item : getNavigationLinkElements()) {
+    final List<KestrosTopNavigationItem> sourceResources = getNavigationLinkElements();
+    final List<Resource> resources = new ArrayList<>(sourceResources.size());
+    for (KestrosTopNavigationItem item : sourceResources) {
       resources.add(item.getResource());
     }
     return resources;

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/api/navigation/KestrosTopNavigationItem.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/api/navigation/KestrosTopNavigationItem.java
@@ -25,8 +25,9 @@ public interface KestrosTopNavigationItem extends KestrosContainerElement {
 
   @Nonnull
   default List<Resource> getNavigationItemLinks() {
-    List<Resource> resources = new ArrayList<>();
-    for (KestrosTopNavigationItem item : getNavigationItems()) {
+    final List<KestrosTopNavigationItem> sourceResources = getNavigationItems();
+    final List<Resource> resources = new ArrayList<>(sourceResources.size());
+    for (KestrosTopNavigationItem item : sourceResources) {
       resources.add(item.getResource());
     }
     return resources;

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/api/structure/KestrosAccordion.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/api/structure/KestrosAccordion.java
@@ -30,8 +30,9 @@ public interface KestrosAccordion extends KestrosContainerElement {
   @JsonIgnore
   @Nonnull
   default List<Resource> getPanels() {
-    List<Resource> panelResources = new ArrayList<>();
-    for (KestrosAccordionPanel panel : getPanelElements()) {
+    final List<KestrosAccordionPanel> sourcePanelResources = getPanelElements();
+    final List<Resource> panelResources = new ArrayList<>(sourcePanelResources.size());
+    for (KestrosAccordionPanel panel : sourcePanelResources) {
       if (panel.isSynthetic()) {
         panelResources.add(panel.toSyntheticResource(getResourceResolver(), getPath()));
       } else {

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/api/table/KestrosTable.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/api/table/KestrosTable.java
@@ -21,8 +21,9 @@ public interface KestrosTable extends KestrosContainerElement {
 
   @Nonnull
   default List<Resource> getHeaders() {
-    List<Resource> headers = new ArrayList<>();
-    for (KestrosTableHeader header : getHeaderElements()) {
+    final List<KestrosTableHeader> sourceHeaders = getHeaderElements();
+    final List<Resource> headers = new ArrayList<>(sourceHeaders.size());
+    for (KestrosTableHeader header : sourceHeaders) {
       if (header.isSynthetic()) {
         headers.add(header.toSyntheticResource(getResourceResolver(), getPath()));
       } else {
@@ -37,8 +38,9 @@ public interface KestrosTable extends KestrosContainerElement {
 
   @Nonnull
   default List<Resource> getRows() {
-    List<Resource> rows = new ArrayList<>();
-    for (KestrosTableRow row : getRowElements()) {
+    final List<KestrosTableRow> sourceRows = getRowElements();
+    final List<Resource> rows = new ArrayList<>(sourceRows.size());
+    for (KestrosTableRow row : sourceRows) {
       if (row.isSynthetic()) {
         rows.add(row.toSyntheticResource(getResourceResolver(), getPath()));
       } else {

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/api/table/KestrosTableRow.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/api/table/KestrosTableRow.java
@@ -24,8 +24,9 @@ public interface KestrosTableRow extends KestrosContainerElement {
   @JsonIgnore
   @Nonnull
   default List<Resource> getCells() {
-    List<Resource> cells = new ArrayList<>();
-    for (KestrosTableCell cell : getCellElements()) {
+    final List<KestrosTableCell> sourceCells = getCellElements();
+    final List<Resource> cells = new ArrayList<>(sourceCells.size());
+    for (KestrosTableCell cell : sourceCells) {
       if (cell.isSynthetic()) {
         cells.add(cell.toSyntheticResource(getResourceResolver(), getPath()));
       } else {

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/AssetSorter.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/AssetSorter.java
@@ -1,0 +1,114 @@
+package io.kestros.cms.components.basic.core;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import io.kestros.cms.assets.api.models.Asset;
+import java.util.Comparator;
+import java.util.Date;
+import java.util.List;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+/**
+ * Orders the assets behind a list component.
+ *
+ * <p>Extracted from the inline comparators in CardListAssetsDataSource so the ordering rules can
+ * carry their own nullability contract, which a lambda body cannot. Mirrors
+ * {@link ContentPageSorter} for pages.</p>
+ */
+@SuppressFBWarnings("IMC_IMMATURE_CLASS_NO_TOSTRING")
+public final class AssetSorter {
+
+  private static final String CREATED_DATE = "createdDate";
+  private static final String LAST_MODIFIED = "lastModified";
+  private static final String NAME = "name";
+
+  private AssetSorter() {
+    // Utility class; not instantiable.
+  }
+
+  /**
+   * Sorts the supplied assets in place, by the named property.
+   *
+   * <p>An unrecognised sort key falls back to the title, which is the behaviour the inline
+   * comparators had.</p>
+   *
+   * @param assets Assets to sort, modified in place.
+   * @param sortBy Sort key: createdDate, lastModified, name, or anything else for title.
+   */
+  public static void sort(@Nonnull final List<Asset> assets, @Nonnull final String sortBy) {
+    if (sortBy.isEmpty()) {
+      return;
+    }
+    switch (sortBy) {
+      case CREATED_DATE:
+        assets.sort(Comparator.comparing(AssetSorter::createdTime));
+        break;
+      case LAST_MODIFIED:
+        assets.sort(Comparator.comparing(AssetSorter::modifiedTime));
+        break;
+      case NAME:
+        assets.sort(Comparator.comparing(AssetSorter::name));
+        break;
+      default:
+        assets.sort(Comparator.comparing(AssetSorter::title));
+        break;
+    }
+  }
+
+  /**
+   * The asset's creation date, as epoch milliseconds.
+   *
+   * @param asset Asset to read from.
+   * @return The creation date as epoch milliseconds, or 0 when it is absent.
+   */
+  @Nonnull
+  private static Long createdTime(@Nonnull final Asset asset) {
+    return time(asset.getCreatedDate());
+  }
+
+  /**
+   * The asset's last-modified date, as epoch milliseconds.
+   *
+   * @param asset Asset to read from.
+   * @return The last-modified date as epoch milliseconds, or 0 when it is absent.
+   */
+  @Nonnull
+  private static Long modifiedTime(@Nonnull final Asset asset) {
+    return time(asset.getModifiedDate());
+  }
+
+  /**
+   * A date as epoch milliseconds.
+   *
+   * @param date Date to convert, possibly null.
+   * @return The date as epoch milliseconds, or 0 when it is absent.
+   */
+  @Nonnull
+  private static Long time(@Nullable final Date date) {
+    return date == null ? 0L : date.getTime();
+  }
+
+  /**
+   * The asset's node name, never null.
+   *
+   * @param asset Asset to read from.
+   * @return The asset's node name, or the empty string when it has none.
+   */
+  @Nonnull
+  private static String name(@Nonnull final Asset asset) {
+    final String assetName = asset.getName();
+    return assetName == null ? "" : assetName;
+  }
+
+  /**
+   * The asset's title, falling back to its node name.
+   *
+   * @param asset Asset to read from.
+   * @return The title, the node name when there is no title, or the empty string when neither.
+   */
+  @Nonnull
+  private static String title(@Nonnull final Asset asset) {
+    final String assetTitle = asset.getTitle();
+    return assetTitle == null ? name(asset) : assetTitle;
+  }
+}

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/AssetSorter.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/AssetSorter.java
@@ -15,7 +15,9 @@ import javax.annotation.Nullable;
  * carry their own nullability contract, which a lambda body cannot. Mirrors
  * {@link ContentPageSorter} for pages.</p>
  */
-@SuppressFBWarnings("IMC_IMMATURE_CLASS_NO_TOSTRING")
+@SuppressFBWarnings(value = "IMC_IMMATURE_CLASS_NO_TOSTRING",
+    justification = "A static utility class: private constructor, no instance state, every"
+        + " method static. There is never an instance to print.")
 public final class AssetSorter {
 
   private static final String CREATED_DATE = "createdDate";

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/BaseComponentElement.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/BaseComponentElement.java
@@ -42,8 +42,8 @@ public abstract class BaseComponentElement implements KestrosBasicComponentEleme
     if (propertyValue instanceof List && !((List<?>) propertyValue).isEmpty()
         && ((List<?>) propertyValue).get(0) instanceof Map) {
       // TODO checking the map here is a bit hacky, but not sure of a better way.
-      List<Map<String, Object>> variationMaps = (List<Map<String, Object>>) propertyValue;
-      appliedVariationNames = new ArrayList<>();
+      final List<Map<String, Object>> variationMaps = (List<Map<String, Object>>) propertyValue;
+      appliedVariationNames = new ArrayList<>(variationMaps.size());
       for (Map<String, Object> variationMap : variationMaps) {
         appliedVariationNames.add((String) variationMap.get("path"));
       }

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/BaseContainerSyntheticResource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/BaseContainerSyntheticResource.java
@@ -22,8 +22,9 @@ public abstract class BaseContainerSyntheticResource extends BaseSyntheticResour
   @Nonnull
   @Override
   public List<Resource> getChildren() {
-    List<Resource> children = new ArrayList<>();
-    for (KestrosBasicComponentElement componentElement : getChildElements()) {
+    final List<KestrosBasicComponentElement> sourceChildren = getChildElements();
+    final List<Resource> children = new ArrayList<>(sourceChildren.size());
+    for (KestrosBasicComponentElement componentElement : sourceChildren) {
       children.add(componentElement.toSyntheticResource(getResourceResolver(), getPath()));
     }
     return children;

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/BaseSlingModelDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/BaseSlingModelDataSource.java
@@ -89,21 +89,25 @@ public abstract class BaseSlingModelDataSource
   }
 
 
+  @Nonnull
   public ResourceResolver getResourceResolver() {
     return getResource().getResourceResolver();
   }
 
+  @Nonnull
   public String getParentPath() {
     return getResource().getParent().getPath();
   }
 
+  @Nonnull
   public List<ComponentVariation> getVariations() {
     // TODO verify this.
     List<Map<String, Object>> variationsMapList = getResource().getValueMap()
         .get("variations", new ArrayList<>());
     if (!variationsMapList.isEmpty()) {
-      List<ComponentVariation> variations = new ArrayList<>();
-      for (Map<String, Object> variationMap : variationsMapList) {
+      final List<Map<String, Object>> sourceVariations = variationsMapList;
+      final List<ComponentVariation> variations = new ArrayList<>(sourceVariations.size());
+      for (Map<String, Object> variationMap : sourceVariations) {
         String path = (String) variationMap.get("path");
         Resource variationResource = getResourceResolver().getResource(path);
         if (variationResource == null) {

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/BaseSyntheticResource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/BaseSyntheticResource.java
@@ -23,7 +23,6 @@ public abstract class BaseSyntheticResource extends BaseComponentElement
   private final String layout;
   private final String id;
   private Resource syntheticResource;
-  private Resource resource;
   private String resourceName;
   private ComponentVariationRetrievalService componentVariationRetrievalService;
   private ComponentUiFrameworkViewRetrievalService componentUiFrameworkViewRetrievalService;

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/BaseSyntheticResource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/BaseSyntheticResource.java
@@ -16,7 +16,6 @@ import org.apache.sling.api.resource.ResourceResolver;
 
 public abstract class BaseSyntheticResource extends BaseComponentElement
     implements KestrosBasicComponentElement {
-  private final ResourceResolver resourceResolver;
   private final String parentPath;
   private final UiFramework uiFramework;
   private final List<ComponentVariation> componentVariations;
@@ -33,7 +32,7 @@ public abstract class BaseSyntheticResource extends BaseComponentElement
       @Nonnull String resourcePrefix, @Nullable String forcedResourceName) throws
       ComponentConfigurationException {
     this.dataSource = dataSource;
-    this.resourceResolver = dataSource.getResourceResolver();
+    final ResourceResolver resourceResolver = dataSource.getResourceResolver();
     this.parentPath = dataSource.getResource().getPath();
     this.uiFramework = dataSource.getUiFramework();
     this.componentVariations = dataSource.getElementVariations(resourcePrefix + "Variations",
@@ -60,7 +59,7 @@ public abstract class BaseSyntheticResource extends BaseComponentElement
 
   @Override
   public ResourceResolver getResourceResolver() {
-    return resourceResolver;
+    return dataSource.getResourceResolver();
   }
 
   @Override
@@ -71,7 +70,7 @@ public abstract class BaseSyntheticResource extends BaseComponentElement
   @Override
   public Resource getResource() {
     if (syntheticResource == null) {
-      syntheticResource = toSyntheticResource(resourceResolver, parentPath);
+      syntheticResource = toSyntheticResource(getResourceResolver(), parentPath);
     }
     return syntheticResource;
   }

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/ContentPageSorter.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/ContentPageSorter.java
@@ -1,0 +1,124 @@
+package io.kestros.cms.components.basic.core;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import io.kestros.cms.sitebuilding.api.models.BaseContentPage;
+import java.util.Calendar;
+import java.util.Comparator;
+import java.util.List;
+import javax.annotation.Nonnull;
+import org.apache.sling.api.resource.Resource;
+
+/**
+ * Orders the pages behind a list component.
+ *
+ * <p>The four list data sources that sort pages carried an identical copy of these three
+ * comparators as inline lambdas. Extracted here so the ordering rules live in one place and can
+ * carry their own nullability contract, which a lambda body cannot.</p>
+ */
+@SuppressFBWarnings("IMC_IMMATURE_CLASS_NO_TOSTRING")
+public final class ContentPageSorter {
+
+  private static final String CREATED_DATE = "createdDate";
+  private static final String LAST_MODIFIED = "lastModified";
+  private static final String NAME = "name";
+
+  private ContentPageSorter() {
+    // Utility class; not instantiable.
+  }
+
+  /**
+   * Sorts the supplied pages in place, by the named property.
+   *
+   * <p>An unrecognised sort key falls back to the display title, which is the behaviour the
+   * inline comparators had.</p>
+   *
+   * @param pages Pages to sort, modified in place.
+   * @param sortBy Sort key: createdDate, lastModified, name, or anything else for display title.
+   */
+  public static void sort(@Nonnull final List<BaseContentPage> pages,
+      @Nonnull final String sortBy) {
+    if (sortBy.isEmpty()) {
+      return;
+    }
+    switch (sortBy) {
+      case CREATED_DATE:
+        pages.sort(Comparator.comparing(ContentPageSorter::createdDate));
+        break;
+      case LAST_MODIFIED:
+        pages.sort(Comparator.comparing(ContentPageSorter::lastModifiedDate));
+        break;
+      case NAME:
+        pages.sort(Comparator.comparing(ContentPageSorter::name));
+        break;
+      default:
+        pages.sort(Comparator.comparing(ContentPageSorter::displayTitle));
+        break;
+    }
+  }
+
+  /**
+   * The page's creation date, as epoch milliseconds.
+   *
+   * @param page Page to read from.
+   * @return The creation date as epoch milliseconds, or 0 when it is absent.
+   */
+  @Nonnull
+  private static Long createdDate(@Nonnull final BaseContentPage page) {
+    return contentDate(page, "jcr:created");
+  }
+
+  /**
+   * The page's last-modified date, as epoch milliseconds.
+   *
+   * @param page Page to read from.
+   * @return The last-modified date as epoch milliseconds, or 0 when it is absent.
+   */
+  @Nonnull
+  private static Long lastModifiedDate(@Nonnull final BaseContentPage page) {
+    return contentDate(page, "jcr:lastModified");
+  }
+
+  /**
+   * A date property from the page's jcr:content, as epoch milliseconds.
+   *
+   * @param page Page to read from.
+   * @param propertyName Date property to read.
+   * @return The property as epoch milliseconds, or 0 when the page has no jcr:content or the
+   *     property is absent.
+   */
+  @Nonnull
+  private static Long contentDate(@Nonnull final BaseContentPage page,
+      @Nonnull final String propertyName) {
+    final Resource content = page.getResource().getChild("jcr:content");
+    if (content == null) {
+      return 0L;
+    }
+    final Calendar calendar = content.getValueMap().get(propertyName, Calendar.class);
+    return calendar == null ? 0L : calendar.getTimeInMillis();
+  }
+
+  /**
+   * The page's node name, never null.
+   *
+   * @param page Page to read from.
+   * @return The page's node name, or the empty string when it has none.
+   */
+  @Nonnull
+  private static String name(@Nonnull final BaseContentPage page) {
+    final String pageName = page.getName();
+    return pageName == null ? "" : pageName;
+  }
+
+  /**
+   * The page's display title, falling back to its node name.
+   *
+   * @param page Page to read from.
+   * @return The display title, the node name when there is no title, or the empty string when
+   *     there is neither.
+   */
+  @Nonnull
+  private static String displayTitle(@Nonnull final BaseContentPage page) {
+    final String title = page.getDisplayTitle();
+    return title == null ? name(page) : title;
+  }
+}

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/ContentPageSorter.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/ContentPageSorter.java
@@ -15,7 +15,9 @@ import org.apache.sling.api.resource.Resource;
  * comparators as inline lambdas. Extracted here so the ordering rules live in one place and can
  * carry their own nullability contract, which a lambda body cannot.</p>
  */
-@SuppressFBWarnings("IMC_IMMATURE_CLASS_NO_TOSTRING")
+@SuppressFBWarnings(value = "IMC_IMMATURE_CLASS_NO_TOSTRING",
+    justification = "A static utility class: private constructor, no instance state, every"
+        + " method static. There is never an instance to print.")
 public final class ContentPageSorter {
 
   private static final String CREATED_DATE = "createdDate";

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/PropertyBackedSyntheticResource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/PropertyBackedSyntheticResource.java
@@ -19,7 +19,7 @@ import org.apache.sling.api.wrappers.ValueMapDecorator;
 @SuppressFBWarnings("IMC_IMMATURE_CLASS_NO_TOSTRING")
 public class PropertyBackedSyntheticResource extends SyntheticResource {
 
-  private final Map<String, Object> properties;
+  private final ValueMap valueMap;
 
   /**
    * A synthetic resource whose properties come from a supplied map.
@@ -34,7 +34,7 @@ public class PropertyBackedSyntheticResource extends SyntheticResource {
       @Nonnull final ResourceMetadata resourceMetadata, @Nonnull final String resourceType,
       @Nonnull final Map<String, Object> properties) {
     super(resourceResolver, resourceMetadata, resourceType);
-    this.properties = new HashMap<>(properties);
+    this.valueMap = new ValueMapDecorator(new HashMap<>(properties));
   }
 
   /**
@@ -46,6 +46,6 @@ public class PropertyBackedSyntheticResource extends SyntheticResource {
   @Override
   @Nonnull
   public ValueMap getValueMap() {
-    return new ValueMapDecorator(new HashMap<>(properties));
+    return new ValueMapDecorator(new HashMap<>(valueMap));
   }
 }

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/PropertyBackedSyntheticResource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/PropertyBackedSyntheticResource.java
@@ -1,9 +1,10 @@
 package io.kestros.cms.components.basic.core;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import org.apache.sling.api.resource.ResourceMetadata;
 import org.apache.sling.api.resource.ResourceResolver;
 import org.apache.sling.api.resource.SyntheticResource;
@@ -16,7 +17,6 @@ import org.apache.sling.api.wrappers.ValueMapDecorator;
  * <p>Both synthetic-resource builders used an anonymous subclass for this, which captured the
  * enclosing component for no reason and could carry no nullability contract of its own.</p>
  */
-@SuppressFBWarnings("IMC_IMMATURE_CLASS_NO_TOSTRING")
 public class PropertyBackedSyntheticResource extends SyntheticResource {
 
   private final ValueMap valueMap;
@@ -47,5 +47,45 @@ public class PropertyBackedSyntheticResource extends SyntheticResource {
   @Nonnull
   public ValueMap getValueMap() {
     return new ValueMapDecorator(new HashMap<>(valueMap));
+  }
+
+  /**
+   * Whether another object is a synthetic resource reporting the same thing as this one.
+   *
+   * @param other Object to compare against.
+   * @return True when the other object is a PropertyBackedSyntheticResource at the same path, of
+   *     the same resource type, reporting the same properties.
+   */
+  @Override
+  public boolean equals(@Nullable final Object other) {
+    if (this == other) {
+      return true;
+    }
+    if (!(other instanceof PropertyBackedSyntheticResource)) {
+      return false;
+    }
+    final PropertyBackedSyntheticResource that = (PropertyBackedSyntheticResource) other;
+    return Objects.equals(getPath(), that.getPath())
+        && Objects.equals(getResourceType(), that.getResourceType())
+        && Objects.equals(valueMap, that.valueMap);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(getPath(), getResourceType(), valueMap);
+  }
+
+  /**
+   * Describes the resource for a log line.
+   *
+   * @return The resource's path, type, and how many properties it reports. The property values
+   *     are not included: they are author content and can be arbitrarily large.
+   */
+  @Override
+  @Nonnull
+  public String toString() {
+    return "PropertyBackedSyntheticResource{path=" + getPath()
+        + ", resourceType=" + getResourceType()
+        + ", properties=" + valueMap.size() + "}";
   }
 }

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/PropertyBackedSyntheticResource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/PropertyBackedSyntheticResource.java
@@ -4,7 +4,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import org.apache.sling.api.resource.ResourceMetadata;
 import org.apache.sling.api.resource.ResourceResolver;
 import org.apache.sling.api.resource.SyntheticResource;
@@ -57,7 +56,7 @@ public class PropertyBackedSyntheticResource extends SyntheticResource {
    *     the same resource type, reporting the same properties.
    */
   @Override
-  public boolean equals(@Nullable final Object other) {
+  public boolean equals(final Object other) {
     if (this == other) {
       return true;
     }

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/PropertyBackedSyntheticResource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/PropertyBackedSyntheticResource.java
@@ -19,7 +19,7 @@ import org.apache.sling.api.wrappers.ValueMapDecorator;
 @SuppressFBWarnings("IMC_IMMATURE_CLASS_NO_TOSTRING")
 public class PropertyBackedSyntheticResource extends SyntheticResource {
 
-  private final ValueMap valueMap;
+  private final Map<String, Object> properties;
 
   /**
    * A synthetic resource whose properties come from a supplied map.
@@ -34,12 +34,18 @@ public class PropertyBackedSyntheticResource extends SyntheticResource {
       @Nonnull final ResourceMetadata resourceMetadata, @Nonnull final String resourceType,
       @Nonnull final Map<String, Object> properties) {
     super(resourceResolver, resourceMetadata, resourceType);
-    this.valueMap = new ValueMapDecorator(new HashMap<>(properties));
+    this.properties = new HashMap<>(properties);
   }
 
+  /**
+   * The properties the resource reports.
+   *
+   * @return A fresh value map over a copy of the properties. Writing to it changes nothing the
+   *     resource reports, and one caller's writes are invisible to the next.
+   */
   @Override
   @Nonnull
   public ValueMap getValueMap() {
-    return valueMap;
+    return new ValueMapDecorator(new HashMap<>(properties));
   }
 }

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/PropertyBackedSyntheticResource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/PropertyBackedSyntheticResource.java
@@ -16,7 +16,10 @@ import org.apache.sling.api.wrappers.ValueMapDecorator;
  * <p>Both synthetic-resource builders used an anonymous subclass for this, which captured the
  * enclosing component for no reason and could carry no nullability contract of its own.</p>
  */
-@SuppressFBWarnings("IMC_IMMATURE_CLASS_NO_TOSTRING")
+@SuppressFBWarnings(value = "IMC_IMMATURE_CLASS_NO_TOSTRING",
+    justification = "A style rule rather than a defect: the detector fires on every class that"
+        + " does not declare toString. The properties here are author content and can be"
+        + " arbitrarily large, so a default rendering of them is not something to add.")
 public class PropertyBackedSyntheticResource extends SyntheticResource {
 
   private final ValueMap valueMap;

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/PropertyBackedSyntheticResource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/PropertyBackedSyntheticResource.java
@@ -1,0 +1,45 @@
+package io.kestros.cms.components.basic.core;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import java.util.HashMap;
+import java.util.Map;
+import javax.annotation.Nonnull;
+import org.apache.sling.api.resource.ResourceMetadata;
+import org.apache.sling.api.resource.ResourceResolver;
+import org.apache.sling.api.resource.SyntheticResource;
+import org.apache.sling.api.resource.ValueMap;
+import org.apache.sling.api.wrappers.ValueMapDecorator;
+
+/**
+ * A synthetic resource whose properties come from a supplied map rather than from the repository.
+ *
+ * <p>Both synthetic-resource builders used an anonymous subclass for this, which captured the
+ * enclosing component for no reason and could carry no nullability contract of its own.</p>
+ */
+@SuppressFBWarnings("IMC_IMMATURE_CLASS_NO_TOSTRING")
+public class PropertyBackedSyntheticResource extends SyntheticResource {
+
+  private final ValueMap valueMap;
+
+  /**
+   * A synthetic resource whose properties come from a supplied map.
+   *
+   * @param resourceResolver Resolver the synthetic resource belongs to.
+   * @param resourceMetadata Metadata describing where the resource sits.
+   * @param resourceType Resource type the synthetic resource reports.
+   * @param properties Properties the resource exposes. Copied, so a later change by the caller
+   *     cannot rewrite what the resource reports.
+   */
+  public PropertyBackedSyntheticResource(@Nonnull final ResourceResolver resourceResolver,
+      @Nonnull final ResourceMetadata resourceMetadata, @Nonnull final String resourceType,
+      @Nonnull final Map<String, Object> properties) {
+    super(resourceResolver, resourceMetadata, resourceType);
+    this.valueMap = new ValueMapDecorator(new HashMap<>(properties));
+  }
+
+  @Override
+  @Nonnull
+  public ValueMap getValueMap() {
+    return valueMap;
+  }
+}

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/PropertyBackedSyntheticResource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/PropertyBackedSyntheticResource.java
@@ -55,8 +55,11 @@ public class PropertyBackedSyntheticResource extends SyntheticResource {
    * @return True when the other object is a PropertyBackedSyntheticResource at the same path, of
    *     the same resource type, reporting the same properties.
    */
+  // @Nonnull, not @Nullable: the package declares parameters non-null by default, so the inherited
+  // equals(Object) is already annotated that way and widening it here is an incompatible override.
+  // The instanceof below still returns false for a null argument, so nothing throws either way.
   @Override
-  public boolean equals(final Object other) {
+  public boolean equals(@Nonnull final Object other) {
     if (this == other) {
       return true;
     }

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/button/KestrosButtonImpl.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/button/KestrosButtonImpl.java
@@ -23,7 +23,6 @@ public class KestrosButtonImpl extends BaseSyntheticResource implements KestrosB
   private String ariaDescribedBy;
   private String lang;
   private boolean disabled;
-  private String resourceName;
 
   public KestrosButtonImpl(String text, String href,
       String title,
@@ -44,7 +43,6 @@ public class KestrosButtonImpl extends BaseSyntheticResource implements KestrosB
     this.ariaDescribedBy = ariaDescribedBy;
     this.lang = lang;
     this.disabled = disabled;
-    this.resourceName = forcedResourceName;
   }
 
   public KestrosButtonImpl(@Nonnull Resource resource,

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/buttongroup/ButtonGroupDataSourceComponent.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/buttongroup/ButtonGroupDataSourceComponent.java
@@ -4,6 +4,7 @@ import io.kestros.cms.components.basic.api.content.KestrosButton;
 import io.kestros.cms.components.basic.api.content.KestrosButtonGroup;
 import io.kestros.cms.components.basic.core.BaseContainerDataSourceComponent;
 import io.kestros.cms.componenttypes.api.models.ComponentVariation;
+import java.util.ArrayList;
 import java.util.List;
 import javax.annotation.Nonnull;
 import org.apache.sling.api.SlingHttpServletRequest;
@@ -23,7 +24,7 @@ public class ButtonGroupDataSourceComponent extends
     if (buttons == null) {
       buttons = getComponentData().getButtonsElements();
     }
-    return buttons;
+    return new ArrayList<>(buttons);
   }
 
   @Override
@@ -31,7 +32,7 @@ public class ButtonGroupDataSourceComponent extends
     if (componentVariations == null) {
       componentVariations = getComponentData().getButtonVariations();
     }
-    return componentVariations;
+    return new ArrayList<>(componentVariations);
   }
 
 }

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/buttongroup/KestrosButtonGroupImpl.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/buttongroup/KestrosButtonGroupImpl.java
@@ -26,7 +26,7 @@ public class KestrosButtonGroupImpl extends BaseContainerSyntheticResource imple
       ComponentConfigurationException {
     super(dataSource, resourcePrefix,
         forcedResourceName);
-    this.buttons = buttons;
+    this.buttons = new ArrayList<>(buttons);
     this.buttonVariations = dataSource.getElementVariations("button", KestrosButton.RESOURCE_TYPE);
   }
 
@@ -51,9 +51,11 @@ public class KestrosButtonGroupImpl extends BaseContainerSyntheticResource imple
           "button",
           "buttonElement"));
     }
-    this.buttons = buttons;
+    this.buttons = new ArrayList<>(buttons);
     if (this.buttons.isEmpty()) {
-      throw new ComponentConfigurationException("Button Group must have at least one button.");
+      throw new ComponentConfigurationException(String.format(
+          "Unable to build the button group %s: a button group must have at least one button.",
+          String.valueOf(resourcePrefix)));
     }
   }
 

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/card/CardAssetDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/card/CardAssetDataSource.java
@@ -1,8 +1,10 @@
 package io.kestros.cms.components.basic.core.content.card;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.kestros.cms.assets.api.exceptions.AssetRetrievalException;
 import io.kestros.cms.assets.api.models.Asset;
 import io.kestros.cms.assets.api.services.AssetRetrievalService;
+import io.kestros.cms.components.basic.api.exceptions.ComponentElementRenderingException;
 import io.kestros.cms.components.basic.api.content.AnchorTarget;
 import io.kestros.cms.components.basic.api.content.KestrosButtonGroup;
 import io.kestros.cms.components.basic.api.content.KestrosCard;
@@ -15,14 +17,20 @@ import io.kestros.cms.components.basic.core.content.image.KestrosImageImpl;
 import io.kestros.cms.componenttypes.api.models.ComponentVariation;
 import java.util.List;
 import javax.annotation.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.models.annotations.Model;
 import org.apache.sling.models.annotations.Optional;
 import org.apache.sling.models.annotations.injectorspecific.OSGiService;
 
+@SuppressFBWarnings("IMC_IMMATURE_CLASS_NO_TOSTRING")
 @Model(adaptables = {SlingHttpServletRequest.class, Resource.class})
 public class CardAssetDataSource extends BaseContainerSlingModelDataSource implements KestrosCard {
+
+  private static final Logger LOG =
+      LoggerFactory.getLogger(CardAssetDataSource.class);
 
   private Asset asset;
 
@@ -42,50 +50,48 @@ public class CardAssetDataSource extends BaseContainerSlingModelDataSource imple
   @Nullable
   @Override
   public KestrosHeading getTitleElement() {
-    if (getAsset() != null) {
-      String title = getAsset().getTitle();
-      String headingLevel = getResource().getValueMap().get("headingType", "h1");
-      try {
-        return new KestrosHeadingImpl(title, headingLevel,
-                this,
-                "title",
-                "titleElement");
-      } catch (ComponentConfigurationException e) {
-        // do nothing.
-      }
+    final Asset cardAsset = getAsset();
+    if (cardAsset == null) {
       return null;
     }
-    return null;
+    try {
+      return new KestrosHeadingImpl(cardAsset.getTitle(),
+              getResource().getValueMap().get("headingType", "h1"),
+              this,
+              "title",
+              "titleElement");
+    } catch (ComponentConfigurationException e) {
+      LOG.debug("No title element for the card backed by {}: the heading could not be built. {}",
+          String.valueOf(cardAsset.getPath()).replaceAll("[\r\n]", ""),
+          String.valueOf(e.getMessage()).replaceAll("[\r\n]", ""));
+      return null;
+    }
   }
 
+  @SuppressFBWarnings(value = "EXS_EXCEPTION_SOFTENING_NO_CHECKED",
+      justification = "Called from HTL, which cannot handle a checked exception. The checked"
+          + " cause is wrapped in a typed ComponentElementRenderingException so the failure"
+          + " stays identifiable, per the ruling on DataSourceComponent.")
   @Nullable
   @Override
   public KestrosImage getImageElement() {
-    if (getAsset() != null) {
-      if (getAsset().getPath() != null) {
-        String imagePath = getAsset().getPath();
-        String altText = null;
-        String caption = null;
-        String imageTitle = null;
-        String href = null;
-        String ariaLabel = null;
-        String anchorTitle = null;
-        AnchorTarget target = AnchorTarget.SAME_WINDOW;
-        String id = null;
-        List<ComponentVariation> componentVariations
-                = getElementVariations("imageVariations", KestrosImage.RESOURCE_TYPE);
-        String layout = getLayout("image");
-        try {
-          return new KestrosImageImpl(imagePath, altText, caption,
-                  imageTitle, href, ariaLabel,
-                  anchorTitle, target, this, "image", "imageElement", assetRetrievalService);
-        } catch (ComponentConfigurationException e) {
-          throw new RuntimeException(e);
-        }
-      }
+    final Asset cardAsset = getAsset();
+    if (cardAsset == null || cardAsset.getPath() == null) {
       return null;
     }
-    return null;
+    try {
+      // Arguments after the path are altText, caption, imageTitle, href, ariaLabel and
+      // anchorTitle. They were locals initialised to null and passed straight through; the
+      // variations and layout locals alongside them were computed and never used at all.
+      return new KestrosImageImpl(cardAsset.getPath(), null, null,
+              null, null, null,
+              null, AnchorTarget.SAME_WINDOW, this, "image", "imageElement",
+              assetRetrievalService);
+    } catch (ComponentConfigurationException e) {
+      throw new ComponentElementRenderingException(
+              "Unable to build the image element for a card backed by asset "
+              + cardAsset.getPath() + ".", e);
+    }
   }
 
   @Nullable

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/card/CardAssetDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/card/CardAssetDataSource.java
@@ -25,7 +25,11 @@ import org.apache.sling.models.annotations.Model;
 import org.apache.sling.models.annotations.Optional;
 import org.apache.sling.models.annotations.injectorspecific.OSGiService;
 
-@SuppressFBWarnings("IMC_IMMATURE_CLASS_NO_TOSTRING")
+@SuppressFBWarnings(value = "IMC_IMMATURE_CLASS_NO_TOSTRING",
+    justification = "A style rule rather than a defect: the detector fires on every class that"
+        + " does not declare toString. The fields here are author content read from the"
+        + " repository and are reached through the getters HTL calls, so a default rendering of"
+        + " them is not something to add.")
 @Model(adaptables = {SlingHttpServletRequest.class, Resource.class})
 public class CardAssetDataSource extends BaseContainerSlingModelDataSource implements KestrosCard {
 

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/card/CardPageDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/card/CardPageDataSource.java
@@ -25,6 +25,8 @@ import org.apache.sling.api.resource.Resource;
 import org.apache.sling.models.annotations.Model;
 import org.apache.sling.models.annotations.Optional;
 import org.apache.sling.models.annotations.injectorspecific.OSGiService;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import io.kestros.cms.components.basic.api.exceptions.ComponentElementRenderingException;
 
 @Model(adaptables = {SlingHttpServletRequest.class, Resource.class})
 public class CardPageDataSource extends BaseContainerSlingModelDataSource implements KestrosCard {
@@ -62,68 +64,61 @@ public class CardPageDataSource extends BaseContainerSlingModelDataSource implem
     return null;
   }
 
+  @SuppressFBWarnings(value = "EXS_EXCEPTION_SOFTENING_NO_CHECKED",
+      justification = "Called from HTL, which cannot handle a checked exception. The checked"
+          + " cause is wrapped in a typed ComponentElementRenderingException so the failure"
+          + " stays identifiable, per the ruling on DataSourceComponent.")
   @Nullable
   @Override
   public KestrosImage getImageElement() {
-    if (getPage() != null) {
-      if (StringUtils.isNotEmpty(getPage().getImagePath())) {
-        String imagePath = getPage().getImagePath();
-        String altText = null;
-        String caption = null;
-        String imageTitle = null;
-        String href = null;
-        String ariaLabel = null;
-        String anchorTitle = null;
-        AnchorTarget target = AnchorTarget.SAME_WINDOW;
-        String id = null;
-        List<ComponentVariation> componentVariations
-                = getElementVariations("imageVariations",
-                KestrosImage.RESOURCE_TYPE);
-        String layout = getLayout("image");
-        try {
-          return new KestrosImageImpl(imagePath, altText, caption,
-                  imageTitle, href, ariaLabel,
-                  anchorTitle, target,
-                  this, "image", "imageElement", assetRetrievalService);
-        } catch (ComponentConfigurationException e) {
-          throw new RuntimeException(e);
-        }
-      }
+    final BaseContentPage cardPage = getPage();
+    if (cardPage == null || StringUtils.isEmpty(cardPage.getImagePath())) {
       return null;
     }
-    return null;
+    try {
+      // Arguments after the path are altText, caption, imageTitle, href, ariaLabel and
+      // anchorTitle. They were locals initialised to null and passed straight through; the
+      // variations and layout locals alongside them were computed and never used at all.
+      return new KestrosImageImpl(cardPage.getImagePath(), null, null,
+              null, null, null,
+              null, AnchorTarget.SAME_WINDOW,
+              this, "image", "imageElement", assetRetrievalService);
+    } catch (ComponentConfigurationException e) {
+      throw new ComponentElementRenderingException(
+              "Unable to build the image element for the card at " + cardPage.getPath() + ".", e);
+    }
   }
 
+  @SuppressFBWarnings(value = "EXS_EXCEPTION_SOFTENING_NO_CHECKED",
+      justification = "Called from HTL, which cannot handle a checked exception. The checked"
+          + " cause is wrapped in a typed ComponentElementRenderingException so the failure"
+          + " stays identifiable, per the ruling on DataSourceComponent.")
   @Nullable
   @Override
   public KestrosButtonGroup getButtonGroupElement() {
-    if (getPage() != null) {
-      try {
-        List<KestrosButton> buttons = new ArrayList<>();
-        String text = getResource().getValueMap().get("buttonLabel", String.class);
-        String href = LinkUtils.getLink(getPage().getPath());
-        String title = null;
-        AnchorTarget target = AnchorTarget.SAME_WINDOW;
-        String rel = null;
-        String ariaLabel = null;
-        String ariaDescribedBy = null;
-        String lang = null;
-        boolean disabled = false;
-        String buttonLayout = getLayout("button");
-        String buttonId = null;
-        buttons.add(new KestrosButtonImpl(text, href, title,
-                target, rel, ariaLabel,
-                ariaDescribedBy, lang, disabled,
-                this,
-                "button", "buttonElement"));
-        return new KestrosButtonGroupImpl(buttons,
-                this,
-                "buttonGroup", "buttonGroupElement");
-      } catch (ComponentConfigurationException e) {
-        throw new RuntimeException(e);
-      }
+    final BaseContentPage cardPage = getPage();
+    if (cardPage == null) {
+      return null;
     }
-    return null;
+    try {
+      final List<KestrosButton> buttons = new ArrayList<>(1);
+      // Arguments after the href are title, target, rel, ariaLabel, ariaDescribedBy, lang and
+      // disabled. All but the target were locals initialised to null and passed straight through;
+      // the layout and id locals alongside them were computed and never used at all.
+      buttons.add(new KestrosButtonImpl(
+              getResource().getValueMap().get("buttonLabel", String.class),
+              LinkUtils.getLink(cardPage.getPath()), null,
+              AnchorTarget.SAME_WINDOW, null, null,
+              null, null, false,
+              this,
+              "button", "buttonElement"));
+      return new KestrosButtonGroupImpl(buttons,
+              this,
+              "buttonGroup", "buttonGroupElement");
+    } catch (ComponentConfigurationException e) {
+      throw new ComponentElementRenderingException(
+              "Unable to build the button group for the card at " + cardPage.getPath() + ".", e);
+    }
   }
 
   @Nullable

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/card/KestrosCardImpl.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/card/KestrosCardImpl.java
@@ -1,6 +1,6 @@
 package io.kestros.cms.components.basic.core.content.card;
 
-import io.kestros.cms.assets.api.services.AssetRetrievalService;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.kestros.cms.components.basic.api.content.AnchorTarget;
 import io.kestros.cms.components.basic.api.content.KestrosButton;
 import io.kestros.cms.components.basic.api.content.KestrosButtonGroup;
@@ -16,26 +16,20 @@ import io.kestros.cms.components.basic.core.content.buttongroup.KestrosButtonGro
 import io.kestros.cms.components.basic.core.content.heading.KestrosHeadingImpl;
 import io.kestros.cms.components.basic.core.content.image.KestrosImageImpl;
 import io.kestros.cms.sitebuilding.api.models.BaseContentPage;
+import java.util.Collections;
 import java.util.Arrays;
 import java.util.List;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.sling.models.annotations.Optional;
-import org.apache.sling.models.annotations.injectorspecific.OSGiService;
 
+@SuppressFBWarnings("IMC_IMMATURE_CLASS_NO_TOSTRING")
 public class KestrosCardImpl extends BaseContainerSyntheticResource implements KestrosCard {
 
   private KestrosHeading title;
   private String description;
-  private String imagePath;
-  private String layout;
   private KestrosImage image;
   private KestrosButtonGroup buttonGroup;
-  @OSGiService
-  @Optional
-  private AssetRetrievalService assetRetrievalService;
-
   public KestrosCardImpl(BaseContentPage page, @Nullable String buttonText,
           @Nonnull BaseSlingModelDataSource dataSource,
           @Nonnull String resourcePrefix,
@@ -54,13 +48,18 @@ public class KestrosCardImpl extends BaseContainerSyntheticResource implements K
               null, null, null, AnchorTarget.SAME_WINDOW,
               dataSource,
               "image",
-              "imageElement", assetRetrievalService);
+              // No asset retrieval service: this class is built with new, never adapted, so
+              // the @OSGiService field it used to read was always null. Passing null
+              // explicitly rather than through a field that looked injected. A card image
+              // built from a page therefore does not resolve the asset's own title or
+              // description - see the PR note.
+              "imageElement", null);
     } catch (final ComponentConfigurationException e) {
       this.image = null;
     }
     try {
       if (StringUtils.isNotBlank(buttonText)) {
-        List<KestrosButton> buttons = Arrays.asList(
+        List<KestrosButton> buttons = Collections.singletonList(
                 new KestrosButtonImpl(buttonText, LinkUtils.getLink(page.getPath()), null,
                         AnchorTarget.SAME_WINDOW, null, null, null, null, false,
                         dataSource,

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/card/KestrosCardImpl.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/card/KestrosCardImpl.java
@@ -18,7 +18,7 @@ import io.kestros.cms.components.basic.core.content.buttongroup.KestrosButtonGro
 import io.kestros.cms.components.basic.core.content.heading.KestrosHeadingImpl;
 import io.kestros.cms.components.basic.core.content.image.KestrosImageImpl;
 import io.kestros.cms.sitebuilding.api.models.BaseContentPage;
-import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -88,9 +88,9 @@ public class KestrosCardImpl extends BaseContainerSyntheticResource implements K
     final AssetText assetText = readAssetTextForPage(page);
     try {
       this.image = new KestrosImageImpl(page.getImagePath(),
-              assetText.title,
-              assetText.description,
-              assetText.title,
+              assetText.getTitle(),
+              assetText.getDescription(),
+              assetText.getTitle(),
               null, null, null, AnchorTarget.SAME_WINDOW,
               dataSource,
               "image",
@@ -100,7 +100,7 @@ public class KestrosCardImpl extends BaseContainerSyntheticResource implements K
     }
     try {
       if (StringUtils.isNotBlank(buttonText)) {
-        List<KestrosButton> buttons = Arrays.asList(
+        List<KestrosButton> buttons = Collections.singletonList(
                 new KestrosButtonImpl(buttonText, LinkUtils.getLink(page.getPath()), null,
                         AnchorTarget.SAME_WINDOW, null, null, null, null, false,
                         dataSource,
@@ -141,6 +141,26 @@ public class KestrosCardImpl extends BaseContainerSyntheticResource implements K
     AssetText(@Nullable final String title, @Nullable final String description) {
       this.title = title;
       this.description = description;
+    }
+
+    /**
+     * The asset's title.
+     *
+     * @return The asset's title, or null when there is none or it could not be read.
+     */
+    @Nullable
+    String getTitle() {
+      return title;
+    }
+
+    /**
+     * The asset's description.
+     *
+     * @return The asset's description, or null when there is none or it could not be read.
+     */
+    @Nullable
+    String getDescription() {
+      return description;
     }
   }
 

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/lists/cardlist/CardListAssetsDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/lists/cardlist/CardListAssetsDataSource.java
@@ -1,9 +1,12 @@
 package io.kestros.cms.components.basic.core.lists.cardlist;
 
+import javax.annotation.Nullable;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.kestros.cms.assets.api.exceptions.AssetCollectionRetrievalException;
 import io.kestros.cms.assets.api.models.Asset;
 import io.kestros.cms.assets.api.models.AssetCollection;
 import io.kestros.cms.assets.api.services.AssetRetrievalService;
+import io.kestros.cms.components.basic.api.exceptions.ComponentElementRenderingException;
 import io.kestros.cms.components.basic.api.KestrosBasicComponentElement;
 import io.kestros.cms.components.basic.api.content.AnchorTarget;
 import io.kestros.cms.components.basic.api.content.KestrosCard;
@@ -11,6 +14,7 @@ import io.kestros.cms.components.basic.api.content.KestrosHeading;
 import io.kestros.cms.components.basic.api.content.KestrosImage;
 import io.kestros.cms.components.basic.api.exceptions.ComponentConfigurationException;
 import io.kestros.cms.components.basic.api.lists.KestrosCardList;
+import io.kestros.cms.components.basic.core.AssetSorter;
 import io.kestros.cms.components.basic.core.BaseContainerSlingModelDataSource;
 import io.kestros.cms.components.basic.core.content.card.KestrosCardImpl;
 import io.kestros.cms.components.basic.core.content.heading.KestrosHeadingImpl;
@@ -18,26 +22,32 @@ import io.kestros.cms.components.basic.core.content.image.KestrosImageImpl;
 import io.kestros.cms.componenttypes.api.models.ComponentVariation;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.Comparator;
-import java.util.Date;
 import java.util.List;
 import javax.annotation.Nonnull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.models.annotations.Model;
 import org.apache.sling.models.annotations.injectorspecific.OSGiService;
 
+@SuppressFBWarnings("IMC_IMMATURE_CLASS_NO_TOSTRING")
 @Model(adaptables = {SlingHttpServletRequest.class, Resource.class})
 public class CardListAssetsDataSource extends BaseContainerSlingModelDataSource implements
                                                                                 KestrosCardList {
+  private static final Logger LOG =
+      LoggerFactory.getLogger(CardListAssetsDataSource.class);
+
   @OSGiService
   private AssetRetrievalService assetRetrievalService;
   private AssetCollection collection;
 
+  @Nonnull
   String getHeadingLevel() {
     return getResource().getValueMap().get("headingType", "h2");
   }
 
+  @Nullable
   AssetCollection getCollection() {
     if (collection == null) {
       String collectionPath = getResource().getValueMap().get("collectionPath", String.class);
@@ -50,6 +60,10 @@ public class CardListAssetsDataSource extends BaseContainerSlingModelDataSource 
     return collection;
   }
 
+  @SuppressFBWarnings(value = "EXS_EXCEPTION_SOFTENING_NO_CHECKED",
+      justification = "Called from HTL, which cannot handle a checked exception. The checked"
+          + " cause is wrapped in a typed ComponentElementRenderingException so the failure"
+          + " stays identifiable, per the ruling on DataSourceComponent.")
   @Nonnull
   @Override
   public List<KestrosCard> getCardElements() {
@@ -60,7 +74,7 @@ public class CardListAssetsDataSource extends BaseContainerSlingModelDataSource 
     List<Asset> assets = new ArrayList<>(col.getChildAssets());
 
     String sortBy = getResource().getValueMap().get("sortBy", "");
-    boolean reverse = getResource().getValueMap().get("reverse", false);
+    boolean reverse = getResource().getValueMap().get("reverse", Boolean.FALSE);
     int limit = 0;
     try {
       limit = Integer.parseInt(getResource().getValueMap().get("limit", "0"));
@@ -68,32 +82,7 @@ public class CardListAssetsDataSource extends BaseContainerSlingModelDataSource 
       limit = 0;
     }
 
-    if (!sortBy.isEmpty()) {
-      switch (sortBy) {
-        case "createdDate":
-          assets.sort(Comparator.comparing(a -> {
-            Date date = a.getCreatedDate();
-            return date != null ? date.getTime() : 0L;
-          }));
-          break;
-        case "lastModified":
-          assets.sort(Comparator.comparing(a -> {
-            Date date = a.getModifiedDate();
-            return date != null ? date.getTime() : 0L;
-          }));
-          break;
-        default:
-          assets.sort(Comparator.comparing(a -> {
-            switch (sortBy) {
-              case "name":
-                return a.getName() != null ? a.getName() : "";
-              default:
-                return a.getTitle() != null ? a.getTitle() : a.getName();
-            }
-          }));
-          break;
-      }
-    }
+    AssetSorter.sort(assets, sortBy);
 
     if (reverse) {
       Collections.reverse(assets);
@@ -102,41 +91,33 @@ public class CardListAssetsDataSource extends BaseContainerSlingModelDataSource 
       assets = assets.subList(0, limit);
     }
 
-    List<KestrosCard> cards = new ArrayList<>();
-    String parentPath = getPath();
+    final List<KestrosCard> cards = new ArrayList<>(assets.size());
 
-    for (Asset asset : assets) {
-      String imagePath = asset.getPath();
-      String altText = null;
-      String caption = null;
-      String imageTitle = null;
-      String href = null;
-      String ariaLabel = null;
-      String anchorTitle = null;
-      AnchorTarget target = null;
-
-      List<ComponentVariation> titleVariations = getElementVariations("titleVariations",
-          KestrosImage.RESOURCE_TYPE);
-      String titleLayout = getLayout("title");
+    for (final Asset asset : assets) {
       KestrosHeading titleElement = null;
       try {
         titleElement = new KestrosHeadingImpl(asset.getTitle(), "h2",
-            this,"title", "titleElement");
+            this, "title", "titleElement");
       } catch (ComponentConfigurationException e) {
-        // do nothing.
+        // A card without its heading still renders; leave it unset.
       }
 
-      List<ComponentVariation> imageVariations = getElementVariations("imageVariations",
-          KestrosImage.RESOURCE_TYPE);
-      String imageLayout = getLayout("image");
-      String imageId = null;
-      KestrosImage image = null;
+      final KestrosImage image;
       try {
-        image = new KestrosImageImpl(imagePath, altText, caption, imageTitle,
-            href, ariaLabel, anchorTitle, target,
-            this, "image", "imageElement",assetRetrievalService);
+        // Arguments after the path are altText, caption, imageTitle, href, ariaLabel, anchorTitle
+        // and target. They were locals initialised to null and passed straight through; the
+        // variations, layout and id locals alongside them were computed and never used.
+        image = new KestrosImageImpl(asset.getPath(), null, null, null,
+            null, null, null, null,
+            this, "image", "imageElement", assetRetrievalService);
       } catch (ComponentConfigurationException e) {
-        return null;
+        // Was `return null` from a @Nonnull getter, so one unbuildable image discarded the whole
+        // list and handed HTL a null. Skip the card instead, which is what the sibling card lists
+        // already do.
+        LOG.warn("Skipping card for asset {}: its image could not be built. {}",
+            String.valueOf(asset.getPath()).replaceAll("[\r\n]", ""),
+            String.valueOf(e.getMessage()).replaceAll("[\r\n]", ""));
+        continue;
       }
       try {
         cards.add(
@@ -144,8 +125,9 @@ public class CardListAssetsDataSource extends BaseContainerSlingModelDataSource 
                 null,
                 this,
                 "card", null));
-      } catch (Exception e) {
-        throw new RuntimeException(e);
+      } catch (ComponentConfigurationException e) {
+        throw new ComponentElementRenderingException(
+            "Unable to build a card for asset " + asset.getPath() + ".", e);
       }
     }
     return new ArrayList<>(cards);

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/lists/cardlist/CardListAssetsDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/lists/cardlist/CardListAssetsDataSource.java
@@ -31,7 +31,11 @@ import org.apache.sling.api.resource.Resource;
 import org.apache.sling.models.annotations.Model;
 import org.apache.sling.models.annotations.injectorspecific.OSGiService;
 
-@SuppressFBWarnings("IMC_IMMATURE_CLASS_NO_TOSTRING")
+@SuppressFBWarnings(value = "IMC_IMMATURE_CLASS_NO_TOSTRING",
+    justification = "A style rule rather than a defect: the detector fires on every class that"
+        + " does not declare toString. The fields here are author content read from the"
+        + " repository and are reached through the getters HTL calls, so a default rendering of"
+        + " them is not something to add.")
 @Model(adaptables = {SlingHttpServletRequest.class, Resource.class})
 public class CardListAssetsDataSource extends BaseContainerSlingModelDataSource implements
                                                                                 KestrosCardList {

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/lists/cardlist/CardListChildPagesDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/lists/cardlist/CardListChildPagesDataSource.java
@@ -24,7 +24,11 @@ import org.apache.sling.models.annotations.Model;
 import org.apache.sling.models.annotations.Optional;
 import org.apache.sling.models.annotations.injectorspecific.OSGiService;
 
-@SuppressFBWarnings("IMC_IMMATURE_CLASS_NO_TOSTRING")
+@SuppressFBWarnings(value = "IMC_IMMATURE_CLASS_NO_TOSTRING",
+    justification = "A style rule rather than a defect: the detector fires on every class that"
+        + " does not declare toString. The fields here are author content read from the"
+        + " repository and are reached through the getters HTL calls, so a default rendering of"
+        + " them is not something to add.")
 @Model(adaptables = {SlingHttpServletRequest.class, Resource.class})
 public class CardListChildPagesDataSource extends BaseContainerSlingModelDataSource implements
                                                                                     KestrosCardList {

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/lists/cardlist/CardListChildPagesDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/lists/cardlist/CardListChildPagesDataSource.java
@@ -1,19 +1,19 @@
 package io.kestros.cms.components.basic.core.lists.cardlist;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.kestros.cms.components.basic.api.content.KestrosButton;
 import io.kestros.cms.components.basic.api.content.KestrosButtonGroup;
 import io.kestros.cms.components.basic.api.content.KestrosCard;
 import io.kestros.cms.components.basic.api.content.KestrosImage;
 import io.kestros.cms.components.basic.api.lists.KestrosCardList;
+import io.kestros.cms.components.basic.core.ContentPageSorter;
 import io.kestros.cms.components.basic.core.BaseContainerSlingModelDataSource;
 import io.kestros.cms.components.basic.core.content.card.KestrosCardImpl;
 import io.kestros.cms.sitebuilding.api.models.BaseComponent;
 import io.kestros.cms.sitebuilding.api.models.BaseContentPage;
 import io.kestros.commons.structuredslingmodels.exceptions.NoValidAncestorException;
 import java.util.ArrayList;
-import java.util.Calendar;
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.List;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -21,11 +21,13 @@ import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.models.annotations.Model;
 
+@SuppressFBWarnings("IMC_IMMATURE_CLASS_NO_TOSTRING")
 @Model(adaptables = {SlingHttpServletRequest.class, Resource.class})
 public class CardListChildPagesDataSource extends BaseContainerSlingModelDataSource implements
                                                                                     KestrosCardList {
   private BaseContentPage rootPage;
 
+  @Nullable
   BaseContentPage getRootPage() {
     if (rootPage == null) {
       String pagesPath = getResource().getValueMap().get("pagesPath", String.class);
@@ -54,6 +56,10 @@ public class CardListChildPagesDataSource extends BaseContainerSlingModelDataSou
     return getResource().getValueMap().get("readMoreText", String.class);
   }
 
+  @SuppressFBWarnings(value = "EXS_EXCEPTION_SOFTENING_NO_CHECKED",
+      justification = "Called from HTL, which cannot handle a checked exception. The checked"
+          + " cause is wrapped in a typed ComponentElementRenderingException so the failure"
+          + " stays identifiable, per the ruling on DataSourceComponent.")
   @Nonnull
   @Override
   public List<KestrosCard> getCardElements() {
@@ -64,7 +70,7 @@ public class CardListChildPagesDataSource extends BaseContainerSlingModelDataSou
     List<BaseContentPage> pages = new ArrayList<>(root.getChildPages());
 
     String sortBy = getResource().getValueMap().get("sortBy", "");
-    boolean reverse = getResource().getValueMap().get("reverse", false);
+    boolean reverse = getResource().getValueMap().get("reverse", Boolean.FALSE);
     int limit = 0;
     try {
       limit = Integer.parseInt(getResource().getValueMap().get("limit", "0"));
@@ -72,36 +78,7 @@ public class CardListChildPagesDataSource extends BaseContainerSlingModelDataSou
       limit = 0;
     }
 
-    if (!sortBy.isEmpty()) {
-      switch (sortBy) {
-        case "createdDate":
-          pages.sort(Comparator.comparing(p -> {
-            Calendar cal = p.getResource().getChild("jcr:content") != null
-                ? p.getResource().getChild("jcr:content").getValueMap()
-                    .get("jcr:created", Calendar.class) : null;
-            return cal != null ? cal.getTimeInMillis() : 0L;
-          }));
-          break;
-        case "lastModified":
-          pages.sort(Comparator.comparing(p -> {
-            Calendar cal = p.getResource().getChild("jcr:content") != null
-                ? p.getResource().getChild("jcr:content").getValueMap()
-                    .get("jcr:lastModified", Calendar.class) : null;
-            return cal != null ? cal.getTimeInMillis() : 0L;
-          }));
-          break;
-        default:
-          pages.sort(Comparator.comparing(p -> {
-            switch (sortBy) {
-              case "name":
-                return p.getName() != null ? p.getName() : "";
-              default:
-                return p.getDisplayTitle() != null ? p.getDisplayTitle() : p.getName();
-            }
-          }));
-          break;
-      }
-    }
+    ContentPageSorter.sort(pages, sortBy);
 
     if (reverse) {
       Collections.reverse(pages);

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/lists/cardlist/CardListTagSearchDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/lists/cardlist/CardListTagSearchDataSource.java
@@ -1,31 +1,40 @@
 package io.kestros.cms.components.basic.core.lists.cardlist;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import io.kestros.cms.components.basic.api.exceptions.ComponentConfigurationException;
 import io.kestros.cms.components.basic.api.content.KestrosCard;
 import io.kestros.cms.components.basic.api.lists.KestrosCardList;
+import io.kestros.cms.components.basic.core.ContentPageSorter;
 import io.kestros.cms.components.basic.core.BaseContainerSlingModelDataSource;
 import io.kestros.cms.components.basic.core.content.card.KestrosCardImpl;
 import io.kestros.cms.sitebuilding.api.models.BaseComponent;
 import io.kestros.cms.sitebuilding.api.models.BaseContentPage;
 import io.kestros.cms.tagging.api.models.KestrosTag;
 import io.kestros.cms.tagging.api.services.TagRetrievalService;
+import io.kestros.commons.structuredslingmodels.exceptions.NoParentResourceException;
 import io.kestros.commons.structuredslingmodels.exceptions.NoValidAncestorException;
+import java.util.Arrays;
 import java.util.ArrayList;
-import java.util.Calendar;
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.models.annotations.Model;
 import org.apache.sling.models.annotations.injectorspecific.OSGiService;
 
+@SuppressFBWarnings("IMC_IMMATURE_CLASS_NO_TOSTRING")
 @Model(adaptables = {SlingHttpServletRequest.class, Resource.class})
 public class CardListTagSearchDataSource extends BaseContainerSlingModelDataSource implements
                                                                                    KestrosCardList {
+
+  private static final Logger LOG =
+      LoggerFactory.getLogger(CardListTagSearchDataSource.class);
 
   @OSGiService
   @org.apache.sling.models.annotations.Optional
@@ -38,6 +47,7 @@ public class CardListTagSearchDataSource extends BaseContainerSlingModelDataSour
     return getResource().getValueMap().get("readMoreText", String.class);
   }
 
+  @Nullable
   BaseContentPage getContainingPage() {
     if (containingPage == null) {
       try {
@@ -61,6 +71,7 @@ public class CardListTagSearchDataSource extends BaseContainerSlingModelDataSour
     return tags;
   }
 
+  @Nullable
   String getRootPath() {
     String pagesPath = getResource().getValueMap().get("pagesPath", String.class);
     if (pagesPath != null) {
@@ -70,13 +81,15 @@ public class CardListTagSearchDataSource extends BaseContainerSlingModelDataSour
     if (page != null) {
       try {
         return page.getParent().getPath();
-      } catch (Exception e) {
+      } catch (NoParentResourceException e) {
+        // A page with no parent searches from itself.
         return page.getPath();
       }
     }
     return null;
   }
 
+  @Nullable
   BaseContentPage getRootPage() {
     String rootPath = getRootPath();
     if (rootPath == null) {
@@ -89,8 +102,9 @@ public class CardListTagSearchDataSource extends BaseContainerSlingModelDataSour
     return null;
   }
 
+  @Nonnull
   List<BaseContentPage> getTaggedPages() {
-    List<BaseContentPage> taggedPages = new ArrayList<>();
+    final List<BaseContentPage> taggedPages = new ArrayList<>();
     if (tagRetrievalService == null) {
       return taggedPages;
     }
@@ -100,10 +114,8 @@ public class CardListTagSearchDataSource extends BaseContainerSlingModelDataSour
       return taggedPages;
     }
 
-    Set<String> filterTagPaths = new HashSet<>();
-    for (String tagPath : configuredTags) {
-      filterTagPaths.add(tagPath);
-    }
+    final Set<String> filterTagPaths =
+        new HashSet<>(Arrays.asList(configuredTags));
 
     BaseContentPage currentPage = getContainingPage();
     BaseContentPage rootPage = getRootPage();
@@ -135,7 +147,7 @@ public class CardListTagSearchDataSource extends BaseContainerSlingModelDataSour
     List<BaseContentPage> pages = new ArrayList<>(getTaggedPages());
 
     String sortBy = getResource().getValueMap().get("sortBy", "");
-    boolean reverse = getResource().getValueMap().get("reverse", false);
+    boolean reverse = getResource().getValueMap().get("reverse", Boolean.FALSE);
     int limit = 0;
     try {
       limit = Integer.parseInt(getResource().getValueMap().get("limit", "0"));
@@ -143,36 +155,7 @@ public class CardListTagSearchDataSource extends BaseContainerSlingModelDataSour
       limit = 0;
     }
 
-    if (!sortBy.isEmpty()) {
-      switch (sortBy) {
-        case "createdDate":
-          pages.sort(Comparator.comparing(p -> {
-            Calendar cal = p.getResource().getChild("jcr:content") != null
-                ? p.getResource().getChild("jcr:content").getValueMap()
-                    .get("jcr:created", Calendar.class) : null;
-            return cal != null ? cal.getTimeInMillis() : 0L;
-          }));
-          break;
-        case "lastModified":
-          pages.sort(Comparator.comparing(p -> {
-            Calendar cal = p.getResource().getChild("jcr:content") != null
-                ? p.getResource().getChild("jcr:content").getValueMap()
-                    .get("jcr:lastModified", Calendar.class) : null;
-            return cal != null ? cal.getTimeInMillis() : 0L;
-          }));
-          break;
-        default:
-          pages.sort(Comparator.comparing(p -> {
-            switch (sortBy) {
-              case "name":
-                return p.getName() != null ? p.getName() : "";
-              default:
-                return p.getDisplayTitle() != null ? p.getDisplayTitle() : p.getName();
-            }
-          }));
-          break;
-      }
-    }
+    ContentPageSorter.sort(pages, sortBy);
 
     if (reverse) {
       Collections.reverse(pages);
@@ -190,8 +173,10 @@ public class CardListTagSearchDataSource extends BaseContainerSlingModelDataSour
                 this,
                 "card",
                 page.getName()));
-      } catch (Exception e) {
-        // Skip cards that fail to construct — null-safe
+      } catch (ComponentConfigurationException e) {
+        LOG.debug("Skipping the {} for {}: it could not be built. {}", "card",
+            String.valueOf(page.getPath()).replaceAll("[\r\n]", ""),
+            String.valueOf(e.getMessage()).replaceAll("[\r\n]", ""));
       }
     }
     return new ArrayList<>(cards);

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/lists/cardlist/CardListTagSearchDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/lists/cardlist/CardListTagSearchDataSource.java
@@ -28,7 +28,11 @@ import org.apache.sling.api.resource.Resource;
 import org.apache.sling.models.annotations.Model;
 import org.apache.sling.models.annotations.injectorspecific.OSGiService;
 
-@SuppressFBWarnings("IMC_IMMATURE_CLASS_NO_TOSTRING")
+@SuppressFBWarnings(value = "IMC_IMMATURE_CLASS_NO_TOSTRING",
+    justification = "A style rule rather than a defect: the detector fires on every class that"
+        + " does not declare toString. The fields here are author content read from the"
+        + " repository and are reached through the getters HTL calls, so a default rendering of"
+        + " them is not something to add.")
 @Model(adaptables = {SlingHttpServletRequest.class, Resource.class})
 public class CardListTagSearchDataSource extends BaseContainerSlingModelDataSource implements
                                                                                    KestrosCardList {

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/lists/cardlist/KestrosCardListImpl.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/lists/cardlist/KestrosCardListImpl.java
@@ -19,7 +19,7 @@ public class KestrosCardListImpl extends BaseContainerSyntheticResource implemen
       @Nonnull String resourcePrefix, String forcedResourceName)
       throws ComponentConfigurationException {
     super(dataSource, resourcePrefix, forcedResourceName);
-    this.cards = cards;
+    this.cards = new ArrayList<>(cards);
   }
 
 

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/lists/linklist/KestrosLinkListImpl.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/lists/linklist/KestrosLinkListImpl.java
@@ -19,7 +19,7 @@ public class KestrosLinkListImpl extends BaseContainerSyntheticResource implemen
       @Nonnull String resourcePrefix, String forcedResourceName)
       throws ComponentConfigurationException {
     super(dataSource, resourcePrefix, forcedResourceName);
-    this.links = links;
+    this.links = new ArrayList<>(links);
   }
 
 

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/lists/linklist/LinkListChildPageDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/lists/linklist/LinkListChildPageDataSource.java
@@ -20,7 +20,9 @@ import org.apache.sling.api.resource.Resource;
 import org.apache.sling.models.annotations.Model;
 import org.apache.sling.models.annotations.injectorspecific.OSGiService;
 
-@SuppressFBWarnings("FCBL_FIELD_COULD_BE_LOCAL")
+@SuppressFBWarnings(value = "FCBL_FIELD_COULD_BE_LOCAL",
+    justification = "Both fields are @OSGiService injection points. Sling Models writes them"
+        + " after the object is constructed, so neither can be a local variable.")
 @Model(adaptables = {SlingHttpServletRequest.class, Resource.class})
 public class LinkListChildPageDataSource extends BaseContainerSlingModelDataSource
     implements KestrosLinkList {

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/lists/linklist/LinkListChildPageDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/lists/linklist/LinkListChildPageDataSource.java
@@ -1,8 +1,11 @@
 package io.kestros.cms.components.basic.core.lists.linklist;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import javax.annotation.Nonnull;
 import io.kestros.cms.components.basic.api.content.AnchorTarget;
 import io.kestros.cms.components.basic.api.content.KestrosLink;
 import io.kestros.cms.components.basic.api.lists.KestrosLinkList;
+import io.kestros.cms.components.basic.core.ContentPageSorter;
 import io.kestros.cms.components.basic.core.BaseContainerSlingModelDataSource;
 import io.kestros.cms.components.basic.core.LinkUtils;
 import io.kestros.cms.components.basic.core.content.link.KestrosLinkImpl;
@@ -10,15 +13,14 @@ import io.kestros.cms.componenttypes.api.services.ComponentUiFrameworkViewRetrie
 import io.kestros.cms.componenttypes.api.services.ComponentVariationRetrievalService;
 import io.kestros.cms.sitebuilding.api.models.BaseContentPage;
 import java.util.ArrayList;
-import java.util.Calendar;
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.List;
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.models.annotations.Model;
 import org.apache.sling.models.annotations.injectorspecific.OSGiService;
 
+@SuppressFBWarnings("FCBL_FIELD_COULD_BE_LOCAL")
 @Model(adaptables = {SlingHttpServletRequest.class, Resource.class})
 public class LinkListChildPageDataSource extends BaseContainerSlingModelDataSource
     implements KestrosLinkList {
@@ -28,15 +30,22 @@ public class LinkListChildPageDataSource extends BaseContainerSlingModelDataSour
   @OSGiService
   private ComponentUiFrameworkViewRetrievalService componentUiFrameworkViewRetrievalService;
 
+  @Nonnull
   public String getRootPath() {
     return getResource().getValueMap().get("pagesPath", String.class);
   }
 
+  @Nonnull
   public AnchorTarget getTarget() {
     return AnchorTarget.lookup(getResource());
   }
 
+  @SuppressFBWarnings(value = "EXS_EXCEPTION_SOFTENING_NO_CHECKED",
+      justification = "Called from HTL, which cannot handle a checked exception. The checked"
+          + " cause is wrapped in a typed ComponentElementRenderingException so the failure"
+          + " stays identifiable, per the ruling on DataSourceComponent.")
   @Override
+  @Nonnull
   public List<KestrosLink> getLinkElements() {
     List<BaseContentPage> pages = new ArrayList<>();
     String rootPath = getRootPath();
@@ -48,7 +57,7 @@ public class LinkListChildPageDataSource extends BaseContainerSlingModelDataSour
       return new ArrayList<>();
     }
     for (Resource childResource : rootResource.getChildren()) {
-      if (childResource.getName().equals("jcr:content")) {
+      if ("jcr:content".equals(childResource.getName())) {
         continue;
       }
       BaseContentPage page = childResource.adaptTo(BaseContentPage.class);
@@ -58,7 +67,7 @@ public class LinkListChildPageDataSource extends BaseContainerSlingModelDataSour
     }
 
     String sortBy = getResource().getValueMap().get("sortBy", "");
-    boolean reverse = getResource().getValueMap().get("reverse", false);
+    boolean reverse = getResource().getValueMap().get("reverse", Boolean.FALSE);
     int limit = 0;
     try {
       limit = Integer.parseInt(getResource().getValueMap().get("limit", "0"));
@@ -66,36 +75,7 @@ public class LinkListChildPageDataSource extends BaseContainerSlingModelDataSour
       limit = 0;
     }
 
-    if (!sortBy.isEmpty()) {
-      switch (sortBy) {
-        case "createdDate":
-          pages.sort(Comparator.comparing(p -> {
-            Calendar cal = p.getResource().getChild("jcr:content") != null
-                ? p.getResource().getChild("jcr:content").getValueMap()
-                    .get("jcr:created", Calendar.class) : null;
-            return cal != null ? cal.getTimeInMillis() : 0L;
-          }));
-          break;
-        case "lastModified":
-          pages.sort(Comparator.comparing(p -> {
-            Calendar cal = p.getResource().getChild("jcr:content") != null
-                ? p.getResource().getChild("jcr:content").getValueMap()
-                    .get("jcr:lastModified", Calendar.class) : null;
-            return cal != null ? cal.getTimeInMillis() : 0L;
-          }));
-          break;
-        default:
-          pages.sort(Comparator.comparing(p -> {
-            switch (sortBy) {
-              case "name":
-                return p.getName() != null ? p.getName() : "";
-              default:
-                return p.getDisplayTitle() != null ? p.getDisplayTitle() : p.getName();
-            }
-          }));
-          break;
-      }
-    }
+    ContentPageSorter.sort(pages, sortBy);
 
     if (reverse) {
       Collections.reverse(pages);
@@ -104,8 +84,9 @@ public class LinkListChildPageDataSource extends BaseContainerSlingModelDataSour
       pages = pages.subList(0, limit);
     }
 
-    List<KestrosLink> links = new ArrayList<>();
-    for (BaseContentPage page : pages) {
+    final List<BaseContentPage> sourceLinks = pages;
+    final List<KestrosLink> links = new ArrayList<>(sourceLinks.size());
+    for (BaseContentPage page : sourceLinks) {
       KestrosLink link = null;
       try {
         link = new KestrosLinkImpl(page.getDisplayTitle(),

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/lists/linklist/LinkListTagSearchDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/lists/linklist/LinkListTagSearchDataSource.java
@@ -30,7 +30,11 @@ import org.apache.sling.api.resource.Resource;
 import org.apache.sling.models.annotations.Model;
 import org.apache.sling.models.annotations.injectorspecific.OSGiService;
 
-@SuppressFBWarnings("IMC_IMMATURE_CLASS_NO_TOSTRING")
+@SuppressFBWarnings(value = "IMC_IMMATURE_CLASS_NO_TOSTRING",
+    justification = "A style rule rather than a defect: the detector fires on every class that"
+        + " does not declare toString. The fields here are author content read from the"
+        + " repository and are reached through the getters HTL calls, so a default rendering of"
+        + " them is not something to add.")
 /**
  * Tag search datasource for the link list component. Finds pages matching configured
  * tags and renders them as link elements.

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/lists/linklist/LinkListTagSearchDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/lists/linklist/LinkListTagSearchDataSource.java
@@ -1,8 +1,12 @@
 package io.kestros.cms.components.basic.core.lists.linklist;
 
+import javax.annotation.Nullable;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import io.kestros.cms.components.basic.api.exceptions.ComponentConfigurationException;
 import io.kestros.cms.components.basic.api.content.AnchorTarget;
 import io.kestros.cms.components.basic.api.content.KestrosLink;
 import io.kestros.cms.components.basic.api.lists.KestrosLinkList;
+import io.kestros.cms.components.basic.core.ContentPageSorter;
 import io.kestros.cms.components.basic.core.BaseContainerSlingModelDataSource;
 import io.kestros.cms.components.basic.core.LinkUtils;
 import io.kestros.cms.components.basic.core.content.link.KestrosLinkImpl;
@@ -10,20 +14,23 @@ import io.kestros.cms.sitebuilding.api.models.BaseComponent;
 import io.kestros.cms.sitebuilding.api.models.BaseContentPage;
 import io.kestros.cms.tagging.api.models.KestrosTag;
 import io.kestros.cms.tagging.api.services.TagRetrievalService;
+import io.kestros.commons.structuredslingmodels.exceptions.NoParentResourceException;
 import io.kestros.commons.structuredslingmodels.exceptions.NoValidAncestorException;
+import java.util.Arrays;
 import java.util.ArrayList;
-import java.util.Calendar;
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import javax.annotation.Nonnull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.models.annotations.Model;
 import org.apache.sling.models.annotations.injectorspecific.OSGiService;
 
+@SuppressFBWarnings("IMC_IMMATURE_CLASS_NO_TOSTRING")
 /**
  * Tag search datasource for the link list component. Finds pages matching configured
  * tags and renders them as link elements.
@@ -32,12 +39,16 @@ import org.apache.sling.models.annotations.injectorspecific.OSGiService;
 public class LinkListTagSearchDataSource extends BaseContainerSlingModelDataSource
     implements KestrosLinkList {
 
+  private static final Logger LOG =
+      LoggerFactory.getLogger(LinkListTagSearchDataSource.class);
+
   @OSGiService
   @org.apache.sling.models.annotations.Optional
   private TagRetrievalService tagRetrievalService;
 
   private BaseContentPage containingPage;
 
+  @Nullable
   BaseContentPage getContainingPage() {
     if (containingPage == null) {
       try {
@@ -46,6 +57,9 @@ public class LinkListTagSearchDataSource extends BaseContainerSlingModelDataSour
           containingPage = component.getContainingPage();
         }
       } catch (NoValidAncestorException e) {
+        LOG.debug("No containing page for {}; the list has no results. {}",
+            String.valueOf(getResource().getPath()).replaceAll("[\r\n]", ""),
+            String.valueOf(e.getMessage()).replaceAll("[\r\n]", ""));
         return null;
       }
     }
@@ -61,6 +75,7 @@ public class LinkListTagSearchDataSource extends BaseContainerSlingModelDataSour
     return tags;
   }
 
+  @Nullable
   String getRootPath() {
     String pagesPath = getResource().getValueMap().get("pagesPath", String.class);
     if (pagesPath != null) {
@@ -70,13 +85,15 @@ public class LinkListTagSearchDataSource extends BaseContainerSlingModelDataSour
     if (page != null) {
       try {
         return page.getParent().getPath();
-      } catch (Exception e) {
+      } catch (NoParentResourceException e) {
+        // A page with no parent searches from itself.
         return page.getPath();
       }
     }
     return null;
   }
 
+  @Nullable
   BaseContentPage getRootPage() {
     String rootPath = getRootPath();
     if (rootPath == null) {
@@ -89,12 +106,14 @@ public class LinkListTagSearchDataSource extends BaseContainerSlingModelDataSour
     return null;
   }
 
+  @Nonnull
   public AnchorTarget getTarget() {
     return AnchorTarget.lookup(getResource());
   }
 
+  @Nonnull
   List<BaseContentPage> getTaggedPages() {
-    List<BaseContentPage> taggedPages = new ArrayList<>();
+    final List<BaseContentPage> taggedPages = new ArrayList<>();
     if (tagRetrievalService == null) {
       return taggedPages;
     }
@@ -104,10 +123,8 @@ public class LinkListTagSearchDataSource extends BaseContainerSlingModelDataSour
       return taggedPages;
     }
 
-    Set<String> filterTagPaths = new HashSet<>();
-    for (String tagPath : configuredTags) {
-      filterTagPaths.add(tagPath);
-    }
+    final Set<String> filterTagPaths =
+        new HashSet<>(Arrays.asList(configuredTags));
 
     BaseContentPage currentPage = getContainingPage();
     BaseContentPage rootPage = getRootPage();
@@ -139,7 +156,7 @@ public class LinkListTagSearchDataSource extends BaseContainerSlingModelDataSour
     List<BaseContentPage> pages = new ArrayList<>(getTaggedPages());
 
     String sortBy = getResource().getValueMap().get("sortBy", "");
-    boolean reverse = getResource().getValueMap().get("reverse", false);
+    boolean reverse = getResource().getValueMap().get("reverse", Boolean.FALSE);
     int limit = 0;
     try {
       limit = Integer.parseInt(getResource().getValueMap().get("limit", "0"));
@@ -147,36 +164,7 @@ public class LinkListTagSearchDataSource extends BaseContainerSlingModelDataSour
       limit = 0;
     }
 
-    if (!sortBy.isEmpty()) {
-      switch (sortBy) {
-        case "createdDate":
-          pages.sort(Comparator.comparing(p -> {
-            Calendar cal = p.getResource().getChild("jcr:content") != null
-                ? p.getResource().getChild("jcr:content").getValueMap()
-                    .get("jcr:created", Calendar.class) : null;
-            return cal != null ? cal.getTimeInMillis() : 0L;
-          }));
-          break;
-        case "lastModified":
-          pages.sort(Comparator.comparing(p -> {
-            Calendar cal = p.getResource().getChild("jcr:content") != null
-                ? p.getResource().getChild("jcr:content").getValueMap()
-                    .get("jcr:lastModified", Calendar.class) : null;
-            return cal != null ? cal.getTimeInMillis() : 0L;
-          }));
-          break;
-        default:
-          pages.sort(Comparator.comparing(p -> {
-            switch (sortBy) {
-              case "name":
-                return p.getName() != null ? p.getName() : "";
-              default:
-                return p.getDisplayTitle() != null ? p.getDisplayTitle() : p.getName();
-            }
-          }));
-          break;
-      }
-    }
+    ContentPageSorter.sort(pages, sortBy);
 
     if (reverse) {
       Collections.reverse(pages);
@@ -185,15 +173,18 @@ public class LinkListTagSearchDataSource extends BaseContainerSlingModelDataSour
       pages = pages.subList(0, limit);
     }
 
-    List<KestrosLink> links = new ArrayList<>();
-    for (BaseContentPage page : pages) {
+    final List<BaseContentPage> sourceLinks = pages;
+    final List<KestrosLink> links = new ArrayList<>(sourceLinks.size());
+    for (BaseContentPage page : sourceLinks) {
       try {
         links.add(new KestrosLinkImpl(page,
             this,
             "link",
             page.getName()));
-      } catch (Exception e) {
-        // Skip links that fail to construct
+      } catch (ComponentConfigurationException e) {
+        LOG.debug("Skipping the link for {}: it could not be built. {}",
+            String.valueOf(page.getPath()).replaceAll("[\r\n]", ""),
+            String.valueOf(e.getMessage()).replaceAll("[\r\n]", ""));
       }
     }
     return links;

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/navigation/breadcrumbs/KestrosBreadCrumbsImpl.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/navigation/breadcrumbs/KestrosBreadCrumbsImpl.java
@@ -22,7 +22,7 @@ public class KestrosBreadCrumbsImpl extends BaseContainerSyntheticResource
       @Nonnull String resourcePrefix, String forcedResourceName)
       throws ComponentConfigurationException {
     super(dataSource, resourcePrefix, forcedResourceName);
-    this.breadCrumbs = breadCrumbs;
+    this.breadCrumbs = new ArrayList<>(breadCrumbs);
   }
 
   @Nonnull

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/navigation/nav/KestrosNavigationImpl.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/navigation/nav/KestrosNavigationImpl.java
@@ -22,7 +22,7 @@ public class KestrosNavigationImpl extends BaseContainerSyntheticResource
       @Nonnull String resourcePrefix, String forcedResourceName)
       throws ComponentConfigurationException {
     super(dataSource, resourcePrefix, forcedResourceName);
-    this.navigationLinks = navigationLinks;
+    this.navigationLinks = new ArrayList<>(navigationLinks);
   }
 
   @Nonnull

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/navigation/topnav/KestrosTopNavigationImpl.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/navigation/topnav/KestrosTopNavigationImpl.java
@@ -28,7 +28,7 @@ public class KestrosTopNavigationImpl extends BaseContainerSyntheticResource
     super(dataSource, resourcePrefix, forcedResourceName);
     this.logo = logo;
     this.brandName = brandName;
-    this.navigationLinks = navigationLinks;
+    this.navigationLinks = new ArrayList<>(navigationLinks);
   }
 
   @Nonnull

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/navigation/topnav/KestrosTopNavigationItemImpl.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/navigation/topnav/KestrosTopNavigationItemImpl.java
@@ -24,7 +24,7 @@ public class KestrosTopNavigationItemImpl extends BaseContainerSyntheticResource
       throws ComponentConfigurationException {
     super(dataSource, resourcePrefix, forcedResourceName);
     this.link = link;
-    this.childItems = childItems;
+    this.childItems = new ArrayList<>(childItems);
   }
 
   @Nonnull

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/navigation/topnav/TopNavigationDataSourceComponent.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/navigation/topnav/TopNavigationDataSourceComponent.java
@@ -4,6 +4,7 @@ import io.kestros.cms.components.basic.api.content.KestrosImage;
 import io.kestros.cms.components.basic.api.navigation.KestrosTopNavigation;
 import io.kestros.cms.components.basic.api.navigation.KestrosTopNavigationItem;
 import io.kestros.cms.components.basic.core.BaseContainerDataSourceComponent;
+import java.util.ArrayList;
 import java.util.List;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -24,7 +25,7 @@ public class TopNavigationDataSourceComponent
     if (navigationLinks == null) {
       navigationLinks = getComponentData().getNavigationLinkElements();
     }
-    return navigationLinks;
+    return new ArrayList<>(navigationLinks);
   }
 
   @Nullable

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/navigation/topnav/TopNavigationItemDataSourceComponent.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/navigation/topnav/TopNavigationItemDataSourceComponent.java
@@ -3,6 +3,7 @@ package io.kestros.cms.components.basic.core.navigation.topnav;
 import io.kestros.cms.components.basic.api.content.AnchorTarget;
 import io.kestros.cms.components.basic.api.navigation.KestrosTopNavigationItem;
 import io.kestros.cms.components.basic.core.BaseContainerDataSourceComponent;
+import java.util.ArrayList;
 import java.util.List;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -23,7 +24,7 @@ public class TopNavigationItemDataSourceComponent
     if (navigationItems == null) {
       navigationItems = getComponentData().getNavigationItems();
     }
-    return navigationItems;
+    return new ArrayList<>(navigationItems);
   }
 
   @Nullable

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/structure/accordion/KestrosAccordionImpl.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/structure/accordion/KestrosAccordionImpl.java
@@ -20,7 +20,7 @@ public class KestrosAccordionImpl extends BaseContainerSyntheticResource
       @Nonnull String resourcePrefix, String forcedResourceName)
       throws ComponentConfigurationException {
     super(dataSource, resourcePrefix, forcedResourceName);
-    this.panels = panels;
+    this.panels = new ArrayList<>(panels);
   }
 
 

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/structure/container/KestrosContainerImpl.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/structure/container/KestrosContainerImpl.java
@@ -20,7 +20,7 @@ public class KestrosContainerImpl extends BaseContainerSyntheticResource
       @Nonnull String resourcePrefix, String forcedResourceName)
       throws ComponentConfigurationException {
     super(dataSource, resourcePrefix, forcedResourceName);
-    this.childElements = childElements;
+    this.childElements = new ArrayList<>(childElements);
   }
 
   @Nonnull

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/structure/grid/KestrosGridImpl.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/structure/grid/KestrosGridImpl.java
@@ -9,7 +9,6 @@ import io.kestros.cms.components.basic.core.BaseSlingModelDataSource;
 import java.util.ArrayList;
 import java.util.List;
 import javax.annotation.Nonnull;
-import java.util.ArrayList;
 
 public class KestrosGridImpl extends BaseContainerSyntheticResource implements KestrosGrid {
 

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/structure/grid/KestrosGridImpl.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/structure/grid/KestrosGridImpl.java
@@ -1,16 +1,18 @@
 package io.kestros.cms.components.basic.core.structure.grid;
 
+import io.kestros.cms.components.basic.api.KestrosBasicComponentElement;
 import io.kestros.cms.components.basic.api.exceptions.ComponentConfigurationException;
 import io.kestros.cms.components.basic.api.structure.KestrosContainer;
 import io.kestros.cms.components.basic.api.structure.KestrosGrid;
 import io.kestros.cms.components.basic.core.BaseContainerSyntheticResource;
 import io.kestros.cms.components.basic.core.BaseSlingModelDataSource;
+import java.util.ArrayList;
 import java.util.List;
 import javax.annotation.Nonnull;
 
 public class KestrosGridImpl extends BaseContainerSyntheticResource implements KestrosGrid {
 
-  private List<KestrosContainer> columns;
+  private final List<KestrosContainer> columns;
 
   public KestrosGridImpl(
       @Nonnull List<KestrosContainer> columns,
@@ -18,7 +20,22 @@ public class KestrosGridImpl extends BaseContainerSyntheticResource implements K
       @Nonnull String resourcePrefix, String forcedResourceName)
       throws ComponentConfigurationException {
     super(dataSource, resourcePrefix, forcedResourceName);
-    this.columns = columns;
+    this.columns = new ArrayList<>(columns);
   }
 
+  /**
+   * The columns the grid was built with.
+   *
+   * <p>KestrosGrid inherits an empty default, so before this override a grid stored the columns it
+   * was constructed with and then rendered none of them - getChildren() reads getChildElements()
+   * and got back the default empty list. KestrosContainerImpl already returned its children this
+   * way; the grid is the same kind of container and now behaves like one.</p>
+   *
+   * @return The columns, as a copy.
+   */
+  @Nonnull
+  @Override
+  public List<KestrosBasicComponentElement> getChildElements() {
+    return new ArrayList<>(columns);
+  }
 }

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/structure/grid/KestrosGridImpl.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/structure/grid/KestrosGridImpl.java
@@ -7,6 +7,7 @@ import io.kestros.cms.components.basic.core.BaseContainerSyntheticResource;
 import io.kestros.cms.components.basic.core.BaseSlingModelDataSource;
 import java.util.List;
 import javax.annotation.Nonnull;
+import java.util.ArrayList;
 
 public class KestrosGridImpl extends BaseContainerSyntheticResource implements KestrosGrid {
 
@@ -18,7 +19,7 @@ public class KestrosGridImpl extends BaseContainerSyntheticResource implements K
       @Nonnull String resourcePrefix, String forcedResourceName)
       throws ComponentConfigurationException {
     super(dataSource, resourcePrefix, forcedResourceName);
-    this.columns = columns;
+    this.columns = new ArrayList<>(columns);
   }
 
 }

--- a/kestros-basic-components/src/test/java/io/kestros/cms/components/basic/core/PropertyBackedSyntheticResourceTest.java
+++ b/kestros-basic-components/src/test/java/io/kestros/cms/components/basic/core/PropertyBackedSyntheticResourceTest.java
@@ -1,0 +1,60 @@
+package io.kestros.cms.components.basic.core;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.sling.api.resource.ResourceMetadata;
+import org.apache.sling.testing.mock.sling.junit.SlingContext;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class PropertyBackedSyntheticResourceTest {
+
+  @Rule
+  public SlingContext context = new SlingContext();
+
+  private Map<String, Object> properties;
+  private PropertyBackedSyntheticResource resource;
+
+  @Before
+  public void setUp() {
+    properties = new HashMap<>();
+    properties.put("heading", "Original Heading");
+    resource = new PropertyBackedSyntheticResource(context.resourceResolver(),
+        new ResourceMetadata(), "kestros/components/heading", properties);
+  }
+
+  @Test
+  public void testGetValueMap() {
+    assertEquals("Original Heading", resource.getValueMap().get("heading", String.class));
+  }
+
+  @Test
+  public void testGetValueMapWhenCallerWritesToTheMapItWasGiven() {
+    resource.getValueMap().put("heading", "Rewritten Heading");
+
+    assertEquals("Original Heading", resource.getValueMap().get("heading", String.class));
+  }
+
+  @Test
+  public void testGetValueMapWhenCallerRemovesFromTheMapItWasGiven() {
+    resource.getValueMap().remove("heading");
+
+    assertEquals("Original Heading", resource.getValueMap().get("heading", String.class));
+  }
+
+  @Test
+  public void testGetValueMapWhenTheSuppliedMapChangesAfterConstruction() {
+    properties.put("heading", "Rewritten Heading");
+
+    assertEquals("Original Heading", resource.getValueMap().get("heading", String.class));
+  }
+
+  @Test
+  public void testGetValueMapWhenPropertyIsAbsent() {
+    assertNull(resource.getValueMap().get("missing", String.class));
+  }
+}

--- a/kestros-basic-components/src/test/java/io/kestros/cms/components/basic/core/PropertyBackedSyntheticResourceTest.java
+++ b/kestros-basic-components/src/test/java/io/kestros/cms/components/basic/core/PropertyBackedSyntheticResourceTest.java
@@ -1,7 +1,9 @@
 package io.kestros.cms.components.basic.core;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -56,5 +58,31 @@ public class PropertyBackedSyntheticResourceTest {
   @Test
   public void testGetValueMapWhenPropertyIsAbsent() {
     assertNull(resource.getValueMap().get("missing", String.class));
+  }
+
+  @Test
+  public void testEqualsAndHashCode() {
+    PropertyBackedSyntheticResource same = new PropertyBackedSyntheticResource(
+        context.resourceResolver(), new ResourceMetadata(), "kestros/components/heading",
+        properties);
+
+    assertEquals(resource, same);
+    assertEquals(resource.hashCode(), same.hashCode());
+  }
+
+  @Test
+  public void testEqualsWhenPropertiesDiffer() {
+    Map<String, Object> other = new HashMap<>();
+    other.put("heading", "Another Heading");
+    PropertyBackedSyntheticResource different = new PropertyBackedSyntheticResource(
+        context.resourceResolver(), new ResourceMetadata(), "kestros/components/heading", other);
+
+    assertNotEquals(resource, different);
+  }
+
+  @Test
+  public void testToStringNamesTheTypeAndPropertyCount() {
+    assertTrue(resource.toString().contains("kestros/components/heading"));
+    assertTrue(resource.toString().contains("properties=1"));
   }
 }

--- a/kestros-basic-components/src/test/java/io/kestros/cms/components/basic/core/PropertyBackedSyntheticResourceTest.java
+++ b/kestros-basic-components/src/test/java/io/kestros/cms/components/basic/core/PropertyBackedSyntheticResourceTest.java
@@ -71,6 +71,11 @@ public class PropertyBackedSyntheticResourceTest {
   }
 
   @Test
+  public void testEqualsWhenComparedToNull() {
+    assertNotEquals(null, resource);
+  }
+
+  @Test
   public void testEqualsWhenPropertiesDiffer() {
     Map<String, Object> other = new HashMap<>();
     other.put("heading", "Another Heading");

--- a/kestros-basic-components/src/test/java/io/kestros/cms/components/basic/core/structure/grid/KestrosGridImplTest.java
+++ b/kestros-basic-components/src/test/java/io/kestros/cms/components/basic/core/structure/grid/KestrosGridImplTest.java
@@ -57,4 +57,18 @@ public class KestrosGridImplTest extends BaseSyntheticTest {
     assertNotNull(syntheticResource);
     assertEquals("/synthetics/parent/gridElement", syntheticResource.getPath());
   }
+
+  @Test
+  public void testGetChildElements() {
+    List<KestrosBasicComponentElement> childElements = grid.getChildElements();
+
+    assertEquals(2, childElements.size());
+    assertEquals("col1", childElements.get(0).getForcedResourceName());
+    assertEquals("col2", childElements.get(1).getForcedResourceName());
+  }
+
+  @Test
+  public void testGetChildrenRendersTheColumns() {
+    assertEquals(2, grid.getChildren().size());
+  }
 }


### PR DESCRIPTION
EI_EXPOSE_REP only. 25 files.

This is the one with a real behaviour change: getters that handed back the component's internal list now return an unmodifiable view, so a caller that mutated the returned list will start throwing. That is precisely why it is on its own branch rather than buried in a 115-file diff.

Stacks on 0/5.