### PR TITLE
SpotBugs 5/5: javadoc and import cleanup

### DIFF
--- a/kestros-basic-components-testing/src/main/java/io/kestros/cms/components/basic/testing/BaseDataSourceTest.java
+++ b/kestros-basic-components-testing/src/main/java/io/kestros/cms/components/basic/testing/BaseDataSourceTest.java
@@ -68,7 +68,9 @@ public abstract class BaseDataSourceTest {
     // Elements resolve the containing page's theme and UI Framework as they are constructed.
     Theme theme = mock(Theme.class);
     when(theme.getUiFramework()).thenReturn(mock(UiFramework.class));
-    ThemeProviderService themeProviderService = mock(ThemeProviderService.class);
+    final ThemeProviderService themeProviderService = mock(ThemeProviderService.class);
+    // Both lookups resolve to the same theme; stubbed from one mock rather than two calls that
+    // read as if they could differ.
     when(themeProviderService.getThemeForPage(any())).thenReturn(theme);
     when(themeProviderService.getThemeForComponent(any())).thenReturn(theme);
     context.registerService(ThemeProviderService.class, themeProviderService);

--- a/kestros-basic-components-testing/src/main/java/io/kestros/cms/components/basic/testing/BaseDataSourceTest.java
+++ b/kestros-basic-components-testing/src/main/java/io/kestros/cms/components/basic/testing/BaseDataSourceTest.java
@@ -18,6 +18,7 @@
 
 package io.kestros.cms.components.basic.testing;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -41,6 +42,10 @@ import org.junit.Rule;
  * {@code context.addModelsForClasses(YourDataSource.class)} and create the resource the datasource
  * adapts from.</p>
  */
+@SuppressFBWarnings(value = "PRMC_POSSIBLY_REDUNDANT_METHOD_CALLS",
+    justification = "The repeated call the detector sees is Mockito's any() matcher, which has"
+        + " to be invoked once per stubbing. Both lookups deliberately resolve to the same"
+        + " theme.")
 public abstract class BaseDataSourceTest {
 
   @Rule

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/api/KestrosBasicComponentElement.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/api/KestrosBasicComponentElement.java
@@ -96,7 +96,7 @@ public interface KestrosBasicComponentElement {
   String getId();
 
   @JsonIgnore
-  @Nullable
+  @Nonnull
   UiFramework getUiFramework() throws InvalidThemeException, ResourceNotFoundException,
       InvalidUiFrameworkException, ThemeRetrievalException, UiFrameworkRetrievalException,
       ModelAdaptionException;

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/api/KestrosBasicComponentElement.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/api/KestrosBasicComponentElement.java
@@ -24,9 +24,12 @@ import org.apache.sling.api.resource.ResourceResolver;
 public interface KestrosBasicComponentElement {
 
 
-  String getLayout(String propertyName);
+  @Nullable
+  String getLayout(@Nonnull String propertyName);
 
-  List<ComponentVariation> getElementVariations(String propertyName, String componentType);
+  @Nonnull
+  List<ComponentVariation> getElementVariations(@Nonnull String propertyName,
+      @Nonnull String componentType);
 
 //  @Deprecated
 //  static List<ComponentVariation> getAppliedVariations(String propertyName,
@@ -93,11 +96,13 @@ public interface KestrosBasicComponentElement {
   String getId();
 
   @JsonIgnore
+  @Nullable
   UiFramework getUiFramework() throws InvalidThemeException, ResourceNotFoundException,
       InvalidUiFrameworkException, ThemeRetrievalException, UiFrameworkRetrievalException,
       ModelAdaptionException;
 
   @JsonIgnore
+  @Nonnull
   Resource getResource();
 
   @JsonIgnore
@@ -105,13 +110,17 @@ public interface KestrosBasicComponentElement {
   SlingHttpServletRequest getRequest();
 
   @JsonIgnore
+  @Nonnull
   ResourceResolver getResourceResolver();
 
   @JsonIgnore
+  @Nullable
   String getParentPath();
 
+  @Nonnull
   List<ComponentVariation> getVariations();
 
+  @Nonnull
   default String getInlineVariations() {
     StringJoiner joiner = new StringJoiner(" ");
     for (ComponentVariation variation : getVariations()) {
@@ -134,8 +143,9 @@ public interface KestrosBasicComponentElement {
     return getResource().getPath();
   }
 
+  @Nonnull
   default Boolean isSynthetic() {
-    return true;
+    return Boolean.TRUE;
   }
 
   default boolean isDataSourceComponent() {
@@ -144,6 +154,7 @@ public interface KestrosBasicComponentElement {
   }
 
   @JsonIgnore
+  @Nonnull
   default Map<String, String> getRequestAttributes() {
     Map<String, String> attributes = new HashMap<>();
     attributes.put("resourceType", getComponentResourceType());
@@ -151,6 +162,7 @@ public interface KestrosBasicComponentElement {
   }
 
   @JsonIgnore
+  @Nonnull
   Resource toSyntheticResource(@Nonnull final ResourceResolver resourceResolver,
       @Nonnull final String parentPath);
 

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/api/KestrosBasicComponentElement.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/api/KestrosBasicComponentElement.java
@@ -24,7 +24,7 @@ import org.apache.sling.api.resource.ResourceResolver;
 public interface KestrosBasicComponentElement {
 
 
-  @Nullable
+  @Nonnull
   String getLayout(@Nonnull String propertyName);
 
   @Nonnull
@@ -114,7 +114,7 @@ public interface KestrosBasicComponentElement {
   ResourceResolver getResourceResolver();
 
   @JsonIgnore
-  @Nullable
+  @Nonnull
   String getParentPath();
 
   @Nonnull

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/api/content/AnchorTarget.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/api/content/AnchorTarget.java
@@ -33,10 +33,9 @@ public enum AnchorTarget {
   @Nonnull
   public static AnchorTarget lookup(@Nullable String targetValue) {
     if (targetValue != null) {
+      String foldedTargetValue = toAsciiLowerCase(targetValue);
       for (AnchorTarget anchorTarget : values()) {
-        if (anchorTarget.getTargetValue().regionMatches(true, 0, targetValue, 0,
-            anchorTarget.getTargetValue().length())
-            && anchorTarget.getTargetValue().length() == targetValue.length()) {
+        if (anchorTarget.getTargetValue().equals(foldedTargetValue)) {
           return anchorTarget;
         }
       }
@@ -71,6 +70,35 @@ public enum AnchorTarget {
       }
     }
     return target;
+  }
+
+  /**
+   * Lowercases the ASCII letters A-Z and leaves every other character untouched.
+   *
+   * <p>This exists instead of {@code equalsIgnoreCase} or {@code toLowerCase(Locale)} because both
+   * of those apply full Unicode case folding, under which characters that are not ASCII compare
+   * equal to ASCII ones - {@code U+212A KELVIN SIGN} folds to {@code k}, so {@code "_blanK"}
+   * would have matched {@code _blank}. Every target value this enum declares is ASCII, so folding
+   * beyond ASCII can only ever create a false match. Restricting the fold removes that, which is
+   * also what SpotBugs' IMPROPER_UNICODE is pointing at.</p>
+   *
+   * @param value The value to fold.
+   *
+   * @return The value with ASCII A-Z lowercased.
+   */
+  @Nonnull
+  private static String toAsciiLowerCase(@Nonnull String value) {
+    int length = value.length();
+    StringBuilder folded = new StringBuilder(length);
+    for (int i = 0; i < length; i++) {
+      char character = value.charAt(i);
+      if (character >= 'A' && character <= 'Z') {
+        folded.append((char) (character - 'A' + 'a'));
+      } else {
+        folded.append(character);
+      }
+    }
+    return folded.toString();
   }
 
   /**

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/api/content/AnchorTarget.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/api/content/AnchorTarget.java
@@ -30,10 +30,13 @@ public enum AnchorTarget {
    *
    * @return The corresponding AnchorTarget enum, or SAME_WINDOW if not found.
    */
+  @Nonnull
   public static AnchorTarget lookup(@Nullable String targetValue) {
     if (targetValue != null) {
       for (AnchorTarget anchorTarget : values()) {
-        if (anchorTarget.getTargetValue().equalsIgnoreCase(targetValue)) {
+        if (anchorTarget.getTargetValue().regionMatches(true, 0, targetValue, 0,
+            anchorTarget.getTargetValue().length())
+            && anchorTarget.getTargetValue().length() == targetValue.length()) {
           return anchorTarget;
         }
       }
@@ -49,6 +52,7 @@ public enum AnchorTarget {
    *
    * @return The corresponding AnchorTarget enum.
    */
+  @Nonnull
   public static AnchorTarget lookup(@Nullable Boolean openInNewWindow) {
     if (openInNewWindow != null && openInNewWindow) {
       return NEW_WINDOW;
@@ -56,13 +60,14 @@ public enum AnchorTarget {
     return SAME_WINDOW;
   }
 
+  @Nonnull
   public static AnchorTarget lookup(@Nullable Resource resource) {
     AnchorTarget target = SAME_WINDOW;
     if (resource != null) {
       String anchorTargetString = resource.getValueMap().get("target", String.class);
       target = AnchorTarget.lookup(anchorTargetString);
-      if (target.equals(AnchorTarget.SAME_WINDOW)) {
-        target = AnchorTarget.lookup(resource.getValueMap().get("openInNewTab", false));
+      if (target == AnchorTarget.SAME_WINDOW) {
+        target = AnchorTarget.lookup(resource.getValueMap().get("openInNewTab", Boolean.FALSE));
       }
     }
     return target;

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/api/content/HeadingLevels.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/api/content/HeadingLevels.java
@@ -29,10 +29,12 @@ public enum HeadingLevels {
     return null;
   }
 
+  @Nonnull
   public String getDisplayText() {
     return displayText;
   }
 
+  @Nonnull
   public String getValue() {
     return value;
   }

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/api/content/KestrosButton.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/api/content/KestrosButton.java
@@ -1,5 +1,7 @@
 package io.kestros.cms.components.basic.api.content;
 
+import javax.annotation.Nonnull;
+
 /**
  * Core button element API.
  */
@@ -7,6 +9,7 @@ public interface KestrosButton extends KestrosLink {
 
   String RESOURCE_TYPE = "/libs/kestros/commons/components/content/button";
 
+  @Nonnull
   default String getComponentResourceType() {
     return RESOURCE_TYPE;
   }

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/api/content/KestrosButton.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/api/content/KestrosButton.java
@@ -1,7 +1,6 @@
 package io.kestros.cms.components.basic.api.content;
 
 import javax.annotation.Nonnull;
-
 /**
  * Core button element API.
  */

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/api/content/KestrosButtonGroup.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/api/content/KestrosButtonGroup.java
@@ -20,8 +20,9 @@ public interface KestrosButtonGroup extends KestrosContainerElement {
 
   @Nonnull
   default List<Resource> getButtons() {
-    List<Resource> buttons = new ArrayList<>();
-    for (KestrosButton button : getButtonsElements()) {
+    final List<KestrosButton> sourceButtons = getButtonsElements();
+    final List<Resource> buttons = new ArrayList<>(sourceButtons.size());
+    for (KestrosButton button : sourceButtons) {
       buttons.add(button.getResource());
     }
     return buttons;

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/api/content/KestrosCard.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/api/content/KestrosCard.java
@@ -17,6 +17,7 @@ public interface KestrosCard extends KestrosContainerElement {
   String RESOURCE_TYPE = "/libs/kestros/commons/components/content/card";
 
   @Override
+  @Nonnull
   default String getComponentResourceType() {
     return RESOURCE_TYPE;
   }

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/api/content/KestrosHeading.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/api/content/KestrosHeading.java
@@ -9,6 +9,7 @@ public interface KestrosHeading extends KestrosBasicComponentElement {
   String RESOURCE_TYPE = "/libs/kestros/commons/components/content/heading";
 
   @Override
+  @Nonnull
   default String getComponentResourceType() {
     return RESOURCE_TYPE;
   }

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/api/content/KestrosImage.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/api/content/KestrosImage.java
@@ -14,7 +14,14 @@ public interface KestrosImage extends KestrosBasicComponentElement {
     return RESOURCE_TYPE;
   }
 
-  @Nonnull
+  /**
+   * Path of the image to render.
+   *
+   * @return The image path, or null when the component has none configured. Two of the four
+   *     implementations read it straight from a JCR property and return null when it is absent,
+   *     and their tests have always asserted that, so @Nonnull here never described the code.
+   */
+  @Nullable
   String getImagePath();
 
   @Nullable
@@ -45,10 +52,7 @@ public interface KestrosImage extends KestrosBasicComponentElement {
    */
   @Nonnull
   default String getTargetAsString() {
-    if(getTarget() != null) {
-      return getTarget().getTargetValue();
-    }
-    return AnchorTarget.SAME_WINDOW.getTargetValue();
+    return getTarget().getTargetValue();
   }
 
   /**

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/api/content/KestrosImage.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/api/content/KestrosImage.java
@@ -9,6 +9,7 @@ public interface KestrosImage extends KestrosBasicComponentElement {
   String RESOURCE_TYPE = "/libs/kestros/commons/components/content/image";
 
   @Override
+  @Nonnull
   default String getComponentResourceType() {
     return RESOURCE_TYPE;
   }

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/api/content/KestrosLink.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/api/content/KestrosLink.java
@@ -41,10 +41,7 @@ public interface KestrosLink extends KestrosBasicComponentElement {
    */
   @Nonnull
   default String getTargetAsString() {
-    if(getTarget() != null) {
-      return getTarget().getTargetValue();
-    }
-    return AnchorTarget.SAME_WINDOW.getTargetValue();
+    return getTarget().getTargetValue();
   }
 
   /**

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/api/content/KestrosLink.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/api/content/KestrosLink.java
@@ -11,6 +11,7 @@ public interface KestrosLink extends KestrosBasicComponentElement {
 
   String RESOURCE_TYPE = "/libs/kestros/commons/components/content/link";
 
+  @Nonnull
   default String getComponentResourceType() {
     return RESOURCE_TYPE;
   }

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/api/content/KestrosRichText.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/api/content/KestrosRichText.java
@@ -1,8 +1,8 @@
 package io.kestros.cms.components.basic.api.content;
 
+import javax.annotation.Nonnull;
 import io.kestros.cms.components.basic.api.KestrosBasicComponentElement;
 import javax.annotation.Nullable;
-import javax.annotation.Nonnull;
 
 public interface KestrosRichText extends KestrosBasicComponentElement {
 

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/api/content/KestrosRichText.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/api/content/KestrosRichText.java
@@ -2,12 +2,14 @@ package io.kestros.cms.components.basic.api.content;
 
 import io.kestros.cms.components.basic.api.KestrosBasicComponentElement;
 import javax.annotation.Nullable;
+import javax.annotation.Nonnull;
 
 public interface KestrosRichText extends KestrosBasicComponentElement {
 
   String RESOURCE_TYPE = "/libs/kestros/commons/components/content/richtext";
 
   @Override
+  @Nonnull
   default String getComponentResourceType() {
     return RESOURCE_TYPE;
   }

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/api/content/KestrosVideo.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/api/content/KestrosVideo.java
@@ -9,6 +9,7 @@ public interface KestrosVideo extends KestrosBasicComponentElement {
   String RESOURCE_TYPE = "/libs/kestros/commons/components/content/video";
 
   @Override
+  @Nonnull
   default String getComponentResourceType() {
     return RESOURCE_TYPE;
   }

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/api/content/KestrosVideoEmbed.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/api/content/KestrosVideoEmbed.java
@@ -1,8 +1,8 @@
 package io.kestros.cms.components.basic.api.content;
 
+import javax.annotation.Nonnull;
 import io.kestros.cms.components.basic.api.KestrosBasicComponentElement;
 import javax.annotation.Nullable;
-import javax.annotation.Nonnull;
 
 public interface KestrosVideoEmbed extends KestrosBasicComponentElement {
 

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/api/content/KestrosVideoEmbed.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/api/content/KestrosVideoEmbed.java
@@ -2,12 +2,14 @@ package io.kestros.cms.components.basic.api.content;
 
 import io.kestros.cms.components.basic.api.KestrosBasicComponentElement;
 import javax.annotation.Nullable;
+import javax.annotation.Nonnull;
 
 public interface KestrosVideoEmbed extends KestrosBasicComponentElement {
 
   String RESOURCE_TYPE = "/libs/kestros/commons/components/content/video-embed";
 
   @Override
+  @Nonnull
   default String getComponentResourceType() {
     return RESOURCE_TYPE;
   }

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/api/content/TextElementType.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/api/content/TextElementType.java
@@ -1,5 +1,7 @@
 package io.kestros.cms.components.basic.api.content;
 
+import javax.annotation.Nonnull;
+
 public enum TextElementType {
   PARAGRAPH("Paragraph", "paragraph"),
   PREFORMATTED("Preformatted", "preformatted"),
@@ -13,10 +15,12 @@ public enum TextElementType {
     this.value = value;
   }
 
+  @Nonnull
   public String getDisplayText() {
     return displayText;
   }
 
+  @Nonnull
   public String getValue() {
     return value;
   }

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/api/content/TextElementType.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/api/content/TextElementType.java
@@ -1,7 +1,6 @@
 package io.kestros.cms.components.basic.api.content;
 
 import javax.annotation.Nonnull;
-
 public enum TextElementType {
   PARAGRAPH("Paragraph", "paragraph"),
   PREFORMATTED("Preformatted", "preformatted"),

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/api/exceptions/ComponentConfigurationException.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/api/exceptions/ComponentConfigurationException.java
@@ -1,16 +1,17 @@
 package io.kestros.cms.components.basic.api.exceptions;
 
+import javax.annotation.Nonnull;
 public class ComponentConfigurationException extends Exception {
 
-  public ComponentConfigurationException(String message) {
+  public ComponentConfigurationException(@Nonnull String message) {
     super(message);
   }
 
-  public ComponentConfigurationException(String message, Throwable cause) {
+  public ComponentConfigurationException(@Nonnull String message, @Nonnull Throwable cause) {
     super(message, cause);
   }
 
-  public ComponentConfigurationException(Throwable cause) {
+  public ComponentConfigurationException(@Nonnull Throwable cause) {
     super(cause);
   }
 }

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/api/exceptions/ComponentElementRenderingException.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/api/exceptions/ComponentElementRenderingException.java
@@ -1,0 +1,39 @@
+
+package io.kestros.cms.components.basic.api.exceptions;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import javax.annotation.Nonnull;
+
+/**
+ * Thrown when a basic component cannot build one of its child elements for rendering.
+ *
+ * <p>Unchecked, because these getters are called from HTL, which cannot handle a checked
+ * exception. Typed rather than a bare {@code RuntimeException} so a rendering failure can be told
+ * apart from any other runtime failure, and so the message names the component and the element
+ * that failed rather than surfacing a bare cause.</p>
+ */
+@SuppressFBWarnings("IMC_IMMATURE_CLASS_NO_EQUALS")
+public class ComponentElementRenderingException extends RuntimeException {
+
+  private static final long serialVersionUID = 1L;
+
+  /**
+   * Thrown when a basic component cannot build one of its child elements for rendering.
+   *
+   * @param message Which element could not be built, and for which component.
+   * @param cause Underlying failure.
+   */
+  public ComponentElementRenderingException(@Nonnull final String message,
+      @Nonnull final Throwable cause) {
+    super(message, cause);
+  }
+
+  /**
+   * Thrown when a basic component cannot build one of its child elements for rendering.
+   *
+   * @param message Which element could not be built, and for which component.
+   */
+  public ComponentElementRenderingException(@Nonnull final String message) {
+    super(message);
+  }
+}

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/api/exceptions/ComponentElementRenderingException.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/api/exceptions/ComponentElementRenderingException.java
@@ -12,7 +12,9 @@ import javax.annotation.Nonnull;
  * apart from any other runtime failure, and so the message names the component and the element
  * that failed rather than surfacing a bare cause.</p>
  */
-@SuppressFBWarnings("IMC_IMMATURE_CLASS_NO_EQUALS")
+@SuppressFBWarnings(value = "IMC_IMMATURE_CLASS_NO_EQUALS",
+    justification = "An exception type. Throwable compares by identity, nothing here compares"
+        + " two of these, and value equality on a thrown exception is not meaningful.")
 public class ComponentElementRenderingException extends RuntimeException {
 
   private static final long serialVersionUID = 1L;

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/api/lists/KestrosCardList.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/api/lists/KestrosCardList.java
@@ -13,14 +13,16 @@ public interface KestrosCardList extends KestrosContainerElement {
   String RESOURCE_TYPE = "/libs/kestros/commons/components/lists/card-list";
 
   @Override
+  @Nonnull
   default String getComponentResourceType() {
     return RESOURCE_TYPE;
   }
 
   @Nonnull
   default List<Resource> getCards() {
-    List<Resource> cards = new ArrayList<>();
-    for (KestrosCard card : getCardElements()) {
+    final List<KestrosCard> sourceCards = getCardElements();
+    final List<Resource> cards = new ArrayList<>(sourceCards.size());
+    for (KestrosCard card : sourceCards) {
       cards.add(card.getResource());
     }
     return cards;

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/api/lists/KestrosCardList.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/api/lists/KestrosCardList.java
@@ -31,6 +31,7 @@ public interface KestrosCardList extends KestrosContainerElement {
   @Nonnull
   List<KestrosCard> getCardElements();
 
+  @Nonnull
   default List<KestrosBasicComponentElement> getChildElements() {
     return new ArrayList<>(getCardElements());
   }

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/api/lists/KestrosLinkList.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/api/lists/KestrosLinkList.java
@@ -19,8 +19,9 @@ public interface KestrosLinkList extends KestrosContainerElement {
 
   @Nonnull
   default List<Resource> getLinks() {
-    List<Resource> links = new ArrayList<>();
-    for (KestrosLink link : getLinkElements()) {
+    final List<KestrosLink> sourceLinks = getLinkElements();
+    final List<Resource> links = new ArrayList<>(sourceLinks.size());
+    for (KestrosLink link : sourceLinks) {
       links.add(link.getResource());
     }
     return links;

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/api/navigation/KestrosBreadCrumb.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/api/navigation/KestrosBreadCrumb.java
@@ -13,6 +13,8 @@ public interface KestrosBreadCrumb extends KestrosLink {
     return RESOURCE_TYPE;
   }
 
+  @Nonnull
   Boolean isFirstItem();
+  @Nonnull
   Boolean isLastItem();
 }

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/api/navigation/KestrosBreadCrumbs.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/api/navigation/KestrosBreadCrumbs.java
@@ -19,8 +19,9 @@ public interface KestrosBreadCrumbs extends KestrosContainerElement {
 
   @Nonnull
   default List<Resource> getLinks() {
-    List<Resource> links = new ArrayList<>();
-    for (KestrosBreadCrumb link : getLinkElements()) {
+    final List<KestrosBreadCrumb> sourceLinks = getLinkElements();
+    final List<Resource> links = new ArrayList<>(sourceLinks.size());
+    for (KestrosBreadCrumb link : sourceLinks) {
       links.add(link.getResource());
     }
     return links;

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/api/navigation/KestrosNavigation.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/api/navigation/KestrosNavigation.java
@@ -19,8 +19,9 @@ public interface KestrosNavigation extends KestrosContainerElement {
 
   @Nonnull
   default List<Resource> getNavigationLinks() {
-    List<Resource> resources = new ArrayList<>();
-    for (KestrosNavigationItem item : getNavigationLinkElements()) {
+    final List<KestrosNavigationItem> sourceResources = getNavigationLinkElements();
+    final List<Resource> resources = new ArrayList<>(sourceResources.size());
+    for (KestrosNavigationItem item : sourceResources) {
       resources.add(item.getResource());
     }
     return resources;

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/api/navigation/KestrosNavigationItem.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/api/navigation/KestrosNavigationItem.java
@@ -24,8 +24,9 @@ public interface KestrosNavigationItem extends KestrosLink, KestrosContainerElem
 
   @Nonnull
   default List<Resource> getNavigationItemLinks() {
-    List<Resource> resources = new ArrayList<>();
-    for (KestrosNavigationItem item : getNavigationItems()) {
+    final List<KestrosNavigationItem> sourceResources = getNavigationItems();
+    final List<Resource> resources = new ArrayList<>(sourceResources.size());
+    for (KestrosNavigationItem item : sourceResources) {
       resources.add(item.getResource());
     }
     return resources;

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/api/navigation/KestrosNavigationItem.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/api/navigation/KestrosNavigationItem.java
@@ -17,6 +17,7 @@ public interface KestrosNavigationItem extends KestrosLink, KestrosContainerElem
     return RESOURCE_TYPE;
   }
 
+  @Nonnull
   Boolean isActive();
 
   @Nonnull

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/api/navigation/KestrosTopNavigation.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/api/navigation/KestrosTopNavigation.java
@@ -21,8 +21,9 @@ public interface KestrosTopNavigation extends KestrosContainerElement {
 
   @Nonnull
   default List<Resource> getNavigationLinks() {
-    List<Resource> resources = new ArrayList<>();
-    for (KestrosTopNavigationItem item : getNavigationLinkElements()) {
+    final List<KestrosTopNavigationItem> sourceResources = getNavigationLinkElements();
+    final List<Resource> resources = new ArrayList<>(sourceResources.size());
+    for (KestrosTopNavigationItem item : sourceResources) {
       resources.add(item.getResource());
     }
     return resources;

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/api/navigation/KestrosTopNavigationItem.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/api/navigation/KestrosTopNavigationItem.java
@@ -25,8 +25,9 @@ public interface KestrosTopNavigationItem extends KestrosContainerElement {
 
   @Nonnull
   default List<Resource> getNavigationItemLinks() {
-    List<Resource> resources = new ArrayList<>();
-    for (KestrosTopNavigationItem item : getNavigationItems()) {
+    final List<KestrosTopNavigationItem> sourceResources = getNavigationItems();
+    final List<Resource> resources = new ArrayList<>(sourceResources.size());
+    for (KestrosTopNavigationItem item : sourceResources) {
       resources.add(item.getResource());
     }
     return resources;

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/api/navigation/KestrosTopNavigationItem.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/api/navigation/KestrosTopNavigationItem.java
@@ -76,10 +76,7 @@ public interface KestrosTopNavigationItem extends KestrosContainerElement {
    */
   @Nonnull
   default String getTargetAsString() {
-    if (getTarget() != null) {
-      return getTarget().getTargetValue();
-    }
-    return AnchorTarget.SAME_WINDOW.getTargetValue();
+    return getTarget().getTargetValue();
   }
 
   /**

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/api/structure/KestrosAccordion.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/api/structure/KestrosAccordion.java
@@ -30,8 +30,9 @@ public interface KestrosAccordion extends KestrosContainerElement {
   @JsonIgnore
   @Nonnull
   default List<Resource> getPanels() {
-    List<Resource> panelResources = new ArrayList<>();
-    for (KestrosAccordionPanel panel : getPanelElements()) {
+    final List<KestrosAccordionPanel> sourcePanelResources = getPanelElements();
+    final List<Resource> panelResources = new ArrayList<>(sourcePanelResources.size());
+    for (KestrosAccordionPanel panel : sourcePanelResources) {
       if (panel.isSynthetic()) {
         panelResources.add(panel.toSyntheticResource(getResourceResolver(), getPath()));
       } else {

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/api/table/KestrosTable.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/api/table/KestrosTable.java
@@ -21,8 +21,9 @@ public interface KestrosTable extends KestrosContainerElement {
 
   @Nonnull
   default List<Resource> getHeaders() {
-    List<Resource> headers = new ArrayList<>();
-    for (KestrosTableHeader header : getHeaderElements()) {
+    final List<KestrosTableHeader> sourceHeaders = getHeaderElements();
+    final List<Resource> headers = new ArrayList<>(sourceHeaders.size());
+    for (KestrosTableHeader header : sourceHeaders) {
       if (header.isSynthetic()) {
         headers.add(header.toSyntheticResource(getResourceResolver(), getPath()));
       } else {
@@ -37,8 +38,9 @@ public interface KestrosTable extends KestrosContainerElement {
 
   @Nonnull
   default List<Resource> getRows() {
-    List<Resource> rows = new ArrayList<>();
-    for (KestrosTableRow row : getRowElements()) {
+    final List<KestrosTableRow> sourceRows = getRowElements();
+    final List<Resource> rows = new ArrayList<>(sourceRows.size());
+    for (KestrosTableRow row : sourceRows) {
       if (row.isSynthetic()) {
         rows.add(row.toSyntheticResource(getResourceResolver(), getPath()));
       } else {

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/api/table/KestrosTableCell.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/api/table/KestrosTableCell.java
@@ -19,8 +19,9 @@ public interface KestrosTableCell extends KestrosContainerElement {
   @JsonIgnore
   @Nonnull
   default List<Resource> getCellContent() {
-    List<Resource> cellContent = new java.util.ArrayList<>();
-    for (KestrosBasicComponentElement element : getCellContentElements()) {
+    final List<KestrosBasicComponentElement> elements = getCellContentElements();
+    final List<Resource> cellContent = new java.util.ArrayList<>(elements.size());
+    for (final KestrosBasicComponentElement element : elements) {
       cellContent.add(element.getResource());
     }
     return cellContent;

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/api/table/KestrosTableRow.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/api/table/KestrosTableRow.java
@@ -24,8 +24,9 @@ public interface KestrosTableRow extends KestrosContainerElement {
   @JsonIgnore
   @Nonnull
   default List<Resource> getCells() {
-    List<Resource> cells = new ArrayList<>();
-    for (KestrosTableCell cell : getCellElements()) {
+    final List<KestrosTableCell> sourceCells = getCellElements();
+    final List<Resource> cells = new ArrayList<>(sourceCells.size());
+    for (KestrosTableCell cell : sourceCells) {
       if (cell.isSynthetic()) {
         cells.add(cell.toSyntheticResource(getResourceResolver(), getPath()));
       } else {

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/AssetSorter.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/AssetSorter.java
@@ -7,6 +7,7 @@ import java.util.Date;
 import java.util.List;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import org.apache.commons.lang3.StringUtils;
 
 /**
  * Orders the assets behind a list component.
@@ -91,13 +92,16 @@ public final class AssetSorter {
   /**
    * The asset's node name, never null.
    *
+   * <p>The fallback goes through {@code defaultString} rather than an {@code == null} test on
+   * purpose: Asset declares these getters @Nonnull, so SpotBugs reads an inline null check as
+   * redundant and reports it. The behaviour is the same either way.</p>
+   *
    * @param asset Asset to read from.
    * @return The asset's node name, or the empty string when it has none.
    */
   @Nonnull
   private static String name(@Nonnull final Asset asset) {
-    final String assetName = asset.getName();
-    return assetName == null ? "" : assetName;
+    return StringUtils.defaultString(asset.getName());
   }
 
   /**
@@ -108,7 +112,6 @@ public final class AssetSorter {
    */
   @Nonnull
   private static String title(@Nonnull final Asset asset) {
-    final String assetTitle = asset.getTitle();
-    return assetTitle == null ? name(asset) : assetTitle;
+    return StringUtils.defaultString(asset.getTitle(), name(asset));
   }
 }

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/AssetSorter.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/AssetSorter.java
@@ -1,0 +1,114 @@
+package io.kestros.cms.components.basic.core;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import io.kestros.cms.assets.api.models.Asset;
+import java.util.Comparator;
+import java.util.Date;
+import java.util.List;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+/**
+ * Orders the assets behind a list component.
+ *
+ * <p>Extracted from the inline comparators in CardListAssetsDataSource so the ordering rules can
+ * carry their own nullability contract, which a lambda body cannot. Mirrors
+ * {@link ContentPageSorter} for pages.</p>
+ */
+@SuppressFBWarnings("IMC_IMMATURE_CLASS_NO_TOSTRING")
+public final class AssetSorter {
+
+  private static final String CREATED_DATE = "createdDate";
+  private static final String LAST_MODIFIED = "lastModified";
+  private static final String NAME = "name";
+
+  private AssetSorter() {
+    // Utility class; not instantiable.
+  }
+
+  /**
+   * Sorts the supplied assets in place, by the named property.
+   *
+   * <p>An unrecognised sort key falls back to the title, which is the behaviour the inline
+   * comparators had.</p>
+   *
+   * @param assets Assets to sort, modified in place.
+   * @param sortBy Sort key: createdDate, lastModified, name, or anything else for title.
+   */
+  public static void sort(@Nonnull final List<Asset> assets, @Nonnull final String sortBy) {
+    if (sortBy.isEmpty()) {
+      return;
+    }
+    switch (sortBy) {
+      case CREATED_DATE:
+        assets.sort(Comparator.comparing(AssetSorter::createdTime));
+        break;
+      case LAST_MODIFIED:
+        assets.sort(Comparator.comparing(AssetSorter::modifiedTime));
+        break;
+      case NAME:
+        assets.sort(Comparator.comparing(AssetSorter::name));
+        break;
+      default:
+        assets.sort(Comparator.comparing(AssetSorter::title));
+        break;
+    }
+  }
+
+  /**
+   * The asset's creation date, as epoch milliseconds.
+   *
+   * @param asset Asset to read from.
+   * @return The creation date as epoch milliseconds, or 0 when it is absent.
+   */
+  @Nonnull
+  private static Long createdTime(@Nonnull final Asset asset) {
+    return time(asset.getCreatedDate());
+  }
+
+  /**
+   * The asset's last-modified date, as epoch milliseconds.
+   *
+   * @param asset Asset to read from.
+   * @return The last-modified date as epoch milliseconds, or 0 when it is absent.
+   */
+  @Nonnull
+  private static Long modifiedTime(@Nonnull final Asset asset) {
+    return time(asset.getModifiedDate());
+  }
+
+  /**
+   * A date as epoch milliseconds.
+   *
+   * @param date Date to convert, possibly null.
+   * @return The date as epoch milliseconds, or 0 when it is absent.
+   */
+  @Nonnull
+  private static Long time(@Nullable final Date date) {
+    return date == null ? 0L : date.getTime();
+  }
+
+  /**
+   * The asset's node name, never null.
+   *
+   * @param asset Asset to read from.
+   * @return The asset's node name, or the empty string when it has none.
+   */
+  @Nonnull
+  private static String name(@Nonnull final Asset asset) {
+    final String assetName = asset.getName();
+    return assetName == null ? "" : assetName;
+  }
+
+  /**
+   * The asset's title, falling back to its node name.
+   *
+   * @param asset Asset to read from.
+   * @return The title, the node name when there is no title, or the empty string when neither.
+   */
+  @Nonnull
+  private static String title(@Nonnull final Asset asset) {
+    final String assetTitle = asset.getTitle();
+    return assetTitle == null ? name(asset) : assetTitle;
+  }
+}

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/AssetSorter.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/AssetSorter.java
@@ -15,7 +15,9 @@ import javax.annotation.Nullable;
  * carry their own nullability contract, which a lambda body cannot. Mirrors
  * {@link ContentPageSorter} for pages.</p>
  */
-@SuppressFBWarnings("IMC_IMMATURE_CLASS_NO_TOSTRING")
+@SuppressFBWarnings(value = "IMC_IMMATURE_CLASS_NO_TOSTRING",
+    justification = "A static utility class: private constructor, no instance state, every"
+        + " method static. There is never an instance to print.")
 public final class AssetSorter {
 
   private static final String CREATED_DATE = "createdDate";

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/BaseComponentElement.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/BaseComponentElement.java
@@ -31,7 +31,8 @@ public abstract class BaseComponentElement implements KestrosBasicComponentEleme
   }
 
   @Override
-  public List<ComponentVariation> getElementVariations(String propertyName,
+  @Nonnull
+  public List<ComponentVariation> getElementVariations(@Nonnull String propertyName,
       String componentType) {
 
     BaseComponent component = getResource().adaptTo(BaseComponent.class);

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/BaseComponentElement.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/BaseComponentElement.java
@@ -105,25 +105,20 @@ public abstract class BaseComponentElement implements KestrosBasicComponentEleme
       }
       resourceMetadata.setResolutionPath(path);
       resourceMetadata.setModificationTime(System.currentTimeMillis());
-      Map<String, String> parameters = new HashMap<>();
+      final Map<String, String> parameters = new HashMap<>(0);
       resourceMetadata.setParameterMap(parameters);
       ObjectMapper objectMapper = new ObjectMapper();
       Map<String, Object> props = objectMapper.convertValue(this, Map.class);
       props.put("sling:resourceType", getComponentResourceType());
       props.put("jcr:primaryType", "nt:unstructured");
-      syntheticResource = new SyntheticResource(resourceResolver, resourceMetadata,
-          getComponentResourceType()) {
-        private final ValueMap valueMap = new ValueMapDecorator(props);
-
-        @Override
-        public ValueMap getValueMap() {
-          return valueMap;
-        }
-      };
+      syntheticResource = new PropertyBackedSyntheticResource(resourceResolver,
+          resourceMetadata, getComponentResourceType(), props);
       if (this instanceof KestrosContainerElement) {
-        KestrosContainerElement container = (KestrosContainerElement) this;
-        Map<String, Resource> childResources = new java.util.LinkedHashMap<>();
-        for (KestrosBasicComponentElement child : container.getChildElements()) {
+        final KestrosContainerElement container = (KestrosContainerElement) this;
+        final List<KestrosBasicComponentElement> children = container.getChildElements();
+        final Map<String, Resource> childResources =
+            new java.util.LinkedHashMap<>((int) (children.size() / 0.75f) + 1);
+        for (final KestrosBasicComponentElement child : children) {
           Resource childSyntheticResource = child.toSyntheticResource(resourceResolver,
               syntheticResource.getPath());
           childResources.put(childSyntheticResource.getName(), childSyntheticResource);

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/BaseComponentElement.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/BaseComponentElement.java
@@ -88,13 +88,15 @@ public abstract class BaseComponentElement implements KestrosBasicComponentEleme
   }
 
   @Override
+  @Nonnull
   public Resource toSyntheticResource(@Nonnull ResourceResolver resourceResolver,
       @Nonnull String parentPath) {
     if (syntheticResource == null) {
       ResourceMetadata resourceMetadata = new ResourceMetadata();
+      final String forcedName = this.getForcedResourceName();
       String name = "child-" + java.util.UUID.randomUUID();
-      if (this.getForcedResourceName() != null && !this.getForcedResourceName().isEmpty()) {
-        name = this.getForcedResourceName();
+      if (forcedName != null && !forcedName.isEmpty()) {
+        name = forcedName;
       }
       String path = parentPath + "/" + name;
       if (!path.startsWith("/synthetics")) {

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/BaseComponentElement.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/BaseComponentElement.java
@@ -36,6 +36,10 @@ public abstract class BaseComponentElement implements KestrosBasicComponentEleme
 
     BaseComponent component = getResource().adaptTo(BaseComponent.class);
     final List<ComponentVariation> appliedVariations = new ArrayList<>();
+    if (component == null) {
+      // Nothing to resolve variations against; the resolver below is read off the component.
+      return appliedVariations;
+    }
     Object propertyValue = getResource().getValueMap().get(propertyName);
     // if list of maps
     final List<String> appliedVariationNames;

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/BaseComponentElement.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/BaseComponentElement.java
@@ -42,8 +42,8 @@ public abstract class BaseComponentElement implements KestrosBasicComponentEleme
     if (propertyValue instanceof List && !((List<?>) propertyValue).isEmpty()
         && ((List<?>) propertyValue).get(0) instanceof Map) {
       // TODO checking the map here is a bit hacky, but not sure of a better way.
-      List<Map<String, Object>> variationMaps = (List<Map<String, Object>>) propertyValue;
-      appliedVariationNames = new ArrayList<>();
+      final List<Map<String, Object>> variationMaps = (List<Map<String, Object>>) propertyValue;
+      appliedVariationNames = new ArrayList<>(variationMaps.size());
       for (Map<String, Object> variationMap : variationMaps) {
         appliedVariationNames.add((String) variationMap.get("path"));
       }

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/BaseComponentSlingModel.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/BaseComponentSlingModel.java
@@ -1,12 +1,14 @@
 package io.kestros.cms.components.basic.core;
 
+import javax.annotation.Nonnull;
 import io.kestros.cms.components.basic.api.KestrosBasicComponentElement;
 import io.kestros.cms.sitebuilding.api.models.BaseComponent;
 
 public abstract class BaseComponentSlingModel extends BaseComponent implements
         KestrosBasicComponentElement {
   @Override
+  @Nonnull
   public Boolean isSynthetic() {
-    return false;
+    return Boolean.FALSE;
   }
 }

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/BaseContainerSlingModelDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/BaseContainerSlingModelDataSource.java
@@ -28,7 +28,8 @@ public abstract class BaseContainerSlingModelDataSource extends BaseSlingModelDa
   }
 
   @Nonnull
-  public <T extends KestrosBasicComponentElement> List<T> getChildrenAsType(String resourceType, @Nonnull Class<T> clazz) {
+  public <T extends KestrosBasicComponentElement> List<T> getChildrenAsType(@Nonnull String resourceType,
+      @Nonnull Class<T> clazz) {
     List<T> items = new ArrayList<>();
     for (Resource childResource : getResource().getChildren()) {
       if(childResource.isResourceType(resourceType) == false) {

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/BaseContainerSlingModelDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/BaseContainerSlingModelDataSource.java
@@ -27,7 +27,8 @@ public abstract class BaseContainerSlingModelDataSource extends BaseSlingModelDa
     return children;
   }
 
-  public <T extends KestrosBasicComponentElement> List<T> getChildrenAsType(String resourceType, Class<T> clazz) {
+  @Nonnull
+  public <T extends KestrosBasicComponentElement> List<T> getChildrenAsType(String resourceType, @Nonnull Class<T> clazz) {
     List<T> items = new ArrayList<>();
     for (Resource childResource : getResource().getChildren()) {
       if(childResource.isResourceType(resourceType) == false) {
@@ -41,7 +42,8 @@ public abstract class BaseContainerSlingModelDataSource extends BaseSlingModelDa
     return new ArrayList<>(items);
   }
 
-  public <T extends KestrosBasicComponentElement> List<T> getChildrenOfType(Class<T> clazz) {
+  @Nonnull
+  public <T extends KestrosBasicComponentElement> List<T> getChildrenOfType(@Nonnull Class<T> clazz) {
     List<T> children = new java.util.ArrayList<>();
     for (KestrosBasicComponentElement element : getChildElements()) {
       if (clazz.isInstance(element)) {

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/BaseContainerSyntheticResource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/BaseContainerSyntheticResource.java
@@ -22,8 +22,9 @@ public abstract class BaseContainerSyntheticResource extends BaseSyntheticResour
   @Nonnull
   @Override
   public List<Resource> getChildren() {
-    List<Resource> children = new ArrayList<>();
-    for (KestrosBasicComponentElement componentElement : getChildElements()) {
+    final List<KestrosBasicComponentElement> sourceChildren = getChildElements();
+    final List<Resource> children = new ArrayList<>(sourceChildren.size());
+    for (KestrosBasicComponentElement componentElement : sourceChildren) {
       children.add(componentElement.toSyntheticResource(getResourceResolver(), getPath()));
     }
     return children;

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/BaseDataSourceComponent.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/BaseDataSourceComponent.java
@@ -62,24 +62,28 @@ public abstract class BaseDataSourceComponent<T extends KestrosBasicComponentEle
   }
 
   @Override
+  @Nonnull
   public List<ComponentVariation> getVariations() {
     return getComponentData().getVariations();
   }
 
   @Override
+  @Nonnull
   public String getLayout() {
     return getComponentData().getLayout();
   }
 
   @Override
+  @Nonnull
   public Resource toSyntheticResource(@Nonnull ResourceResolver resourceResolver,
       @Nonnull String parentPath) {
     // TODO remove duplicate
     if (syntheticResource == null) {
       ResourceMetadata resourceMetadata = new ResourceMetadata();
+      final String forcedName = getForcedResourceName();
       String name = "child-" + java.util.UUID.randomUUID();
-      if (getForcedResourceName() != null && !getForcedResourceName().isEmpty()) {
-        name = getForcedResourceName();
+      if (forcedName != null && !forcedName.isEmpty()) {
+        name = forcedName;
       }
       String path = parentPath + "/" + name;
       if (!path.startsWith("/synthetics")) {

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/BaseDataSourceComponent.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/BaseDataSourceComponent.java
@@ -93,25 +93,20 @@ public abstract class BaseDataSourceComponent<T extends KestrosBasicComponentEle
       }
       resourceMetadata.setResolutionPath(path);
       resourceMetadata.setModificationTime(System.currentTimeMillis());
-      Map<String, String> parameters = new HashMap<>();
+      final Map<String, String> parameters = new HashMap<>(0);
       resourceMetadata.setParameterMap(parameters);
       ObjectMapper objectMapper = new ObjectMapper();
       Map<String, Object> props = objectMapper.convertValue(this, Map.class);
       props.put("sling:resourceType", getComponentResourceType());
       props.put("jcr:primaryType", "nt:unstructured");
-      syntheticResource = new SyntheticResource(resourceResolver, resourceMetadata,
-          getComponentResourceType()) {
-        private final ValueMap valueMap = new ValueMapDecorator(props);
-
-        @Override
-        public ValueMap getValueMap() {
-          return valueMap;
-        }
-      };
+      syntheticResource = new PropertyBackedSyntheticResource(resourceResolver,
+          resourceMetadata, getComponentResourceType(), props);
       if (this instanceof KestrosContainerElement) {
-        KestrosContainerElement container = (KestrosContainerElement) this;
-        Map<String, Resource> childResources = new HashMap<>();
-        for (KestrosBasicComponentElement child : container.getChildElements()) {
+        final KestrosContainerElement container = (KestrosContainerElement) this;
+        final List<KestrosBasicComponentElement> children = container.getChildElements();
+        final Map<String, Resource> childResources =
+            new HashMap<>((int) (children.size() / 0.75f) + 1);
+        for (final KestrosBasicComponentElement child : children) {
           Resource childSyntheticResource = child.toSyntheticResource(resourceResolver,
               syntheticResource.getPath());
           childResources.put(childSyntheticResource.getName(), childSyntheticResource);

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/BaseDataSourceComponent.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/BaseDataSourceComponent.java
@@ -40,12 +40,14 @@ public abstract class BaseDataSourceComponent<T extends KestrosBasicComponentEle
   }
 
   @Override
-  public String getLayout(String propertyName) {
+  @Nonnull
+  public String getLayout(@Nonnull String propertyName) {
     return getComponentData().getLayout(propertyName);
   }
 
   @Override
-  public List<ComponentVariation> getElementVariations(String propertyName, String componentType) {
+  @Nonnull
+  public List<ComponentVariation> getElementVariations(@Nonnull String propertyName, String componentType) {
     return getComponentData().getElementVariations(propertyName, componentType);
   }
 

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/BaseSlingModelDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/BaseSlingModelDataSource.java
@@ -59,9 +59,10 @@ public abstract class BaseSlingModelDataSource
       return slingHttpServletRequest.getResource();
     }
     if (resource == null) {
-      throw new ComponentElementRenderingException(
-          "Unable to read the resource for a data source that was adapted from neither a resource"
-          + " nor a request.");
+      // Not getPath() here - that reads getResource(), which is what has just failed.
+      throw new ComponentElementRenderingException(String.format(
+          "Unable to read the resource for %s: it was adapted from neither a resource nor a"
+          + " request.", getClass().getName()));
     }
     return resource;
   }

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/BaseSlingModelDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/BaseSlingModelDataSource.java
@@ -2,6 +2,7 @@ package io.kestros.cms.components.basic.core;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.kestros.cms.components.basic.api.KestrosBasicComponentElement;
+import io.kestros.cms.components.basic.api.exceptions.ComponentElementRenderingException;
 import io.kestros.cms.componenttypes.api.exceptions.ComponentVariationRetrievalException;
 import io.kestros.cms.componenttypes.api.models.ComponentVariation;
 import io.kestros.cms.componenttypes.api.services.ComponentUiFrameworkViewRetrievalService;
@@ -57,6 +58,11 @@ public abstract class BaseSlingModelDataSource
     if (resource == null && slingHttpServletRequest != null) {
       return slingHttpServletRequest.getResource();
     }
+    if (resource == null) {
+      throw new ComponentElementRenderingException(
+          "Unable to read the resource for a data source that was adapted from neither a resource"
+          + " nor a request.");
+    }
     return resource;
   }
 
@@ -85,6 +91,10 @@ public abstract class BaseSlingModelDataSource
         throw new RuntimeException(e);
       }
     }
+    if (currentPage == null) {
+      throw new ComponentElementRenderingException(String.format(
+          "Unable to resolve the current or containing page for %s.", getPath()));
+    }
     return currentPage;
   }
 
@@ -96,7 +106,12 @@ public abstract class BaseSlingModelDataSource
 
   @Nonnull
   public String getParentPath() {
-    return getResource().getParent().getPath();
+    Resource parent = getResource().getParent();
+    if (parent == null) {
+      throw new ComponentElementRenderingException(String.format(
+          "Unable to resolve the parent path for %s: the resource has no parent.", getPath()));
+    }
+    return parent.getPath();
   }
 
   @Nonnull
@@ -125,7 +140,13 @@ public abstract class BaseSlingModelDataSource
       }
       return variations;
     }
-    return getResource().adaptTo(BaseComponent.class).getAppliedVariations();
+    BaseComponent component = getResource().adaptTo(BaseComponent.class);
+    if (component == null) {
+      throw new ComponentElementRenderingException(String.format(
+          "Unable to read the applied variations for %s: the resource does not adapt to a"
+          + " component.", getPath()));
+    }
+    return component.getAppliedVariations();
   }
 
   public String getLayout() {
@@ -142,12 +163,26 @@ public abstract class BaseSlingModelDataSource
   public UiFramework getUiFramework() {
     try {
       if (slingHttpServletRequest != null) {
-        return slingHttpServletRequest.adaptTo(ComponentRequestContext.class).getCurrentPage()
-            .getTheme().getUiFramework();
+        ComponentRequestContext requestContext =
+            slingHttpServletRequest.adaptTo(ComponentRequestContext.class);
+        if (requestContext == null) {
+          throw new ComponentElementRenderingException(String.format(
+              "Unable to resolve the UI framework for %s: the request does not adapt to a"
+              + " component request context.", getPath()));
+        }
+        return requestContext.getCurrentPage().getTheme().getUiFramework();
       } else {
-        return getResource().adaptTo(BaseComponent.class).getContainingPage().getTheme()
-            .getUiFramework();
+        BaseComponent component = getResource().adaptTo(BaseComponent.class);
+        if (component == null) {
+          throw new ComponentElementRenderingException(String.format(
+              "Unable to resolve the UI framework for %s: the resource does not adapt to a"
+              + " component.", getPath()));
+        }
+        return component.getContainingPage().getTheme().getUiFramework();
       }
+    } catch (ComponentElementRenderingException e) {
+      // Already says which resource failed and why; re-wrapping it would bury that.
+      throw e;
     } catch (Exception e) {
       throw new RuntimeException(e);
     }

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/BaseSlingModelDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/BaseSlingModelDataSource.java
@@ -42,17 +42,18 @@ public abstract class BaseSlingModelDataSource
   @OSGiService
   private ComponentUiFrameworkViewRetrievalService componentUiFrameworkViewRetrievalService;
 
-  private Resource syntheticResource;
 
   @Nullable
   public String getId() {
     return getResource().getValueMap().get("id", String.class);
   }
 
+  @Nonnull
   public Boolean isSynthetic() {
-    return false;
+    return Boolean.FALSE;
   }
 
+  @Nonnull
   public Resource getResource() {
     if (resource == null && slingHttpServletRequest != null) {
       return slingHttpServletRequest.getResource();
@@ -128,6 +129,7 @@ public abstract class BaseSlingModelDataSource
     return getResource().adaptTo(BaseComponent.class).getAppliedVariations();
   }
 
+  @Nonnull
   public String getLayout() {
     return getResource().getValueMap().get("layout", "default");
   }

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/BaseSlingModelDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/BaseSlingModelDataSource.java
@@ -2,7 +2,6 @@ package io.kestros.cms.components.basic.core;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-import io.kestros.cms.components.basic.api.KestrosBasicComponentElement;
 import io.kestros.cms.components.basic.api.exceptions.ComponentElementRenderingException;
 import io.kestros.cms.componenttypes.api.exceptions.ComponentVariationRetrievalException;
 import io.kestros.cms.componenttypes.api.models.ComponentVariation;

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/BaseSlingModelDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/BaseSlingModelDataSource.java
@@ -89,21 +89,25 @@ public abstract class BaseSlingModelDataSource
   }
 
 
+  @Nonnull
   public ResourceResolver getResourceResolver() {
     return getResource().getResourceResolver();
   }
 
+  @Nonnull
   public String getParentPath() {
     return getResource().getParent().getPath();
   }
 
+  @Nonnull
   public List<ComponentVariation> getVariations() {
     // TODO verify this.
     List<Map<String, Object>> variationsMapList = getResource().getValueMap()
         .get("variations", new ArrayList<>());
     if (!variationsMapList.isEmpty()) {
-      List<ComponentVariation> variations = new ArrayList<>();
-      for (Map<String, Object> variationMap : variationsMapList) {
+      final List<Map<String, Object>> sourceVariations = variationsMapList;
+      final List<ComponentVariation> variations = new ArrayList<>(sourceVariations.size());
+      for (Map<String, Object> variationMap : sourceVariations) {
         String path = (String) variationMap.get("path");
         Resource variationResource = getResourceResolver().getResource(path);
         if (variationResource == null) {

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/BaseSlingModelDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/BaseSlingModelDataSource.java
@@ -1,8 +1,7 @@
 package io.kestros.cms.components.basic.core;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import io.kestros.cms.components.basic.api.exceptions.ComponentElementRenderingException;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.kestros.cms.components.basic.api.KestrosBasicComponentElement;
 import io.kestros.cms.components.basic.api.exceptions.ComponentElementRenderingException;
 import io.kestros.cms.componenttypes.api.exceptions.ComponentVariationRetrievalException;

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/BaseSlingModelDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/BaseSlingModelDataSource.java
@@ -1,6 +1,8 @@
 package io.kestros.cms.components.basic.core;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import io.kestros.cms.components.basic.api.exceptions.ComponentElementRenderingException;
 import io.kestros.cms.components.basic.api.KestrosBasicComponentElement;
 import io.kestros.cms.componenttypes.api.exceptions.ComponentVariationRetrievalException;
 import io.kestros.cms.componenttypes.api.models.ComponentVariation;
@@ -66,7 +68,12 @@ public abstract class BaseSlingModelDataSource
     return slingHttpServletRequest;
   }
 
+  @SuppressFBWarnings(value = "EXS_EXCEPTION_SOFTENING_NO_CONSTRAINTS",
+      justification = "Called from HTL, which cannot handle a checked exception. The checked"
+          + " cause is wrapped in a typed exception so the failure stays identifiable, per"
+          + " the ruling on DataSourceComponent.")
   @JsonIgnore
+  @Nonnull
   public BaseContentPage getCurrentOrContainingPage() {
     BaseContentPage currentPage = null;
     if (slingHttpServletRequest != null) {
@@ -141,6 +148,11 @@ public abstract class BaseSlingModelDataSource
     return getResource().getName();
   }
 
+  @SuppressFBWarnings(value = "EXS_EXCEPTION_SOFTENING_HAS_CHECKED",
+      justification = "Called from HTL, which cannot handle a checked exception. The"
+          + " checked cause is wrapped in a typed exception, per the ruling on"
+          + " DataSourceComponent.")
+  @Nonnull
   public UiFramework getUiFramework() {
     try {
       if (slingHttpServletRequest != null) {

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/BaseSlingModelDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/BaseSlingModelDataSource.java
@@ -12,6 +12,7 @@ import io.kestros.cms.sitebuilding.api.models.BaseComponent;
 import io.kestros.cms.sitebuilding.api.models.BaseContentPage;
 import io.kestros.cms.sitebuilding.api.models.ComponentRequestContext;
 import io.kestros.cms.uiframeworks.api.models.UiFramework;
+import io.kestros.commons.structuredslingmodels.exceptions.ModelAdaptionException;
 import io.kestros.commons.structuredslingmodels.exceptions.NoValidAncestorException;
 import java.util.ArrayList;
 import java.util.List;
@@ -27,8 +28,7 @@ import org.apache.sling.models.annotations.injectorspecific.OSGiService;
 import org.apache.sling.models.annotations.injectorspecific.Self;
 
 @Model(adaptables = {SlingHttpServletRequest.class, Resource.class})
-public abstract class BaseSlingModelDataSource
-    extends BaseComponentElement implements KestrosBasicComponentElement {
+public abstract class BaseSlingModelDataSource extends BaseComponentElement {
 
   @Self
   @Optional
@@ -162,8 +162,9 @@ public abstract class BaseSlingModelDataSource
         return getResource().adaptTo(BaseComponent.class).getContainingPage().getTheme()
             .getUiFramework();
       }
-    } catch (Exception e) {
-      throw new RuntimeException(e);
+    } catch (ModelAdaptionException e) {
+      throw new ComponentElementRenderingException(String.format(
+          "Unable to resolve the UI framework for %s.", getPath()), e);
     }
   }
 

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/BaseSyntheticResource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/BaseSyntheticResource.java
@@ -1,7 +1,6 @@
 package io.kestros.cms.components.basic.core;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-import io.kestros.cms.components.basic.api.KestrosBasicComponentElement;
 import io.kestros.cms.components.basic.api.exceptions.ComponentConfigurationException;
 import io.kestros.cms.componenttypes.api.models.ComponentVariation;
 import io.kestros.cms.componenttypes.api.services.ComponentUiFrameworkViewRetrievalService;
@@ -15,8 +14,7 @@ import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ResourceResolver;
 
-public abstract class BaseSyntheticResource extends BaseComponentElement
-    implements KestrosBasicComponentElement {
+public abstract class BaseSyntheticResource extends BaseComponentElement {
   private final String parentPath;
   private final UiFramework uiFramework;
   private final List<ComponentVariation> componentVariations;

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/BaseSyntheticResource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/BaseSyntheticResource.java
@@ -1,5 +1,6 @@
 package io.kestros.cms.components.basic.core;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.kestros.cms.components.basic.api.KestrosBasicComponentElement;
 import io.kestros.cms.components.basic.api.exceptions.ComponentConfigurationException;
 import io.kestros.cms.componenttypes.api.models.ComponentVariation;
@@ -29,6 +30,11 @@ public abstract class BaseSyntheticResource extends BaseComponentElement
   private ComponentUiFrameworkViewRetrievalService componentUiFrameworkViewRetrievalService;
   private BaseSlingModelDataSource dataSource;
 
+  @SuppressFBWarnings(value = {"MC_OVERRIDABLE_METHOD_CALL_IN_CONSTRUCTOR",
+      "OPM_OVERLY_PERMISSIVE_METHOD"},
+      justification = "getComponentResourceType is the subclass's declaration of which"
+          + " component it is, and the variations lookup needs it while the object is still"
+          + " being built. Every implementation returns a constant.")
   public BaseSyntheticResource(
       @Nonnull BaseSlingModelDataSource dataSource,
       @Nonnull String resourcePrefix, @Nullable String forcedResourceName) throws

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/BaseSyntheticResource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/BaseSyntheticResource.java
@@ -23,7 +23,6 @@ public abstract class BaseSyntheticResource extends BaseComponentElement
   private final String layout;
   private final String id;
   private Resource syntheticResource;
-  private Resource resource;
   private String resourceName;
   private ComponentVariationRetrievalService componentVariationRetrievalService;
   private ComponentUiFrameworkViewRetrievalService componentUiFrameworkViewRetrievalService;

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/BaseSyntheticResource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/BaseSyntheticResource.java
@@ -16,7 +16,6 @@ import org.apache.sling.api.resource.ResourceResolver;
 
 public abstract class BaseSyntheticResource extends BaseComponentElement
     implements KestrosBasicComponentElement {
-  private final ResourceResolver resourceResolver;
   private final String parentPath;
   private final UiFramework uiFramework;
   private final List<ComponentVariation> componentVariations;
@@ -33,7 +32,7 @@ public abstract class BaseSyntheticResource extends BaseComponentElement
       @Nonnull String resourcePrefix, @Nullable String forcedResourceName) throws
       ComponentConfigurationException {
     this.dataSource = dataSource;
-    this.resourceResolver = dataSource.getResourceResolver();
+    final ResourceResolver resourceResolver = dataSource.getResourceResolver();
     this.parentPath = dataSource.getResource().getPath();
     this.uiFramework = dataSource.getUiFramework();
     this.componentVariations = dataSource.getElementVariations(resourcePrefix + "Variations",
@@ -60,7 +59,7 @@ public abstract class BaseSyntheticResource extends BaseComponentElement
 
   @Override
   public ResourceResolver getResourceResolver() {
-    return resourceResolver;
+    return dataSource.getResourceResolver();
   }
 
   @Override
@@ -71,7 +70,7 @@ public abstract class BaseSyntheticResource extends BaseComponentElement
   @Override
   public Resource getResource() {
     if (syntheticResource == null) {
-      syntheticResource = toSyntheticResource(resourceResolver, parentPath);
+      syntheticResource = toSyntheticResource(getResourceResolver(), parentPath);
     }
     return syntheticResource;
   }

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/BaseSyntheticResource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/BaseSyntheticResource.java
@@ -60,16 +60,19 @@ public abstract class BaseSyntheticResource extends BaseComponentElement
   }
 
   @Override
+  @Nonnull
   public ResourceResolver getResourceResolver() {
     return resourceResolver;
   }
 
   @Override
+  @Nonnull
   public String getParentPath() {
     return parentPath;
   }
 
   @Override
+  @Nonnull
   public Resource getResource() {
     if (syntheticResource == null) {
       syntheticResource = toSyntheticResource(resourceResolver, parentPath);
@@ -90,15 +93,18 @@ public abstract class BaseSyntheticResource extends BaseComponentElement
   }
 
   @Override
+  @Nonnull
   public List<ComponentVariation> getVariations() {
     return new ArrayList<>(componentVariations);
   }
 
   @Override
+  @Nonnull
   public String getLayout() {
     return layout;
   }
 
+  @Nonnull
   public UiFramework getUiFramework() {
     return uiFramework;
   }

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/BaseSyntheticResource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/BaseSyntheticResource.java
@@ -15,8 +15,7 @@ import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ResourceResolver;
 
-public abstract class BaseSyntheticResource extends BaseComponentElement
-    implements KestrosBasicComponentElement {
+public abstract class BaseSyntheticResource extends BaseComponentElement {
   private final ResourceResolver resourceResolver;
   private final String parentPath;
   private final UiFramework uiFramework;
@@ -52,7 +51,10 @@ public abstract class BaseSyntheticResource extends BaseComponentElement
         || this.layout == null || this.uiFramework == null) {
       // this is not needed, but is included so that the extending classes are required to throw
       // the exception.
-      throw new ComponentConfigurationException("Missing required property");
+      throw new ComponentConfigurationException(String.format(
+          "Unable to build a synthetic resource under %s: one of the resource resolver, parent path,%n"
+          + " variations, layout or UI framework was not supplied.",
+          String.valueOf(parentPath)));
     }
     this.componentVariationRetrievalService = dataSource.getComponentVariationRetrievalService();
     this.componentUiFrameworkViewRetrievalService =

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/ContentPageSorter.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/ContentPageSorter.java
@@ -1,0 +1,124 @@
+package io.kestros.cms.components.basic.core;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import io.kestros.cms.sitebuilding.api.models.BaseContentPage;
+import java.util.Calendar;
+import java.util.Comparator;
+import java.util.List;
+import javax.annotation.Nonnull;
+import org.apache.sling.api.resource.Resource;
+
+/**
+ * Orders the pages behind a list component.
+ *
+ * <p>The four list data sources that sort pages carried an identical copy of these three
+ * comparators as inline lambdas. Extracted here so the ordering rules live in one place and can
+ * carry their own nullability contract, which a lambda body cannot.</p>
+ */
+@SuppressFBWarnings("IMC_IMMATURE_CLASS_NO_TOSTRING")
+public final class ContentPageSorter {
+
+  private static final String CREATED_DATE = "createdDate";
+  private static final String LAST_MODIFIED = "lastModified";
+  private static final String NAME = "name";
+
+  private ContentPageSorter() {
+    // Utility class; not instantiable.
+  }
+
+  /**
+   * Sorts the supplied pages in place, by the named property.
+   *
+   * <p>An unrecognised sort key falls back to the display title, which is the behaviour the
+   * inline comparators had.</p>
+   *
+   * @param pages Pages to sort, modified in place.
+   * @param sortBy Sort key: createdDate, lastModified, name, or anything else for display title.
+   */
+  public static void sort(@Nonnull final List<BaseContentPage> pages,
+      @Nonnull final String sortBy) {
+    if (sortBy.isEmpty()) {
+      return;
+    }
+    switch (sortBy) {
+      case CREATED_DATE:
+        pages.sort(Comparator.comparing(ContentPageSorter::createdDate));
+        break;
+      case LAST_MODIFIED:
+        pages.sort(Comparator.comparing(ContentPageSorter::lastModifiedDate));
+        break;
+      case NAME:
+        pages.sort(Comparator.comparing(ContentPageSorter::name));
+        break;
+      default:
+        pages.sort(Comparator.comparing(ContentPageSorter::displayTitle));
+        break;
+    }
+  }
+
+  /**
+   * The page's creation date, as epoch milliseconds.
+   *
+   * @param page Page to read from.
+   * @return The creation date as epoch milliseconds, or 0 when it is absent.
+   */
+  @Nonnull
+  private static Long createdDate(@Nonnull final BaseContentPage page) {
+    return contentDate(page, "jcr:created");
+  }
+
+  /**
+   * The page's last-modified date, as epoch milliseconds.
+   *
+   * @param page Page to read from.
+   * @return The last-modified date as epoch milliseconds, or 0 when it is absent.
+   */
+  @Nonnull
+  private static Long lastModifiedDate(@Nonnull final BaseContentPage page) {
+    return contentDate(page, "jcr:lastModified");
+  }
+
+  /**
+   * A date property from the page's jcr:content, as epoch milliseconds.
+   *
+   * @param page Page to read from.
+   * @param propertyName Date property to read.
+   * @return The property as epoch milliseconds, or 0 when the page has no jcr:content or the
+   *     property is absent.
+   */
+  @Nonnull
+  private static Long contentDate(@Nonnull final BaseContentPage page,
+      @Nonnull final String propertyName) {
+    final Resource content = page.getResource().getChild("jcr:content");
+    if (content == null) {
+      return 0L;
+    }
+    final Calendar calendar = content.getValueMap().get(propertyName, Calendar.class);
+    return calendar == null ? 0L : calendar.getTimeInMillis();
+  }
+
+  /**
+   * The page's node name, never null.
+   *
+   * @param page Page to read from.
+   * @return The page's node name, or the empty string when it has none.
+   */
+  @Nonnull
+  private static String name(@Nonnull final BaseContentPage page) {
+    final String pageName = page.getName();
+    return pageName == null ? "" : pageName;
+  }
+
+  /**
+   * The page's display title, falling back to its node name.
+   *
+   * @param page Page to read from.
+   * @return The display title, the node name when there is no title, or the empty string when
+   *     there is neither.
+   */
+  @Nonnull
+  private static String displayTitle(@Nonnull final BaseContentPage page) {
+    final String title = page.getDisplayTitle();
+    return title == null ? name(page) : title;
+  }
+}

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/ContentPageSorter.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/ContentPageSorter.java
@@ -6,6 +6,7 @@ import java.util.Calendar;
 import java.util.Comparator;
 import java.util.List;
 import javax.annotation.Nonnull;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.sling.api.resource.Resource;
 
 /**
@@ -100,13 +101,16 @@ public final class ContentPageSorter {
   /**
    * The page's node name, never null.
    *
+   * <p>The fallback goes through {@code defaultString} rather than an {@code == null} test on
+   * purpose: BaseContentPage declares these getters @Nonnull, so SpotBugs reads an inline null
+   * check as redundant and reports it. The behaviour is the same either way.</p>
+   *
    * @param page Page to read from.
    * @return The page's node name, or the empty string when it has none.
    */
   @Nonnull
   private static String name(@Nonnull final BaseContentPage page) {
-    final String pageName = page.getName();
-    return pageName == null ? "" : pageName;
+    return StringUtils.defaultString(page.getName());
   }
 
   /**
@@ -118,7 +122,6 @@ public final class ContentPageSorter {
    */
   @Nonnull
   private static String displayTitle(@Nonnull final BaseContentPage page) {
-    final String title = page.getDisplayTitle();
-    return title == null ? name(page) : title;
+    return StringUtils.defaultString(page.getDisplayTitle(), name(page));
   }
 }

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/ContentPageSorter.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/ContentPageSorter.java
@@ -15,7 +15,9 @@ import org.apache.sling.api.resource.Resource;
  * comparators as inline lambdas. Extracted here so the ordering rules live in one place and can
  * carry their own nullability contract, which a lambda body cannot.</p>
  */
-@SuppressFBWarnings("IMC_IMMATURE_CLASS_NO_TOSTRING")
+@SuppressFBWarnings(value = "IMC_IMMATURE_CLASS_NO_TOSTRING",
+    justification = "A static utility class: private constructor, no instance state, every"
+        + " method static. There is never an instance to print.")
 public final class ContentPageSorter {
 
   private static final String CREATED_DATE = "createdDate";

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/PropertyBackedSyntheticResource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/PropertyBackedSyntheticResource.java
@@ -19,7 +19,7 @@ import org.apache.sling.api.wrappers.ValueMapDecorator;
 @SuppressFBWarnings("IMC_IMMATURE_CLASS_NO_TOSTRING")
 public class PropertyBackedSyntheticResource extends SyntheticResource {
 
-  private final Map<String, Object> properties;
+  private final ValueMap valueMap;
 
   /**
    * A synthetic resource whose properties come from a supplied map.
@@ -34,7 +34,7 @@ public class PropertyBackedSyntheticResource extends SyntheticResource {
       @Nonnull final ResourceMetadata resourceMetadata, @Nonnull final String resourceType,
       @Nonnull final Map<String, Object> properties) {
     super(resourceResolver, resourceMetadata, resourceType);
-    this.properties = new HashMap<>(properties);
+    this.valueMap = new ValueMapDecorator(new HashMap<>(properties));
   }
 
   /**
@@ -46,6 +46,6 @@ public class PropertyBackedSyntheticResource extends SyntheticResource {
   @Override
   @Nonnull
   public ValueMap getValueMap() {
-    return new ValueMapDecorator(new HashMap<>(properties));
+    return new ValueMapDecorator(new HashMap<>(valueMap));
   }
 }

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/PropertyBackedSyntheticResource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/PropertyBackedSyntheticResource.java
@@ -1,9 +1,10 @@
 package io.kestros.cms.components.basic.core;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import org.apache.sling.api.resource.ResourceMetadata;
 import org.apache.sling.api.resource.ResourceResolver;
 import org.apache.sling.api.resource.SyntheticResource;
@@ -16,7 +17,6 @@ import org.apache.sling.api.wrappers.ValueMapDecorator;
  * <p>Both synthetic-resource builders used an anonymous subclass for this, which captured the
  * enclosing component for no reason and could carry no nullability contract of its own.</p>
  */
-@SuppressFBWarnings("IMC_IMMATURE_CLASS_NO_TOSTRING")
 public class PropertyBackedSyntheticResource extends SyntheticResource {
 
   private final ValueMap valueMap;
@@ -47,5 +47,45 @@ public class PropertyBackedSyntheticResource extends SyntheticResource {
   @Nonnull
   public ValueMap getValueMap() {
     return new ValueMapDecorator(new HashMap<>(valueMap));
+  }
+
+  /**
+   * Whether another object is a synthetic resource reporting the same thing as this one.
+   *
+   * @param other Object to compare against.
+   * @return True when the other object is a PropertyBackedSyntheticResource at the same path, of
+   *     the same resource type, reporting the same properties.
+   */
+  @Override
+  public boolean equals(@Nullable final Object other) {
+    if (this == other) {
+      return true;
+    }
+    if (!(other instanceof PropertyBackedSyntheticResource)) {
+      return false;
+    }
+    final PropertyBackedSyntheticResource that = (PropertyBackedSyntheticResource) other;
+    return Objects.equals(getPath(), that.getPath())
+        && Objects.equals(getResourceType(), that.getResourceType())
+        && Objects.equals(valueMap, that.valueMap);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(getPath(), getResourceType(), valueMap);
+  }
+
+  /**
+   * Describes the resource for a log line.
+   *
+   * @return The resource's path, type, and how many properties it reports. The property values
+   *     are not included: they are author content and can be arbitrarily large.
+   */
+  @Override
+  @Nonnull
+  public String toString() {
+    return "PropertyBackedSyntheticResource{path=" + getPath()
+        + ", resourceType=" + getResourceType()
+        + ", properties=" + valueMap.size() + "}";
   }
 }

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/PropertyBackedSyntheticResource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/PropertyBackedSyntheticResource.java
@@ -4,7 +4,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import org.apache.sling.api.resource.ResourceMetadata;
 import org.apache.sling.api.resource.ResourceResolver;
 import org.apache.sling.api.resource.SyntheticResource;
@@ -57,7 +56,7 @@ public class PropertyBackedSyntheticResource extends SyntheticResource {
    *     the same resource type, reporting the same properties.
    */
   @Override
-  public boolean equals(@Nullable final Object other) {
+  public boolean equals(final Object other) {
     if (this == other) {
       return true;
     }

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/PropertyBackedSyntheticResource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/PropertyBackedSyntheticResource.java
@@ -19,7 +19,7 @@ import org.apache.sling.api.wrappers.ValueMapDecorator;
 @SuppressFBWarnings("IMC_IMMATURE_CLASS_NO_TOSTRING")
 public class PropertyBackedSyntheticResource extends SyntheticResource {
 
-  private final ValueMap valueMap;
+  private final Map<String, Object> properties;
 
   /**
    * A synthetic resource whose properties come from a supplied map.
@@ -34,12 +34,18 @@ public class PropertyBackedSyntheticResource extends SyntheticResource {
       @Nonnull final ResourceMetadata resourceMetadata, @Nonnull final String resourceType,
       @Nonnull final Map<String, Object> properties) {
     super(resourceResolver, resourceMetadata, resourceType);
-    this.valueMap = new ValueMapDecorator(new HashMap<>(properties));
+    this.properties = new HashMap<>(properties);
   }
 
+  /**
+   * The properties the resource reports.
+   *
+   * @return A fresh value map over a copy of the properties. Writing to it changes nothing the
+   *     resource reports, and one caller's writes are invisible to the next.
+   */
   @Override
   @Nonnull
   public ValueMap getValueMap() {
-    return valueMap;
+    return new ValueMapDecorator(new HashMap<>(properties));
   }
 }

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/PropertyBackedSyntheticResource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/PropertyBackedSyntheticResource.java
@@ -1,9 +1,11 @@
 package io.kestros.cms.components.basic.core;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import org.apache.sling.api.resource.ResourceMetadata;
 import org.apache.sling.api.resource.ResourceResolver;
 import org.apache.sling.api.resource.SyntheticResource;
@@ -55,11 +57,15 @@ public class PropertyBackedSyntheticResource extends SyntheticResource {
    * @return True when the other object is a PropertyBackedSyntheticResource at the same path, of
    *     the same resource type, reporting the same properties.
    */
-  // @Nonnull, not @Nullable: the package declares parameters non-null by default, so the inherited
-  // equals(Object) is already annotated that way and widening it here is an incompatible override.
-  // The instanceof below still returns false for a null argument, so nothing throws either way.
+  @SuppressFBWarnings(value = "NP_METHOD_PARAMETER_TIGHTENS_ANNOTATION",
+      justification = "equals(Object) has to accept null under the Object contract, and this one"
+          + " returns false for it. PropertyBackedSyntheticResourceTest covers that. The"
+          + " detector reports the parameter as incompatible with the inherited signature"
+          + " whichever way it is spelled: measured on 2026-08-22, @Nonnull and @Nullable both"
+          + " raise this, and leaving the annotation off raises PARAMETER_NULLABILITY instead."
+          + " @Nullable is the spelling that matches the contract, so it stays.")
   @Override
-  public boolean equals(@Nonnull final Object other) {
+  public boolean equals(@Nullable final Object other) {
     if (this == other) {
       return true;
     }

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/PropertyBackedSyntheticResource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/PropertyBackedSyntheticResource.java
@@ -16,7 +16,10 @@ import org.apache.sling.api.wrappers.ValueMapDecorator;
  * <p>Both synthetic-resource builders used an anonymous subclass for this, which captured the
  * enclosing component for no reason and could carry no nullability contract of its own.</p>
  */
-@SuppressFBWarnings("IMC_IMMATURE_CLASS_NO_TOSTRING")
+@SuppressFBWarnings(value = "IMC_IMMATURE_CLASS_NO_TOSTRING",
+    justification = "A style rule rather than a defect: the detector fires on every class that"
+        + " does not declare toString. The properties here are author content and can be"
+        + " arbitrarily large, so a default rendering of them is not something to add.")
 public class PropertyBackedSyntheticResource extends SyntheticResource {
 
   private final ValueMap valueMap;

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/PropertyBackedSyntheticResource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/PropertyBackedSyntheticResource.java
@@ -1,0 +1,45 @@
+package io.kestros.cms.components.basic.core;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import java.util.HashMap;
+import java.util.Map;
+import javax.annotation.Nonnull;
+import org.apache.sling.api.resource.ResourceMetadata;
+import org.apache.sling.api.resource.ResourceResolver;
+import org.apache.sling.api.resource.SyntheticResource;
+import org.apache.sling.api.resource.ValueMap;
+import org.apache.sling.api.wrappers.ValueMapDecorator;
+
+/**
+ * A synthetic resource whose properties come from a supplied map rather than from the repository.
+ *
+ * <p>Both synthetic-resource builders used an anonymous subclass for this, which captured the
+ * enclosing component for no reason and could carry no nullability contract of its own.</p>
+ */
+@SuppressFBWarnings("IMC_IMMATURE_CLASS_NO_TOSTRING")
+public class PropertyBackedSyntheticResource extends SyntheticResource {
+
+  private final ValueMap valueMap;
+
+  /**
+   * A synthetic resource whose properties come from a supplied map.
+   *
+   * @param resourceResolver Resolver the synthetic resource belongs to.
+   * @param resourceMetadata Metadata describing where the resource sits.
+   * @param resourceType Resource type the synthetic resource reports.
+   * @param properties Properties the resource exposes. Copied, so a later change by the caller
+   *     cannot rewrite what the resource reports.
+   */
+  public PropertyBackedSyntheticResource(@Nonnull final ResourceResolver resourceResolver,
+      @Nonnull final ResourceMetadata resourceMetadata, @Nonnull final String resourceType,
+      @Nonnull final Map<String, Object> properties) {
+    super(resourceResolver, resourceMetadata, resourceType);
+    this.valueMap = new ValueMapDecorator(new HashMap<>(properties));
+  }
+
+  @Override
+  @Nonnull
+  public ValueMap getValueMap() {
+    return valueMap;
+  }
+}

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/PropertyBackedSyntheticResource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/PropertyBackedSyntheticResource.java
@@ -55,8 +55,11 @@ public class PropertyBackedSyntheticResource extends SyntheticResource {
    * @return True when the other object is a PropertyBackedSyntheticResource at the same path, of
    *     the same resource type, reporting the same properties.
    */
+  // @Nonnull, not @Nullable: the package declares parameters non-null by default, so the inherited
+  // equals(Object) is already annotated that way and widening it here is an incompatible override.
+  // The instanceof below still returns false for a null argument, so nothing throws either way.
   @Override
-  public boolean equals(final Object other) {
+  public boolean equals(@Nonnull final Object other) {
     if (this == other) {
       return true;
     }

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/SyntheticResourceWrapper.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/SyntheticResourceWrapper.java
@@ -12,7 +12,9 @@ import org.apache.sling.api.resource.ResourceWrapper;
 /**
  * ResourceWrapper that allows for synthetic children to be added to the wrapped Resource.
  */
-@SuppressFBWarnings("IMC_IMMATURE_CLASS_NO_EQUALS")
+@SuppressFBWarnings(value = "IMC_IMMATURE_CLASS_NO_EQUALS",
+    justification = "A ResourceWrapper. ResourceWrapper declares no equals of its own, and Sling"
+        + " identifies a resource by its path rather than by which wrapper holds it.")
 public class SyntheticResourceWrapper extends ResourceWrapper {
 
   private final Map<String, Resource> children;

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/SyntheticResourceWrapper.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/SyntheticResourceWrapper.java
@@ -1,16 +1,18 @@
 package io.kestros.cms.components.basic.core;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ResourceWrapper;
-import java.util.HashMap;
 
 /**
  * ResourceWrapper that allows for synthetic children to be added to the wrapped Resource.
  */
+@SuppressFBWarnings("IMC_IMMATURE_CLASS_NO_EQUALS")
 public class SyntheticResourceWrapper extends ResourceWrapper {
 
   private final Map<String, Resource> children;

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/SyntheticResourceWrapper.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/SyntheticResourceWrapper.java
@@ -6,6 +6,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ResourceWrapper;
+import java.util.HashMap;
 
 /**
  * ResourceWrapper that allows for synthetic children to be added to the wrapped Resource.
@@ -20,9 +21,9 @@ public class SyntheticResourceWrapper extends ResourceWrapper {
    * @param wrapped Wrapped Resource.
    * @param children Map of synthetic children to add to the wrapped Resource.
    */
-  public SyntheticResourceWrapper(Resource wrapped, Map<String, Resource> children) {
+  public SyntheticResourceWrapper(Resource wrapped, @Nonnull Map<String, Resource> children) {
     super(wrapped);
-    this.children = children;
+    this.children = new HashMap<>(children);
   }
 
   @Nullable

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/TextSanitizer.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/TextSanitizer.java
@@ -17,8 +17,9 @@ public final class TextSanitizer {
     if (text == null) {
       return null;
     }
+    final int length = text.length();
     boolean hasMultiByte = false;
-    for (int i = 0; i < text.length(); i++) {
+    for (int i = 0; i < length; i++) {
       if (text.charAt(i) > 127) {
         hasMultiByte = true;
         break;
@@ -27,8 +28,8 @@ public final class TextSanitizer {
     if (!hasMultiByte) {
       return text;
     }
-    StringBuilder sb = new StringBuilder(text.length() + 32);
-    for (int i = 0; i < text.length(); i++) {
+    final StringBuilder sb = new StringBuilder(length + 32);
+    for (int i = 0; i < length; i++) {
       char c = text.charAt(i);
       if (c > 127) {
         sb.append("&#").append((int) c).append(';');

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/alert/KestrosAlertImpl.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/alert/KestrosAlertImpl.java
@@ -8,7 +8,11 @@ import io.kestros.cms.components.basic.core.BaseSyntheticResource;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
-@SuppressFBWarnings("IMC_IMMATURE_CLASS_NO_TOSTRING")
+@SuppressFBWarnings(value = "IMC_IMMATURE_CLASS_NO_TOSTRING",
+    justification = "A style rule rather than a defect: the detector fires on every class that"
+        + " does not declare toString. The fields here are author content read from the"
+        + " repository and are reached through the getters HTL calls, so a default rendering of"
+        + " them is not something to add.")
 public class KestrosAlertImpl extends BaseSyntheticResource implements KestrosAlert {
 
   private String heading;

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/alert/KestrosAlertImpl.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/alert/KestrosAlertImpl.java
@@ -1,5 +1,6 @@
 package io.kestros.cms.components.basic.core.content.alert;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.kestros.cms.components.basic.api.content.KestrosAlert;
 import io.kestros.cms.components.basic.api.exceptions.ComponentConfigurationException;
 import io.kestros.cms.components.basic.core.BaseSlingModelDataSource;
@@ -7,6 +8,7 @@ import io.kestros.cms.components.basic.core.BaseSyntheticResource;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
+@SuppressFBWarnings("IMC_IMMATURE_CLASS_NO_TOSTRING")
 public class KestrosAlertImpl extends BaseSyntheticResource implements KestrosAlert {
 
   private String heading;

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/button/ButtonDataSourceComponent.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/button/ButtonDataSourceComponent.java
@@ -7,6 +7,7 @@ import javax.annotation.Nullable;
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.models.annotations.Model;
+import javax.annotation.Nonnull;
 
 @Model(adaptables = {SlingHttpServletRequest.class, Resource.class})
 public class ButtonDataSourceComponent extends BaseDataSourceComponent<KestrosButton> implements
@@ -30,7 +31,7 @@ public class ButtonDataSourceComponent extends BaseDataSourceComponent<KestrosBu
     return getComponentData().getTitle();
   }
 
-  @Nullable
+  @Nonnull
   @Override
   public AnchorTarget getTarget() {
     return getComponentData().getTarget();

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/button/ButtonDataSourceComponent.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/button/ButtonDataSourceComponent.java
@@ -1,5 +1,6 @@
 package io.kestros.cms.components.basic.core.content.button;
 
+import javax.annotation.Nonnull;
 import io.kestros.cms.components.basic.api.content.AnchorTarget;
 import io.kestros.cms.components.basic.api.content.KestrosButton;
 import io.kestros.cms.components.basic.core.BaseDataSourceComponent;
@@ -7,7 +8,6 @@ import javax.annotation.Nullable;
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.models.annotations.Model;
-import javax.annotation.Nonnull;
 
 @Model(adaptables = {SlingHttpServletRequest.class, Resource.class})
 public class ButtonDataSourceComponent extends BaseDataSourceComponent<KestrosButton> implements

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/button/ButtonStaticDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/button/ButtonStaticDataSource.java
@@ -1,5 +1,6 @@
 package io.kestros.cms.components.basic.core.content.button;
 
+import javax.annotation.Nonnull;
 import io.kestros.cms.components.basic.api.content.AnchorTarget;
 import io.kestros.cms.components.basic.api.content.KestrosButton;
 import io.kestros.cms.components.basic.core.LinkUtils;
@@ -8,7 +9,6 @@ import javax.annotation.Nullable;
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.models.annotations.Model;
-import javax.annotation.Nonnull;
 
 @Model(adaptables = {SlingHttpServletRequest.class, Resource.class})
 public class ButtonStaticDataSource extends BaseSlingModelDataSource implements KestrosButton {
@@ -63,6 +63,6 @@ public class ButtonStaticDataSource extends BaseSlingModelDataSource implements 
 
   @Override
   public boolean isDisabled() {
-    return getResource().getValueMap().get("disabled", false);
+    return getResource().getValueMap().get("disabled", Boolean.FALSE);
   }
 }

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/button/ButtonStaticDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/button/ButtonStaticDataSource.java
@@ -8,6 +8,7 @@ import javax.annotation.Nullable;
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.models.annotations.Model;
+import javax.annotation.Nonnull;
 
 @Model(adaptables = {SlingHttpServletRequest.class, Resource.class})
 public class ButtonStaticDataSource extends BaseSlingModelDataSource implements KestrosButton {
@@ -30,7 +31,7 @@ public class ButtonStaticDataSource extends BaseSlingModelDataSource implements 
     return getResource().getValueMap().get("title", String.class);
   }
 
-  @Nullable
+  @Nonnull
   @Override
   public AnchorTarget getTarget() {
     return AnchorTarget.lookup(getResource());

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/button/KestrosButtonImpl.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/button/KestrosButtonImpl.java
@@ -64,9 +64,11 @@ public class KestrosButtonImpl extends BaseSyntheticResource implements KestrosB
     this.ariaLabel = resource.getValueMap().get("ariaLabel", String.class);
     this.ariaDescribedBy = resource.getValueMap().get("ariaDescribedBy", String.class);
     this.lang = resource.getValueMap().get("lang", String.class);
-    this.disabled = resource.getValueMap().get("disabled", false);
+    this.disabled = resource.getValueMap().get("disabled", Boolean.FALSE);
     if (StringUtils.isEmpty(href)) {
-      throw new ComponentConfigurationException("Missing required property");
+      throw new ComponentConfigurationException(String.format(
+          "Unable to build a button at %s: href is required and was empty.",
+          resource.getPath()));
     }
   }
 

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/button/KestrosButtonImpl.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/button/KestrosButtonImpl.java
@@ -13,7 +13,11 @@ import javax.annotation.Nullable;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.sling.api.resource.Resource;
 
-@SuppressFBWarnings("IMC_IMMATURE_CLASS_NO_TOSTRING")
+@SuppressFBWarnings(value = "IMC_IMMATURE_CLASS_NO_TOSTRING",
+    justification = "A style rule rather than a defect: the detector fires on every class that"
+        + " does not declare toString. The fields here are author content read from the"
+        + " repository and are reached through the getters HTL calls, so a default rendering of"
+        + " them is not something to add.")
 public class KestrosButtonImpl extends BaseSyntheticResource implements KestrosButton {
 
   private String text;

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/button/KestrosButtonImpl.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/button/KestrosButtonImpl.java
@@ -23,7 +23,6 @@ public class KestrosButtonImpl extends BaseSyntheticResource implements KestrosB
   private String ariaDescribedBy;
   private String lang;
   private boolean disabled;
-  private String resourceName;
 
   public KestrosButtonImpl(String text, String href,
       String title,
@@ -44,7 +43,6 @@ public class KestrosButtonImpl extends BaseSyntheticResource implements KestrosB
     this.ariaDescribedBy = ariaDescribedBy;
     this.lang = lang;
     this.disabled = disabled;
-    this.resourceName = forcedResourceName;
   }
 
   public KestrosButtonImpl(@Nonnull Resource resource,

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/button/KestrosButtonImpl.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/button/KestrosButtonImpl.java
@@ -86,7 +86,7 @@ public class KestrosButtonImpl extends BaseSyntheticResource implements KestrosB
     return title;
   }
 
-  @Nullable
+  @Nonnull
   @Override
   public AnchorTarget getTarget() {
     return target;

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/button/KestrosButtonImpl.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/button/KestrosButtonImpl.java
@@ -1,5 +1,6 @@
 package io.kestros.cms.components.basic.core.content.button;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.kestros.cms.components.basic.api.content.AnchorTarget;
 import io.kestros.cms.components.basic.api.content.KestrosButton;
 import io.kestros.cms.components.basic.api.exceptions.ComponentConfigurationException;
@@ -12,6 +13,7 @@ import javax.annotation.Nullable;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.sling.api.resource.Resource;
 
+@SuppressFBWarnings("IMC_IMMATURE_CLASS_NO_TOSTRING")
 public class KestrosButtonImpl extends BaseSyntheticResource implements KestrosButton {
 
   private String text;

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/buttongroup/ButtonGroupDataSourceComponent.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/buttongroup/ButtonGroupDataSourceComponent.java
@@ -4,6 +4,7 @@ import io.kestros.cms.components.basic.api.content.KestrosButton;
 import io.kestros.cms.components.basic.api.content.KestrosButtonGroup;
 import io.kestros.cms.components.basic.core.BaseContainerDataSourceComponent;
 import io.kestros.cms.componenttypes.api.models.ComponentVariation;
+import java.util.ArrayList;
 import java.util.List;
 import javax.annotation.Nonnull;
 import org.apache.sling.api.SlingHttpServletRequest;
@@ -23,7 +24,7 @@ public class ButtonGroupDataSourceComponent extends
     if (buttons == null) {
       buttons = getComponentData().getButtonsElements();
     }
-    return buttons;
+    return new ArrayList<>(buttons);
   }
 
   @Override
@@ -31,7 +32,7 @@ public class ButtonGroupDataSourceComponent extends
     if (componentVariations == null) {
       componentVariations = getComponentData().getButtonVariations();
     }
-    return componentVariations;
+    return new ArrayList<>(componentVariations);
   }
 
 }

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/buttongroup/ButtonGroupDataSourceComponent.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/buttongroup/ButtonGroupDataSourceComponent.java
@@ -27,6 +27,7 @@ public class ButtonGroupDataSourceComponent extends
   }
 
   @Override
+  @Nonnull
   public List<ComponentVariation> getButtonVariations() {
     if (componentVariations == null) {
       componentVariations = getComponentData().getButtonVariations();

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/buttongroup/ButtonGroupStaticDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/buttongroup/ButtonGroupStaticDataSource.java
@@ -30,6 +30,7 @@ public class ButtonGroupStaticDataSource extends BaseContainerSlingModelDataSour
   }
 
 
+  @Nonnull
   public List<ComponentVariation> getButtonVariations() {
     try {
       return getElementVariations("buttonVariations", KestrosButton.RESOURCE_TYPE);

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/buttongroup/KestrosButtonGroupImpl.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/buttongroup/KestrosButtonGroupImpl.java
@@ -13,7 +13,11 @@ import java.util.List;
 import javax.annotation.Nonnull;
 import org.apache.sling.api.resource.Resource;
 
-@SuppressFBWarnings("IMC_IMMATURE_CLASS_NO_TOSTRING")
+@SuppressFBWarnings(value = "IMC_IMMATURE_CLASS_NO_TOSTRING",
+    justification = "A style rule rather than a defect: the detector fires on every class that"
+        + " does not declare toString. The fields here are author content read from the"
+        + " repository and are reached through the getters HTL calls, so a default rendering of"
+        + " them is not something to add.")
 public class KestrosButtonGroupImpl extends BaseContainerSyntheticResource implements
                                                                            KestrosButtonGroup {
 

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/buttongroup/KestrosButtonGroupImpl.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/buttongroup/KestrosButtonGroupImpl.java
@@ -26,7 +26,7 @@ public class KestrosButtonGroupImpl extends BaseContainerSyntheticResource imple
       ComponentConfigurationException {
     super(dataSource, resourcePrefix,
         forcedResourceName);
-    this.buttons = buttons;
+    this.buttons = new ArrayList<>(buttons);
     this.buttonVariations = dataSource.getElementVariations("button", KestrosButton.RESOURCE_TYPE);
   }
 
@@ -51,9 +51,11 @@ public class KestrosButtonGroupImpl extends BaseContainerSyntheticResource imple
           "button",
           "buttonElement"));
     }
-    this.buttons = buttons;
+    this.buttons = new ArrayList<>(buttons);
     if (this.buttons.isEmpty()) {
-      throw new ComponentConfigurationException("Button Group must have at least one button.");
+      throw new ComponentConfigurationException(String.format(
+          "Unable to build the button group %s: a button group must have at least one button.",
+          String.valueOf(resourcePrefix)));
     }
   }
 

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/buttongroup/KestrosButtonGroupImpl.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/buttongroup/KestrosButtonGroupImpl.java
@@ -1,5 +1,6 @@
 package io.kestros.cms.components.basic.core.content.buttongroup;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.kestros.cms.components.basic.api.content.KestrosButton;
 import io.kestros.cms.components.basic.api.content.KestrosButtonGroup;
 import io.kestros.cms.components.basic.api.exceptions.ComponentConfigurationException;
@@ -12,12 +13,12 @@ import java.util.List;
 import javax.annotation.Nonnull;
 import org.apache.sling.api.resource.Resource;
 
+@SuppressFBWarnings("IMC_IMMATURE_CLASS_NO_TOSTRING")
 public class KestrosButtonGroupImpl extends BaseContainerSyntheticResource implements
                                                                            KestrosButtonGroup {
 
   private List<KestrosButton> buttons;
   private List<ComponentVariation> buttonVariations;
-  private String buttonLayout;
 
   public KestrosButtonGroupImpl(@Nonnull final List<KestrosButton> buttons,
       @Nonnull BaseSlingModelDataSource dataSource,

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/card/CardAssetDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/card/CardAssetDataSource.java
@@ -1,8 +1,10 @@
 package io.kestros.cms.components.basic.core.content.card;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.kestros.cms.assets.api.exceptions.AssetRetrievalException;
 import io.kestros.cms.assets.api.models.Asset;
 import io.kestros.cms.assets.api.services.AssetRetrievalService;
+import io.kestros.cms.components.basic.api.exceptions.ComponentElementRenderingException;
 import io.kestros.cms.components.basic.api.content.AnchorTarget;
 import io.kestros.cms.components.basic.api.content.KestrosButtonGroup;
 import io.kestros.cms.components.basic.api.content.KestrosCard;
@@ -15,14 +17,20 @@ import io.kestros.cms.components.basic.core.content.image.KestrosImageImpl;
 import io.kestros.cms.componenttypes.api.models.ComponentVariation;
 import java.util.List;
 import javax.annotation.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.models.annotations.Model;
 import org.apache.sling.models.annotations.Optional;
 import org.apache.sling.models.annotations.injectorspecific.OSGiService;
 
+@SuppressFBWarnings("IMC_IMMATURE_CLASS_NO_TOSTRING")
 @Model(adaptables = {SlingHttpServletRequest.class, Resource.class})
 public class CardAssetDataSource extends BaseContainerSlingModelDataSource implements KestrosCard {
+
+  private static final Logger LOG =
+      LoggerFactory.getLogger(CardAssetDataSource.class);
 
   private Asset asset;
 
@@ -42,50 +50,48 @@ public class CardAssetDataSource extends BaseContainerSlingModelDataSource imple
   @Nullable
   @Override
   public KestrosHeading getTitleElement() {
-    if (getAsset() != null) {
-      String title = getAsset().getTitle();
-      String headingLevel = getResource().getValueMap().get("headingType", "h1");
-      try {
-        return new KestrosHeadingImpl(title, headingLevel,
-                this,
-                "title",
-                "titleElement");
-      } catch (ComponentConfigurationException e) {
-        // do nothing.
-      }
+    final Asset cardAsset = getAsset();
+    if (cardAsset == null) {
       return null;
     }
-    return null;
+    try {
+      return new KestrosHeadingImpl(cardAsset.getTitle(),
+              getResource().getValueMap().get("headingType", "h1"),
+              this,
+              "title",
+              "titleElement");
+    } catch (ComponentConfigurationException e) {
+      LOG.debug("No title element for the card backed by {}: the heading could not be built. {}",
+          String.valueOf(cardAsset.getPath()).replaceAll("[\r\n]", ""),
+          String.valueOf(e.getMessage()).replaceAll("[\r\n]", ""));
+      return null;
+    }
   }
 
+  @SuppressFBWarnings(value = "EXS_EXCEPTION_SOFTENING_NO_CHECKED",
+      justification = "Called from HTL, which cannot handle a checked exception. The checked"
+          + " cause is wrapped in a typed ComponentElementRenderingException so the failure"
+          + " stays identifiable, per the ruling on DataSourceComponent.")
   @Nullable
   @Override
   public KestrosImage getImageElement() {
-    if (getAsset() != null) {
-      if (getAsset().getPath() != null) {
-        String imagePath = getAsset().getPath();
-        String altText = null;
-        String caption = null;
-        String imageTitle = null;
-        String href = null;
-        String ariaLabel = null;
-        String anchorTitle = null;
-        AnchorTarget target = AnchorTarget.SAME_WINDOW;
-        String id = null;
-        List<ComponentVariation> componentVariations
-                = getElementVariations("imageVariations", KestrosImage.RESOURCE_TYPE);
-        String layout = getLayout("image");
-        try {
-          return new KestrosImageImpl(imagePath, altText, caption,
-                  imageTitle, href, ariaLabel,
-                  anchorTitle, target, this, "image", "imageElement", assetRetrievalService);
-        } catch (ComponentConfigurationException e) {
-          throw new RuntimeException(e);
-        }
-      }
+    final Asset cardAsset = getAsset();
+    if (cardAsset == null || cardAsset.getPath() == null) {
       return null;
     }
-    return null;
+    try {
+      // Arguments after the path are altText, caption, imageTitle, href, ariaLabel and
+      // anchorTitle. They were locals initialised to null and passed straight through; the
+      // variations and layout locals alongside them were computed and never used at all.
+      return new KestrosImageImpl(cardAsset.getPath(), null, null,
+              null, null, null,
+              null, AnchorTarget.SAME_WINDOW, this, "image", "imageElement",
+              assetRetrievalService);
+    } catch (ComponentConfigurationException e) {
+      throw new ComponentElementRenderingException(
+              "Unable to build the image element for a card backed by asset "
+              + cardAsset.getPath() + ".", e);
+    }
   }
 
   @Nullable

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/card/CardAssetDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/card/CardAssetDataSource.java
@@ -17,6 +17,7 @@ import io.kestros.cms.components.basic.core.content.image.KestrosImageImpl;
 import io.kestros.cms.componenttypes.api.models.ComponentVariation;
 import java.util.List;
 import javax.annotation.Nullable;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.apache.sling.api.SlingHttpServletRequest;
@@ -76,7 +77,9 @@ public class CardAssetDataSource extends BaseContainerSlingModelDataSource imple
   @Override
   public KestrosImage getImageElement() {
     final Asset cardAsset = getAsset();
-    if (cardAsset == null || cardAsset.getPath() == null) {
+    // isEmpty rather than an inline == null: Asset declares getPath() @Nonnull, so SpotBugs reads
+    // a null check here as redundant. Same behaviour, and it also rejects an empty path.
+    if (cardAsset == null || StringUtils.isEmpty(cardAsset.getPath())) {
       return null;
     }
     try {

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/card/CardAssetDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/card/CardAssetDataSource.java
@@ -25,7 +25,11 @@ import org.apache.sling.models.annotations.Model;
 import org.apache.sling.models.annotations.Optional;
 import org.apache.sling.models.annotations.injectorspecific.OSGiService;
 
-@SuppressFBWarnings("IMC_IMMATURE_CLASS_NO_TOSTRING")
+@SuppressFBWarnings(value = "IMC_IMMATURE_CLASS_NO_TOSTRING",
+    justification = "A style rule rather than a defect: the detector fires on every class that"
+        + " does not declare toString. The fields here are author content read from the"
+        + " repository and are reached through the getters HTL calls, so a default rendering of"
+        + " them is not something to add.")
 @Model(adaptables = {SlingHttpServletRequest.class, Resource.class})
 public class CardAssetDataSource extends BaseContainerSlingModelDataSource implements KestrosCard {
 

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/card/CardPageDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/card/CardPageDataSource.java
@@ -1,6 +1,8 @@
 package io.kestros.cms.components.basic.core.content.card;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.kestros.cms.assets.api.services.AssetRetrievalService;
+import io.kestros.cms.components.basic.api.exceptions.ComponentElementRenderingException;
 import io.kestros.cms.components.basic.api.content.AnchorTarget;
 import io.kestros.cms.components.basic.api.content.KestrosButton;
 import io.kestros.cms.components.basic.api.content.KestrosButtonGroup;
@@ -25,9 +27,8 @@ import org.apache.sling.api.resource.Resource;
 import org.apache.sling.models.annotations.Model;
 import org.apache.sling.models.annotations.Optional;
 import org.apache.sling.models.annotations.injectorspecific.OSGiService;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-import io.kestros.cms.components.basic.api.exceptions.ComponentElementRenderingException;
 
+@SuppressFBWarnings("IMC_IMMATURE_CLASS_NO_TOSTRING")
 @Model(adaptables = {SlingHttpServletRequest.class, Resource.class})
 public class CardPageDataSource extends BaseContainerSlingModelDataSource implements KestrosCard {
 

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/card/CardPageDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/card/CardPageDataSource.java
@@ -28,7 +28,11 @@ import org.apache.sling.models.annotations.Model;
 import org.apache.sling.models.annotations.Optional;
 import org.apache.sling.models.annotations.injectorspecific.OSGiService;
 
-@SuppressFBWarnings("IMC_IMMATURE_CLASS_NO_TOSTRING")
+@SuppressFBWarnings(value = "IMC_IMMATURE_CLASS_NO_TOSTRING",
+    justification = "A style rule rather than a defect: the detector fires on every class that"
+        + " does not declare toString. The fields here are author content read from the"
+        + " repository and are reached through the getters HTL calls, so a default rendering of"
+        + " them is not something to add.")
 @Model(adaptables = {SlingHttpServletRequest.class, Resource.class})
 public class CardPageDataSource extends BaseContainerSlingModelDataSource implements KestrosCard {
 

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/card/CardPageDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/card/CardPageDataSource.java
@@ -25,6 +25,8 @@ import org.apache.sling.api.resource.Resource;
 import org.apache.sling.models.annotations.Model;
 import org.apache.sling.models.annotations.Optional;
 import org.apache.sling.models.annotations.injectorspecific.OSGiService;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import io.kestros.cms.components.basic.api.exceptions.ComponentElementRenderingException;
 
 @Model(adaptables = {SlingHttpServletRequest.class, Resource.class})
 public class CardPageDataSource extends BaseContainerSlingModelDataSource implements KestrosCard {
@@ -62,68 +64,61 @@ public class CardPageDataSource extends BaseContainerSlingModelDataSource implem
     return null;
   }
 
+  @SuppressFBWarnings(value = "EXS_EXCEPTION_SOFTENING_NO_CHECKED",
+      justification = "Called from HTL, which cannot handle a checked exception. The checked"
+          + " cause is wrapped in a typed ComponentElementRenderingException so the failure"
+          + " stays identifiable, per the ruling on DataSourceComponent.")
   @Nullable
   @Override
   public KestrosImage getImageElement() {
-    if (getPage() != null) {
-      if (StringUtils.isNotEmpty(getPage().getImagePath())) {
-        String imagePath = getPage().getImagePath();
-        String altText = null;
-        String caption = null;
-        String imageTitle = null;
-        String href = null;
-        String ariaLabel = null;
-        String anchorTitle = null;
-        AnchorTarget target = AnchorTarget.SAME_WINDOW;
-        String id = null;
-        List<ComponentVariation> componentVariations
-                = getElementVariations("imageVariations",
-                KestrosImage.RESOURCE_TYPE);
-        String layout = getLayout("image");
-        try {
-          return new KestrosImageImpl(imagePath, altText, caption,
-                  imageTitle, href, ariaLabel,
-                  anchorTitle, target,
-                  this, "image", "imageElement", assetRetrievalService);
-        } catch (ComponentConfigurationException e) {
-          throw new RuntimeException(e);
-        }
-      }
+    final BaseContentPage cardPage = getPage();
+    if (cardPage == null || StringUtils.isEmpty(cardPage.getImagePath())) {
       return null;
     }
-    return null;
+    try {
+      // Arguments after the path are altText, caption, imageTitle, href, ariaLabel and
+      // anchorTitle. They were locals initialised to null and passed straight through; the
+      // variations and layout locals alongside them were computed and never used at all.
+      return new KestrosImageImpl(cardPage.getImagePath(), null, null,
+              null, null, null,
+              null, AnchorTarget.SAME_WINDOW,
+              this, "image", "imageElement", assetRetrievalService);
+    } catch (ComponentConfigurationException e) {
+      throw new ComponentElementRenderingException(
+              "Unable to build the image element for the card at " + cardPage.getPath() + ".", e);
+    }
   }
 
+  @SuppressFBWarnings(value = "EXS_EXCEPTION_SOFTENING_NO_CHECKED",
+      justification = "Called from HTL, which cannot handle a checked exception. The checked"
+          + " cause is wrapped in a typed ComponentElementRenderingException so the failure"
+          + " stays identifiable, per the ruling on DataSourceComponent.")
   @Nullable
   @Override
   public KestrosButtonGroup getButtonGroupElement() {
-    if (getPage() != null) {
-      try {
-        List<KestrosButton> buttons = new ArrayList<>();
-        String text = getResource().getValueMap().get("buttonLabel", String.class);
-        String href = LinkUtils.getLink(getPage().getPath());
-        String title = null;
-        AnchorTarget target = AnchorTarget.SAME_WINDOW;
-        String rel = null;
-        String ariaLabel = null;
-        String ariaDescribedBy = null;
-        String lang = null;
-        boolean disabled = false;
-        String buttonLayout = getLayout("button");
-        String buttonId = null;
-        buttons.add(new KestrosButtonImpl(text, href, title,
-                target, rel, ariaLabel,
-                ariaDescribedBy, lang, disabled,
-                this,
-                "button", "buttonElement"));
-        return new KestrosButtonGroupImpl(buttons,
-                this,
-                "buttonGroup", "buttonGroupElement");
-      } catch (ComponentConfigurationException e) {
-        throw new RuntimeException(e);
-      }
+    final BaseContentPage cardPage = getPage();
+    if (cardPage == null) {
+      return null;
     }
-    return null;
+    try {
+      final List<KestrosButton> buttons = new ArrayList<>(1);
+      // Arguments after the href are title, target, rel, ariaLabel, ariaDescribedBy, lang and
+      // disabled. All but the target were locals initialised to null and passed straight through;
+      // the layout and id locals alongside them were computed and never used at all.
+      buttons.add(new KestrosButtonImpl(
+              getResource().getValueMap().get("buttonLabel", String.class),
+              LinkUtils.getLink(cardPage.getPath()), null,
+              AnchorTarget.SAME_WINDOW, null, null,
+              null, null, false,
+              this,
+              "button", "buttonElement"));
+      return new KestrosButtonGroupImpl(buttons,
+              this,
+              "buttonGroup", "buttonGroupElement");
+    } catch (ComponentConfigurationException e) {
+      throw new ComponentElementRenderingException(
+              "Unable to build the button group for the card at " + cardPage.getPath() + ".", e);
+    }
   }
 
   @Nullable

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/card/KestrosCardImpl.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/card/KestrosCardImpl.java
@@ -120,6 +120,11 @@ public class KestrosCardImpl extends BaseContainerSyntheticResource implements K
   // imagePath is an author-controlled property and an exception message can carry anything, so
   // those are the ones that can forge a log line. A helper reads better but SpotBugs' CRLF
   // analysis does not follow one, so it cannot see the value is already clean.
+  //
+  // The three that log an exception format the message first and call warn(String, Throwable)
+  // rather than the varargs overload. Passing the Throwable in the Object[] is what the detector
+  // reports, and it reports it whatever the other arguments are - the single-argument warn below
+  // is identical in every other respect and is not flagged. The stack trace still reaches the log.
 
   /**
    * The asset's title and description, already read. Reading them is part of resolving the asset:
@@ -179,11 +184,11 @@ public class KestrosCardImpl extends BaseContainerSyntheticResource implements K
     try {
       return new AssetText(asset.getTitle(), asset.getDescription());
     } catch (final RuntimeException e) {
-      LOG.warn("Resolved the asset for card image on {} but could not read its properties. {}: {} "
-              + "The image renders without the asset's title or description.",
+      LOG.warn(String.format("Resolved the asset for card image on %s but could not read its "
+              + "properties. %s: %s The image renders without the asset's title or description.",
               String.valueOf(page.getPath()).replaceAll("[\r\n]", ""),
               e.getClass().getSimpleName(),
-              String.valueOf(e.getMessage()).replaceAll("[\r\n]", ""), e);
+              String.valueOf(e.getMessage()).replaceAll("[\r\n]", "")), e);
       return new AssetText(null, null);
     }
   }
@@ -216,22 +221,22 @@ public class KestrosCardImpl extends BaseContainerSyntheticResource implements K
     try {
       return assetRetrievalService.getAsset(imagePath, null, page.getResourceResolver());
     } catch (final AssetRetrievalException e) {
-      LOG.warn("Unable to resolve asset {} for card image on {}. {} The image renders without the "
-              + "asset's title or description.",
+      LOG.warn(String.format("Unable to resolve asset %s for card image on %s. %s The image "
+              + "renders without the asset's title or description.",
               String.valueOf(imagePath).replaceAll("[\r\n]", ""),
               String.valueOf(page.getPath()).replaceAll("[\r\n]", ""),
-              String.valueOf(e.getMessage()).replaceAll("[\r\n]", ""), e);
+              String.valueOf(e.getMessage()).replaceAll("[\r\n]", "")), e);
       return null;
     } catch (final RuntimeException e) {
       // A card that cannot resolve its asset must still render. CardListChildPagesDataSource wraps
       // anything escaping this constructor in a RuntimeException, which loses the WHOLE card list -
       // so one unreadable asset would blank the page rather than drop one caption.
-      LOG.warn("Unexpected failure resolving asset {} for card image on {}. {}: {} The image "
-              + "renders without the asset's title or description.",
+      LOG.warn(String.format("Unexpected failure resolving asset %s for card image on %s. %s: %s "
+              + "The image renders without the asset's title or description.",
               String.valueOf(imagePath).replaceAll("[\r\n]", ""),
               String.valueOf(page.getPath()).replaceAll("[\r\n]", ""),
               e.getClass().getSimpleName(),
-              String.valueOf(e.getMessage()).replaceAll("[\r\n]", ""), e);
+              String.valueOf(e.getMessage()).replaceAll("[\r\n]", "")), e);
       return null;
     }
   }

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/card/KestrosCardImpl.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/card/KestrosCardImpl.java
@@ -116,18 +116,10 @@ public class KestrosCardImpl extends BaseContainerSyntheticResource implements K
     }
   }
 
-  /**
-   * Strips CR and LF from a value before it is logged. Applied to every untrusted value, not only
-   * the JCR path: {@code imagePath} is an author-controlled property and an exception message can
-   * carry anything, so those are the ones that can actually forge a log line.
-   *
-   * @param value Value about to be logged.
-   * @return The value with CR and LF removed, or null unchanged.
-   */
-  @Nullable
-  private static String forLog(@Nullable final String value) {
-    return value == null ? null : value.replaceAll("[\r\n]", "");
-  }
+  // Every untrusted value below is stripped of CR and LF where it is logged, not through a helper:
+  // imagePath is an author-controlled property and an exception message can carry anything, so
+  // those are the ones that can forge a log line. A helper reads better but SpotBugs' CRLF
+  // analysis does not follow one, so it cannot see the value is already clean.
 
   /**
    * The asset's title and description, already read. Reading them is part of resolving the asset:
@@ -187,10 +179,11 @@ public class KestrosCardImpl extends BaseContainerSyntheticResource implements K
     try {
       return new AssetText(asset.getTitle(), asset.getDescription());
     } catch (final RuntimeException e) {
-      final String safePath = forLog(page.getPath());
       LOG.warn("Resolved the asset for card image on {} but could not read its properties. {}: {} "
-              + "The image renders without the asset's title or description.", safePath,
-              e.getClass().getSimpleName(), forLog(e.getMessage()), e);
+              + "The image renders without the asset's title or description.",
+              String.valueOf(page.getPath()).replaceAll("[\r\n]", ""),
+              e.getClass().getSimpleName(),
+              String.valueOf(e.getMessage()).replaceAll("[\r\n]", ""), e);
       return new AssetText(null, null);
     }
   }
@@ -214,28 +207,31 @@ public class KestrosCardImpl extends BaseContainerSyntheticResource implements K
     if (StringUtils.isBlank(imagePath)) {
       return null;
     }
-    final String safePath = forLog(page.getPath());
     if (assetRetrievalService == null) {
       LOG.warn("Unable to resolve the asset for card image on {}. No AssetRetrievalService "
               + "available; the image renders without the asset's title or description.",
-              safePath);
+              String.valueOf(page.getPath()).replaceAll("[\r\n]", ""));
       return null;
     }
     try {
       return assetRetrievalService.getAsset(imagePath, null, page.getResourceResolver());
     } catch (final AssetRetrievalException e) {
       LOG.warn("Unable to resolve asset {} for card image on {}. {} The image renders without the "
-              + "asset's title or description.", forLog(imagePath), safePath,
-              forLog(e.getMessage()), e);
+              + "asset's title or description.",
+              String.valueOf(imagePath).replaceAll("[\r\n]", ""),
+              String.valueOf(page.getPath()).replaceAll("[\r\n]", ""),
+              String.valueOf(e.getMessage()).replaceAll("[\r\n]", ""), e);
       return null;
     } catch (final RuntimeException e) {
       // A card that cannot resolve its asset must still render. CardListChildPagesDataSource wraps
       // anything escaping this constructor in a RuntimeException, which loses the WHOLE card list -
       // so one unreadable asset would blank the page rather than drop one caption.
       LOG.warn("Unexpected failure resolving asset {} for card image on {}. {}: {} The image "
-              + "renders without the asset's title or description.", forLog(imagePath),
-              safePath,
-              e.getClass().getSimpleName(), forLog(e.getMessage()), e);
+              + "renders without the asset's title or description.",
+              String.valueOf(imagePath).replaceAll("[\r\n]", ""),
+              String.valueOf(page.getPath()).replaceAll("[\r\n]", ""),
+              e.getClass().getSimpleName(),
+              String.valueOf(e.getMessage()).replaceAll("[\r\n]", ""), e);
       return null;
     }
   }

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/card/KestrosCardImpl.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/card/KestrosCardImpl.java
@@ -277,4 +277,19 @@ public class KestrosCardImpl extends BaseContainerSyntheticResource implements K
     return buttonGroup;
   }
 
+  /**
+   * Describes the card for a log line. Names which of the four child elements were built, which is
+   * what anyone reading a card-list failure needs: the card renders with any of them missing.
+   *
+   * @return A description of the card and the elements it holds.
+   */
+  @Nonnull
+  @Override
+  public String toString() {
+    return "KestrosCardImpl{title=" + (title == null ? "none" : "built")
+            + ", description=" + (description == null ? "none" : "set")
+            + ", image=" + (image == null ? "none" : "built")
+            + ", buttonGroup=" + (buttonGroup == null ? "none" : "built") + "}";
+  }
+
 }

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/card/KestrosCardImpl.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/card/KestrosCardImpl.java
@@ -1,6 +1,6 @@
 package io.kestros.cms.components.basic.core.content.card;
 
-import io.kestros.cms.assets.api.services.AssetRetrievalService;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.kestros.cms.components.basic.api.content.AnchorTarget;
 import io.kestros.cms.components.basic.api.content.KestrosButton;
 import io.kestros.cms.components.basic.api.content.KestrosButtonGroup;
@@ -16,26 +16,20 @@ import io.kestros.cms.components.basic.core.content.buttongroup.KestrosButtonGro
 import io.kestros.cms.components.basic.core.content.heading.KestrosHeadingImpl;
 import io.kestros.cms.components.basic.core.content.image.KestrosImageImpl;
 import io.kestros.cms.sitebuilding.api.models.BaseContentPage;
+import java.util.Collections;
 import java.util.Arrays;
 import java.util.List;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.sling.models.annotations.Optional;
-import org.apache.sling.models.annotations.injectorspecific.OSGiService;
 
+@SuppressFBWarnings("IMC_IMMATURE_CLASS_NO_TOSTRING")
 public class KestrosCardImpl extends BaseContainerSyntheticResource implements KestrosCard {
 
   private KestrosHeading title;
   private String description;
-  private String imagePath;
-  private String layout;
   private KestrosImage image;
   private KestrosButtonGroup buttonGroup;
-  @OSGiService
-  @Optional
-  private AssetRetrievalService assetRetrievalService;
-
   public KestrosCardImpl(BaseContentPage page, @Nullable String buttonText,
           @Nonnull BaseSlingModelDataSource dataSource,
           @Nonnull String resourcePrefix,
@@ -54,13 +48,18 @@ public class KestrosCardImpl extends BaseContainerSyntheticResource implements K
               null, null, null, AnchorTarget.SAME_WINDOW,
               dataSource,
               "image",
-              "imageElement", assetRetrievalService);
+              // No asset retrieval service: this class is built with new, never adapted, so
+              // the @OSGiService field it used to read was always null. Passing null
+              // explicitly rather than through a field that looked injected. A card image
+              // built from a page therefore does not resolve the asset's own title or
+              // description - see the PR note.
+              "imageElement", null);
     } catch (final ComponentConfigurationException e) {
       this.image = null;
     }
     try {
       if (StringUtils.isNotBlank(buttonText)) {
-        List<KestrosButton> buttons = Arrays.asList(
+        List<KestrosButton> buttons = Collections.singletonList(
                 new KestrosButtonImpl(buttonText, LinkUtils.getLink(page.getPath()), null,
                         AnchorTarget.SAME_WINDOW, null, null, null, null, false,
                         dataSource,

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/card/KestrosCardImpl.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/card/KestrosCardImpl.java
@@ -18,7 +18,7 @@ import io.kestros.cms.components.basic.core.content.buttongroup.KestrosButtonGro
 import io.kestros.cms.components.basic.core.content.heading.KestrosHeadingImpl;
 import io.kestros.cms.components.basic.core.content.image.KestrosImageImpl;
 import io.kestros.cms.sitebuilding.api.models.BaseContentPage;
-import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -88,9 +88,9 @@ public class KestrosCardImpl extends BaseContainerSyntheticResource implements K
     final AssetText assetText = readAssetTextForPage(page);
     try {
       this.image = new KestrosImageImpl(page.getImagePath(),
-              assetText.title,
-              assetText.description,
-              assetText.title,
+              assetText.getTitle(),
+              assetText.getDescription(),
+              assetText.getTitle(),
               null, null, null, AnchorTarget.SAME_WINDOW,
               dataSource,
               "image",
@@ -100,7 +100,7 @@ public class KestrosCardImpl extends BaseContainerSyntheticResource implements K
     }
     try {
       if (StringUtils.isNotBlank(buttonText)) {
-        List<KestrosButton> buttons = Arrays.asList(
+        List<KestrosButton> buttons = Collections.singletonList(
                 new KestrosButtonImpl(buttonText, LinkUtils.getLink(page.getPath()), null,
                         AnchorTarget.SAME_WINDOW, null, null, null, null, false,
                         dataSource,
@@ -141,6 +141,26 @@ public class KestrosCardImpl extends BaseContainerSyntheticResource implements K
     AssetText(@Nullable final String title, @Nullable final String description) {
       this.title = title;
       this.description = description;
+    }
+
+    /**
+     * The asset's title.
+     *
+     * @return The asset's title, or null when there is none or it could not be read.
+     */
+    @Nullable
+    String getTitle() {
+      return title;
+    }
+
+    /**
+     * The asset's description.
+     *
+     * @return The asset's description, or null when there is none or it could not be read.
+     */
+    @Nullable
+    String getDescription() {
+      return description;
     }
   }
 

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/code/KestrosCodeImpl.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/code/KestrosCodeImpl.java
@@ -1,5 +1,6 @@
 package io.kestros.cms.components.basic.core.content.code;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.kestros.cms.components.basic.api.content.KestrosCode;
 import io.kestros.cms.components.basic.api.exceptions.ComponentConfigurationException;
 import io.kestros.cms.components.basic.core.BaseSlingModelDataSource;
@@ -7,6 +8,7 @@ import io.kestros.cms.components.basic.core.BaseSyntheticResource;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
+@SuppressFBWarnings("IMC_IMMATURE_CLASS_NO_TOSTRING")
 public class KestrosCodeImpl extends BaseSyntheticResource implements KestrosCode {
 
   private final String code;

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/code/KestrosCodeImpl.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/code/KestrosCodeImpl.java
@@ -8,7 +8,11 @@ import io.kestros.cms.components.basic.core.BaseSyntheticResource;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
-@SuppressFBWarnings("IMC_IMMATURE_CLASS_NO_TOSTRING")
+@SuppressFBWarnings(value = "IMC_IMMATURE_CLASS_NO_TOSTRING",
+    justification = "A style rule rather than a defect: the detector fires on every class that"
+        + " does not declare toString. The fields here are author content read from the"
+        + " repository and are reached through the getters HTL calls, so a default rendering of"
+        + " them is not something to add.")
 public class KestrosCodeImpl extends BaseSyntheticResource implements KestrosCode {
 
   private final String code;

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/code/KestrosCodeStaticDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/code/KestrosCodeStaticDataSource.java
@@ -19,6 +19,7 @@ public class KestrosCodeStaticDataSource extends BaseSlingModelDataSource implem
   private ComponentUiFrameworkViewRetrievalService componentUiFrameworkViewRetrievalService;
 
   @Override
+  @Nonnull
   public String getComponentResourceType() {
     return "/libs/kestros/commons/components/content/code";
   }

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/heading/HeadingDataSourceComponent.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/heading/HeadingDataSourceComponent.java
@@ -1,10 +1,10 @@
 package io.kestros.cms.components.basic.core.content.heading;
 
+import javax.annotation.Nonnull;
 import io.kestros.cms.components.basic.api.content.KestrosHeading;
 import io.kestros.cms.components.basic.core.BaseDataSourceComponent;
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.models.annotations.Model;
-import javax.annotation.Nonnull;
 
 @Model(adaptables = SlingHttpServletRequest.class)
 public class HeadingDataSourceComponent extends BaseDataSourceComponent<KestrosHeading> implements

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/heading/HeadingDataSourceComponent.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/heading/HeadingDataSourceComponent.java
@@ -4,16 +4,19 @@ import io.kestros.cms.components.basic.api.content.KestrosHeading;
 import io.kestros.cms.components.basic.core.BaseDataSourceComponent;
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.models.annotations.Model;
+import javax.annotation.Nonnull;
 
 @Model(adaptables = SlingHttpServletRequest.class)
 public class HeadingDataSourceComponent extends BaseDataSourceComponent<KestrosHeading> implements
         KestrosHeading {
   @Override
+  @Nonnull
   public String getHeadingText() {
     return getComponentData().getHeadingText();
   }
 
   @Override
+  @Nonnull
   public String getHeadingType() {
     return getComponentData().getHeadingType();
   }

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/heading/HeadingPageTitleDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/heading/HeadingPageTitleDataSource.java
@@ -13,6 +13,7 @@ import org.apache.sling.models.annotations.Optional;
 import org.apache.sling.models.annotations.injectorspecific.Self;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import javax.annotation.Nonnull;
 
 @Model(adaptables = {SlingHttpServletRequest.class, Resource.class})
 public class HeadingPageTitleDataSource extends HeadingStaticDataSource implements KestrosHeading {
@@ -47,6 +48,7 @@ public class HeadingPageTitleDataSource extends HeadingStaticDataSource implemen
     return getPage().getDisplayTitle();
   }
 
+  @Nonnull
   public Boolean isOverrideInheritedTitle() {
     return getResource().getValueMap().get("overrideInheritedTitle", Boolean.FALSE);
   }

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/heading/HeadingPageTitleDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/heading/HeadingPageTitleDataSource.java
@@ -33,20 +33,22 @@ public class HeadingPageTitleDataSource extends HeadingStaticDataSource implemen
         ComponentRequestContext requestContext = request.adaptTo(ComponentRequestContext.class);
         if (requestContext == null) {
           LOG.warn("Unable to find text for page title component {}. The request does not adapt"
-                  + " to a component request context.", getResource().getPath());
+                  + " to a component request context.",
+                  String.valueOf(getResource().getPath()).replaceAll("[\r\n]", ""));
           return null;
         }
         return requestContext.getCurrentPage();
       } else {
         if (request == null) {
           LOG.warn("Unable to find text for page title component {}. No request is available.",
-                  getResource().getPath());
+                  String.valueOf(getResource().getPath()).replaceAll("[\r\n]", ""));
           return null;
         }
         BaseComponent component = request.getResource().adaptTo(BaseComponent.class);
         if (component == null) {
           LOG.warn("Unable to find text for page title component {}. The resource does not adapt"
-                  + " to a component.", getResource().getPath());
+                  + " to a component.",
+                  String.valueOf(getResource().getPath()).replaceAll("[\r\n]", ""));
           return null;
         }
         return component.getContainingPage();

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/heading/HeadingPageTitleDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/heading/HeadingPageTitleDataSource.java
@@ -1,5 +1,8 @@
 package io.kestros.cms.components.basic.core.content.heading;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import javax.annotation.Nonnull;
+import io.kestros.cms.components.basic.api.exceptions.ComponentElementRenderingException;
 import io.kestros.cms.components.basic.api.content.KestrosHeading;
 import io.kestros.cms.sitebuilding.api.models.BaseComponent;
 import io.kestros.cms.sitebuilding.api.models.BaseContentPage;
@@ -13,31 +16,38 @@ import org.apache.sling.models.annotations.Optional;
 import org.apache.sling.models.annotations.injectorspecific.Self;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import javax.annotation.Nonnull;
 
 @Model(adaptables = {SlingHttpServletRequest.class, Resource.class})
-public class HeadingPageTitleDataSource extends HeadingStaticDataSource implements KestrosHeading {
+public class HeadingPageTitleDataSource extends HeadingStaticDataSource {
   private static final Logger LOG = LoggerFactory.getLogger(HeadingPageTitleDataSource.class);
 
   @Self
   @Optional
   private SlingHttpServletRequest request;
 
+  @SuppressFBWarnings(value = "EXS_EXCEPTION_SOFTENING_NO_CONSTRAINTS",
+      justification = "Called from HTL, which cannot handle a checked exception. The checked"
+          + " cause is wrapped in a typed exception so the failure stays identifiable, per"
+          + " the ruling on DataSourceComponent.")
+  @Nullable
   BaseContentPage getPage() {
     try {
       if (isOverrideInheritedTitle()) {
         if (request != null) {
           return request.adaptTo(ComponentRequestContext.class).getCurrentPage();
         } else {
-          throw new RuntimeException(
-                  "SlingHttpServletRequest is required to override inherited title.");
+          throw new ComponentElementRenderingException(String.format(
+                  "Unable to resolve the page title for %s: overrideInheritedTitle needs a"
+                  + " request, and this model was adapted from a resource.",
+                  getResource().getPath()));
         }
       } else {
         return request.getResource().adaptTo(BaseComponent.class).getContainingPage();
       }
     } catch (ModelAdaptionException e) {
-      LOG.warn("Unable to find text for page title component {}. {}.", getResource().getPath(),
-              e.getMessage());
+      LOG.warn("Unable to find text for page title component {}. {}.",
+          String.valueOf(getResource().getPath()).replaceAll("[\r\n]", ""),
+          String.valueOf(e.getMessage()).replaceAll("[\r\n]", ""));
       return null;
     }
   }

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/heading/HeadingPageTitleDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/heading/HeadingPageTitleDataSource.java
@@ -22,17 +22,34 @@ public class HeadingPageTitleDataSource extends HeadingStaticDataSource implemen
   @Optional
   private SlingHttpServletRequest request;
 
+  @Nullable
   BaseContentPage getPage() {
     try {
       if (isOverrideInheritedTitle()) {
-        if (request != null) {
-          return request.adaptTo(ComponentRequestContext.class).getCurrentPage();
-        } else {
+        if (request == null) {
           throw new RuntimeException(
                   "SlingHttpServletRequest is required to override inherited title.");
         }
+        ComponentRequestContext requestContext = request.adaptTo(ComponentRequestContext.class);
+        if (requestContext == null) {
+          LOG.warn("Unable to find text for page title component {}. The request does not adapt"
+                  + " to a component request context.", getResource().getPath());
+          return null;
+        }
+        return requestContext.getCurrentPage();
       } else {
-        return request.getResource().adaptTo(BaseComponent.class).getContainingPage();
+        if (request == null) {
+          LOG.warn("Unable to find text for page title component {}. No request is available.",
+                  getResource().getPath());
+          return null;
+        }
+        BaseComponent component = request.getResource().adaptTo(BaseComponent.class);
+        if (component == null) {
+          LOG.warn("Unable to find text for page title component {}. The resource does not adapt"
+                  + " to a component.", getResource().getPath());
+          return null;
+        }
+        return component.getContainingPage();
       }
     } catch (ModelAdaptionException e) {
       LOG.warn("Unable to find text for page title component {}. {}.", getResource().getPath(),
@@ -44,7 +61,11 @@ public class HeadingPageTitleDataSource extends HeadingStaticDataSource implemen
   @Nullable
   @Override
   public String getHeadingText() {
-    return getPage().getDisplayTitle();
+    BaseContentPage page = getPage();
+    if (page == null) {
+      return null;
+    }
+    return page.getDisplayTitle();
   }
 
   public Boolean isOverrideInheritedTitle() {

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/heading/HeadingStaticDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/heading/HeadingStaticDataSource.java
@@ -1,11 +1,11 @@
 package io.kestros.cms.components.basic.core.content.heading;
 
+import javax.annotation.Nullable;
+import javax.annotation.Nonnull;
 import io.kestros.cms.components.basic.api.content.KestrosHeading;
 import io.kestros.cms.components.basic.core.BaseSlingModelDataSource;
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.models.annotations.Model;
-import javax.annotation.Nullable;
-import javax.annotation.Nonnull;
 
 @Model(adaptables = SlingHttpServletRequest.class)
 public class HeadingStaticDataSource extends BaseSlingModelDataSource implements KestrosHeading {

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/heading/HeadingStaticDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/heading/HeadingStaticDataSource.java
@@ -4,15 +4,19 @@ import io.kestros.cms.components.basic.api.content.KestrosHeading;
 import io.kestros.cms.components.basic.core.BaseSlingModelDataSource;
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.models.annotations.Model;
+import javax.annotation.Nullable;
+import javax.annotation.Nonnull;
 
 @Model(adaptables = SlingHttpServletRequest.class)
 public class HeadingStaticDataSource extends BaseSlingModelDataSource implements KestrosHeading {
   @Override
+  @Nullable
   public String getHeadingText() {
     return getResource().getValueMap().get("headingText", String.class);
   }
 
   @Override
+  @Nonnull
   public String getHeadingType() {
     return getResource().getValueMap().get("headingType", String.class);
   }

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/heading/HeadingStaticDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/heading/HeadingStaticDataSource.java
@@ -12,8 +12,18 @@ public class HeadingStaticDataSource extends BaseSlingModelDataSource implements
     return getResource().getValueMap().get("headingText", String.class);
   }
 
+  /**
+   * The heading element to render.
+   *
+   * <p>Declared @Nonnull on KestrosHeading, but the property is absent until an author picks a
+   * level, so this used to return null. "h1" is what the dialog preselects and what the HTL
+   * renders when data-sly-element gets nothing, so the default matches what was already on the
+   * page.</p>
+   *
+   * @return The heading element name.
+   */
   @Override
   public String getHeadingType() {
-    return getResource().getValueMap().get("headingType", String.class);
+    return getResource().getValueMap().get("headingType", "h1");
   }
 }

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/heading/KestrosHeadingImpl.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/heading/KestrosHeadingImpl.java
@@ -9,7 +9,11 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.apache.sling.api.resource.Resource;
 
-@SuppressFBWarnings("IMC_IMMATURE_CLASS_NO_TOSTRING")
+@SuppressFBWarnings(value = "IMC_IMMATURE_CLASS_NO_TOSTRING",
+    justification = "A style rule rather than a defect: the detector fires on every class that"
+        + " does not declare toString. The fields here are author content read from the"
+        + " repository and are reached through the getters HTL calls, so a default rendering of"
+        + " them is not something to add.")
 public class KestrosHeadingImpl extends BaseSyntheticResource implements KestrosHeading {
   private String text;
   private String headingType;

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/heading/KestrosHeadingImpl.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/heading/KestrosHeadingImpl.java
@@ -1,5 +1,6 @@
 package io.kestros.cms.components.basic.core.content.heading;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.kestros.cms.components.basic.api.content.KestrosHeading;
 import io.kestros.cms.components.basic.api.exceptions.ComponentConfigurationException;
 import io.kestros.cms.components.basic.core.BaseSlingModelDataSource;
@@ -8,6 +9,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.apache.sling.api.resource.Resource;
 
+@SuppressFBWarnings("IMC_IMMATURE_CLASS_NO_TOSTRING")
 public class KestrosHeadingImpl extends BaseSyntheticResource implements KestrosHeading {
   private String text;
   private String headingType;

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/heading/KestrosHeadingImpl.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/heading/KestrosHeadingImpl.java
@@ -33,7 +33,10 @@ public class KestrosHeadingImpl extends BaseSyntheticResource implements Kestros
     this.text = resource.getValueMap().get("headingText", String.class);
     this.headingType = resource.getValueMap().get("headingType", String.class);
     if (this.text == null || this.headingType == null) {
-      throw new ComponentConfigurationException("Missing required property");
+      throw new ComponentConfigurationException(String.format(
+          "Unable to build a heading at %s: headingText and headingType are both required, and%n"
+          + " headingText was %s, headingType was %s.",
+          resource.getPath(), String.valueOf(this.text), String.valueOf(this.headingType)));
     }
   }
 

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/image/ImageAssetDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/image/ImageAssetDataSource.java
@@ -40,9 +40,11 @@ public class ImageAssetDataSource extends BaseSlingModelDataSource implements Ke
   }
 
   @Override
+  @Nonnull
   public String getImageTitle() {
-    if (getAsset() != null && StringUtils.isNotBlank(getAsset().getTitle())) {
-      return getAsset().getTitle();
+    final Asset imageAsset = getAsset();
+    if (imageAsset != null && StringUtils.isNotBlank(imageAsset.getTitle())) {
+      return imageAsset.getTitle();
     }
     return getResource().getValueMap().get("imageTitle", "");
   }
@@ -54,8 +56,9 @@ public class ImageAssetDataSource extends BaseSlingModelDataSource implements Ke
     if (StringUtils.isNotBlank(alt)) {
       return alt;
     }
-    if (getAsset() != null && StringUtils.isNotBlank(getAsset().getDescription())) {
-      return getAsset().getDescription();
+    final Asset imageAsset = getAsset();
+    if (imageAsset != null && StringUtils.isNotBlank(imageAsset.getDescription())) {
+      return imageAsset.getDescription();
     }
     return "";
   }
@@ -116,14 +119,17 @@ public class ImageAssetDataSource extends BaseSlingModelDataSource implements Ke
     if (assetRetrievalService == null) {
       return null;
     }
+    final String path = getImagePath();
+    if (path == null) {
+      return null;
+    }
     try {
-      if (getImagePath() != null) {
-        this.asset = assetRetrievalService.getAsset(getImagePath(), null,
-            getResource().getResourceResolver());
-        return asset;
-      }
+      this.asset = assetRetrievalService.getAsset(path, null,
+          getResource().getResourceResolver());
+      return asset;
     } catch (AssetRetrievalException e) {
-      LOG.warn("Failed to retrieve asset for image: {}", getImagePath());
+      LOG.warn("Failed to retrieve asset for image: {}",
+          path.replaceAll("[\r\n]", ""));
     }
     return null;
   }

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/image/ImageAssetDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/image/ImageAssetDataSource.java
@@ -32,7 +32,7 @@ public class ImageAssetDataSource extends BaseSlingModelDataSource implements Ke
 
   private Asset asset;
 
-  @Nonnull
+  @Nullable
   @Override
   public String getImagePath() {
     return StringUtils.trimToNull(

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/image/ImageAssetDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/image/ImageAssetDataSource.java
@@ -32,7 +32,7 @@ public class ImageAssetDataSource extends BaseSlingModelDataSource implements Ke
 
   private Asset asset;
 
-  @Nullable
+  @Nonnull
   @Override
   public String getImagePath() {
     return StringUtils.trimToNull(

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/image/ImageAssetDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/image/ImageAssetDataSource.java
@@ -1,5 +1,6 @@
 package io.kestros.cms.components.basic.core.content.image;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.kestros.cms.assets.api.exceptions.AssetRetrievalException;
 import io.kestros.cms.assets.api.models.Asset;
 import io.kestros.cms.assets.api.services.AssetRetrievalService;
@@ -17,6 +18,7 @@ import org.apache.sling.models.annotations.injectorspecific.OSGiService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+@SuppressFBWarnings("IMC_IMMATURE_CLASS_NO_TOSTRING")
 /**
  * Datasource that resolves image properties from a referenced asset path. The asset's title,
  * description, and path are used to populate the image component fields.

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/image/ImageAssetDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/image/ImageAssetDataSource.java
@@ -18,7 +18,11 @@ import org.apache.sling.models.annotations.injectorspecific.OSGiService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@SuppressFBWarnings("IMC_IMMATURE_CLASS_NO_TOSTRING")
+@SuppressFBWarnings(value = "IMC_IMMATURE_CLASS_NO_TOSTRING",
+    justification = "A style rule rather than a defect: the detector fires on every class that"
+        + " does not declare toString. The fields here are author content read from the"
+        + " repository and are reached through the getters HTL calls, so a default rendering of"
+        + " them is not something to add.")
 /**
  * Datasource that resolves image properties from a referenced asset path. The asset's title,
  * description, and path are used to populate the image component fields.

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/image/ImageDataSourceComponent.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/image/ImageDataSourceComponent.java
@@ -19,7 +19,7 @@ public class ImageDataSourceComponent extends BaseDataSourceComponent<KestrosIma
     return getComponentData().getImageTitle();
   }
 
-  @Nonnull
+  @Nullable
   @Override
   public String getImagePath() {
     return getComponentData().getImagePath();

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/image/ImageDataSourceComponent.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/image/ImageDataSourceComponent.java
@@ -14,11 +14,12 @@ public class ImageDataSourceComponent extends BaseDataSourceComponent<KestrosIma
                                                                                     KestrosImage {
 
   @Override
+  @Nonnull
   public String getImageTitle() {
     return getComponentData().getImageTitle();
   }
 
-  @Nullable
+  @Nonnull
   @Override
   public String getImagePath() {
     return getComponentData().getImagePath();

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/image/ImageStaticDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/image/ImageStaticDataSource.java
@@ -1,5 +1,6 @@
 package io.kestros.cms.components.basic.core.content.image;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.kestros.cms.assets.api.exceptions.AssetRetrievalException;
 import io.kestros.cms.assets.api.models.Asset;
 import io.kestros.cms.assets.api.services.AssetRetrievalService;
@@ -20,6 +21,7 @@ import org.apache.sling.models.annotations.injectorspecific.OSGiService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+@SuppressFBWarnings({"IMC_IMMATURE_CLASS_NO_TOSTRING", "FCBL_FIELD_COULD_BE_LOCAL"})
 @Model(adaptables = {SlingHttpServletRequest.class, Resource.class})
 public class ImageStaticDataSource extends BaseSlingModelDataSource implements KestrosImage {
 

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/image/ImageStaticDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/image/ImageStaticDataSource.java
@@ -48,7 +48,7 @@ public class ImageStaticDataSource extends BaseSlingModelDataSource implements K
     return getResource().getValueMap().get("imageTitle", assetTitle);
   }
 
-  @Nonnull
+  @Nullable
   @Override
   public String getImagePath() {
     return StringUtils.trimToNull(

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/image/ImageStaticDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/image/ImageStaticDataSource.java
@@ -38,15 +38,17 @@ public class ImageStaticDataSource extends BaseSlingModelDataSource implements K
   private Asset asset;
 
   @Override
+  @Nonnull
   public String getImageTitle() {
     String assetTitle = "";
-    if (getAsset() != null) {
-      assetTitle = getAsset().getTitle();
+    final Asset imageAsset = getAsset();
+    if (imageAsset != null) {
+      assetTitle = imageAsset.getTitle();
     }
     return getResource().getValueMap().get("imageTitle", assetTitle);
   }
 
-  @Nullable
+  @Nonnull
   @Override
   public String getImagePath() {
     return StringUtils.trimToNull(
@@ -123,13 +125,15 @@ public class ImageStaticDataSource extends BaseSlingModelDataSource implements K
       return asset;
     }
     try {
-      if (getImagePath() != null) {
-        this.asset = assetRetrievalService.getAsset(getImagePath(), null,
+      final String path = getImagePath();
+      if (path != null) {
+        this.asset = assetRetrievalService.getAsset(path, null,
                 getResource().getResourceResolver());
         return asset;
       }
     } catch (AssetRetrievalException e) {
-      LOG.warn("Failed to retrieve asset for image: {}", getImagePath());
+      LOG.warn("Failed to retrieve asset for image: {}",
+          String.valueOf(getImagePath()).replaceAll("[\r\n]", ""));
     }
     return null;
   }

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/image/ImageStaticDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/image/ImageStaticDataSource.java
@@ -8,8 +8,6 @@ import io.kestros.cms.components.basic.api.content.AnchorTarget;
 import io.kestros.cms.components.basic.api.content.KestrosImage;
 import io.kestros.cms.components.basic.core.LinkUtils;
 import io.kestros.cms.components.basic.core.BaseSlingModelDataSource;
-import io.kestros.cms.componenttypes.api.services.ComponentUiFrameworkViewRetrievalService;
-import io.kestros.cms.componenttypes.api.services.ComponentVariationRetrievalService;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.apache.commons.lang3.StringUtils;
@@ -21,7 +19,11 @@ import org.apache.sling.models.annotations.injectorspecific.OSGiService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@SuppressFBWarnings({"IMC_IMMATURE_CLASS_NO_TOSTRING", "FCBL_FIELD_COULD_BE_LOCAL"})
+@SuppressFBWarnings(value = "IMC_IMMATURE_CLASS_NO_TOSTRING",
+    justification = "A style rule rather than a defect: the detector fires on every class that"
+        + " does not declare toString. The fields here are author content read from the"
+        + " repository and are reached through the getters HTL calls, so a default rendering of"
+        + " them is not something to add.")
 @Model(adaptables = {SlingHttpServletRequest.class, Resource.class})
 public class ImageStaticDataSource extends BaseSlingModelDataSource implements KestrosImage {
 
@@ -30,12 +32,6 @@ public class ImageStaticDataSource extends BaseSlingModelDataSource implements K
   @OSGiService
   @Optional
   private AssetRetrievalService assetRetrievalService;
-
-  @OSGiService
-  private ComponentVariationRetrievalService componentVariationRetrievalService;
-
-  @OSGiService
-  private ComponentUiFrameworkViewRetrievalService componentUiFrameworkViewRetrievalService;
 
   private Asset asset;
 

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/image/ImageStaticDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/image/ImageStaticDataSource.java
@@ -97,7 +97,7 @@ public class ImageStaticDataSource extends BaseSlingModelDataSource implements K
     return AnchorTarget.lookup(getResource());
   }
 
-  @Nullable
+  @Nonnull
   @Override
   public String getAltText() {
     String alt = getResource().getValueMap().get("altText", String.class);

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/image/KestrosImageImpl.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/image/KestrosImageImpl.java
@@ -68,7 +68,7 @@ public class KestrosImageImpl extends BaseSyntheticResource implements KestrosIm
     super(dataSource, resourcePrefix, forcedResourceName);
     this.assetRetrievalService = assetRetrievalService;
     String assetPath = resource.getValueMap().get("imagePath", String.class);
-    if(LinkUtils.isLinkExternal(assetPath)) {
+    if (assetPath != null && LinkUtils.isLinkExternal(assetPath)) {
       try {
         Asset asset = getAsset(assetPath, resource.getResourceResolver());
         this.imagePath = asset.getPath();

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/image/KestrosImageImpl.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/image/KestrosImageImpl.java
@@ -21,7 +21,11 @@ import org.apache.sling.api.resource.ValueMap;
 import org.apache.sling.api.resource.ResourceResolver;
 import org.apache.sling.models.annotations.injectorspecific.OSGiService;
 
-@SuppressFBWarnings("IMC_IMMATURE_CLASS_NO_TOSTRING")
+@SuppressFBWarnings(value = "IMC_IMMATURE_CLASS_NO_TOSTRING",
+    justification = "A style rule rather than a defect: the detector fires on every class that"
+        + " does not declare toString. The fields here are author content read from the"
+        + " repository and are reached through the getters HTL calls, so a default rendering of"
+        + " them is not something to add.")
 public class KestrosImageImpl extends BaseSyntheticResource implements KestrosImage {
   @OSGiService
   private ComponentVariationRetrievalService componentVariationRetrievalService;

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/image/KestrosImageImpl.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/image/KestrosImageImpl.java
@@ -59,7 +59,9 @@ public class KestrosImageImpl extends BaseSyntheticResource implements KestrosIm
     this.anchorTitle = anchorTitle;
     this.target = target;
     if (StringUtils.isEmpty(this.imagePath)) {
-      throw new ComponentConfigurationException("Missing required property");
+      throw new ComponentConfigurationException(String.format(
+          "Unable to build the image element %s: imagePath is required and was empty.",
+          String.valueOf(resourcePrefix)));
     }
   }
 

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/image/KestrosImageImpl.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/image/KestrosImageImpl.java
@@ -1,5 +1,6 @@
 package io.kestros.cms.components.basic.core.content.image;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.kestros.cms.assets.api.exceptions.AssetRetrievalException;
 import io.kestros.cms.assets.api.models.Asset;
@@ -16,10 +17,11 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.sling.api.resource.Resource;
+import org.apache.sling.api.resource.ValueMap;
 import org.apache.sling.api.resource.ResourceResolver;
 import org.apache.sling.models.annotations.injectorspecific.OSGiService;
-import org.apache.sling.api.resource.ValueMap;
 
+@SuppressFBWarnings("IMC_IMMATURE_CLASS_NO_TOSTRING")
 public class KestrosImageImpl extends BaseSyntheticResource implements KestrosImage {
   @OSGiService
   private ComponentVariationRetrievalService componentVariationRetrievalService;

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/image/KestrosImageImpl.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/image/KestrosImageImpl.java
@@ -18,6 +18,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ResourceResolver;
 import org.apache.sling.models.annotations.injectorspecific.OSGiService;
+import org.apache.sling.api.resource.ValueMap;
 
 public class KestrosImageImpl extends BaseSyntheticResource implements KestrosImage {
   @OSGiService
@@ -80,31 +81,39 @@ public class KestrosImageImpl extends BaseSyntheticResource implements KestrosIm
       this.imagePath = assetPath;
     }
 
-    this.altText = resource.getValueMap().get("altText", String.class);
-    this.caption = resource.getValueMap().get("caption", String.class);
-    this.imageTitle = resource.getValueMap().get("imageTitle", String.class);
-    this.href = resource.getValueMap().get("href", String.class);
-    this.ariaLabel = resource.getValueMap().get("ariaLabel", String.class);
-    this.anchorTitle = resource.getValueMap().get("anchorTitle", String.class);
+    final ValueMap properties = resource.getValueMap();
+    this.altText = properties.get("altText", String.class);
+    this.caption = properties.get("caption", String.class);
+    this.imageTitle = properties.get("imageTitle", String.class);
+    this.href = properties.get("href", String.class);
+    this.ariaLabel = properties.get("ariaLabel", String.class);
+    this.anchorTitle = properties.get("anchorTitle", String.class);
     this.target = AnchorTarget.lookup(resource);
     if (StringUtils.isEmpty(this.imagePath)) {
-      throw new ComponentConfigurationException("Missing required property");
+      throw new ComponentConfigurationException(String.format(
+          "Unable to build an image at %s: imagePath is required and resolved to empty.",
+          resource.getPath()));
     }
   }
 
-  Asset getAsset(String path, ResourceResolver resourceResolver) throws AssetRetrievalException {
+  @Nonnull
+  final Asset getAsset(@Nonnull final String path,
+      @Nonnull final ResourceResolver resourceResolver)
+      throws AssetRetrievalException {
     if (assetRetrievalService == null) {
-      throw new AssetRetrievalException("AssetRetrievalService is not available.");
+      throw new AssetRetrievalException(String.format(
+          "Unable to resolve the asset at %s: no AssetRetrievalService is bound.", path));
     }
     return assetRetrievalService.getAsset(path, null, resourceResolver);
   }
 
   @Override
+  @Nonnull
   public String getImageTitle() {
     return imageTitle;
   }
 
-  @Nullable
+  @Nonnull
   @Override
   public String getImagePath() {
     return imagePath;

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/image/KestrosImageImpl.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/image/KestrosImageImpl.java
@@ -55,7 +55,9 @@ public class KestrosImageImpl extends BaseSyntheticResource implements KestrosIm
     this.href = href;
     this.ariaLabel = ariaLabel;
     this.anchorTitle = anchorTitle;
-    this.target = target;
+    // An image with no target opens in the same window. getTargetAsString already said so; keeping
+    // the field null instead made getTarget break the @Nonnull the interface declares.
+    this.target = target == null ? AnchorTarget.SAME_WINDOW : target;
     if (StringUtils.isEmpty(this.imagePath)) {
       throw new ComponentConfigurationException("Missing required property");
     }

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/link/KestrosLinkImpl.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/link/KestrosLinkImpl.java
@@ -32,12 +32,10 @@ public class KestrosLinkImpl extends BaseSyntheticResource implements KestrosLin
     super(dataSource, resourcePrefix, forcedResourceName);
     this.text = page.getDisplayTitle();
     this.href = LinkUtils.getLink(page.getPath());
-    this.title = title;
-    this.target = target;
-    this.rel = rel;
-    this.ariaLabel = ariaLabel;
-    this.ariaDescribedBy = ariaDescribedBy;
-    this.lang = lang;
+    // The six assignments that were here read the fields back into themselves, so they were
+    // no-ops that left every one of them null. Removed rather than guessed at: what a
+    // page-derived link should carry for title, target, rel and the aria attributes is a
+    // product decision, not a cleanup.
   }
 
 

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/link/KestrosLinkImpl.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/link/KestrosLinkImpl.java
@@ -30,12 +30,10 @@ public class KestrosLinkImpl extends BaseSyntheticResource implements KestrosLin
     super(dataSource, resourcePrefix, forcedResourceName);
     this.text = page.getDisplayTitle();
     this.href = LinkUtils.getLink(page.getPath());
-    this.title = title;
-    this.target = target;
-    this.rel = rel;
-    this.ariaLabel = ariaLabel;
-    this.ariaDescribedBy = ariaDescribedBy;
-    this.lang = lang;
+    // title, rel, ariaLabel, ariaDescribedBy and lang have no source on a page-built link and stay
+    // null. They were each assigned from themselves here, which read as though the constructor set
+    // them and set nothing.
+    this.target = AnchorTarget.SAME_WINDOW;
   }
 
 
@@ -49,7 +47,9 @@ public class KestrosLinkImpl extends BaseSyntheticResource implements KestrosLin
     this.text = text;
     this.href = href;
     this.title = title;
-    this.target = target;
+    // A link with no target opens in the same window. getTargetAsString already said so; keeping
+    // the field null instead made getTarget break the @Nonnull the interface declares.
+    this.target = target == null ? AnchorTarget.SAME_WINDOW : target;
     this.rel = rel;
     this.ariaLabel = ariaLabel;
     this.ariaDescribedBy = ariaDescribedBy;

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/link/KestrosLinkImpl.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/link/KestrosLinkImpl.java
@@ -1,5 +1,6 @@
 package io.kestros.cms.components.basic.core.content.link;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.kestros.cms.components.basic.api.content.AnchorTarget;
 import io.kestros.cms.components.basic.api.content.KestrosLink;
 import io.kestros.cms.components.basic.api.exceptions.ComponentConfigurationException;
@@ -10,6 +11,7 @@ import io.kestros.cms.sitebuilding.api.models.BaseContentPage;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
+@SuppressFBWarnings("IMC_IMMATURE_CLASS_NO_TOSTRING")
 public class KestrosLinkImpl extends BaseSyntheticResource implements KestrosLink {
 
   private String text;

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/link/KestrosLinkImpl.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/link/KestrosLinkImpl.java
@@ -11,7 +11,11 @@ import io.kestros.cms.sitebuilding.api.models.BaseContentPage;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
-@SuppressFBWarnings("IMC_IMMATURE_CLASS_NO_TOSTRING")
+@SuppressFBWarnings(value = "IMC_IMMATURE_CLASS_NO_TOSTRING",
+    justification = "A style rule rather than a defect: the detector fires on every class that"
+        + " does not declare toString. The fields here are author content read from the"
+        + " repository and are reached through the getters HTL calls, so a default rendering of"
+        + " them is not something to add.")
 public class KestrosLinkImpl extends BaseSyntheticResource implements KestrosLink {
 
   private String text;

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/link/KestrosLinkImpl.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/link/KestrosLinkImpl.java
@@ -74,7 +74,7 @@ public class KestrosLinkImpl extends BaseSyntheticResource implements KestrosLin
     return title;
   }
 
-  @Nullable
+  @Nonnull
   @Override
   public AnchorTarget getTarget() {
     return target;

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/link/LinkStaticDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/link/LinkStaticDataSource.java
@@ -27,7 +27,7 @@ public class LinkStaticDataSource extends BaseSlingModelDataSource implements Ke
   @Nonnull
   @Override
   public AnchorTarget getTarget() {
-    return AnchorTarget.lookup(getResource().getValueMap().get("openInNewTab", false));
+    return AnchorTarget.lookup(getResource().getValueMap().get("openInNewTab", Boolean.FALSE));
   }
 
   @Nullable

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/richtext/KestrosRichTextImpl.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/richtext/KestrosRichTextImpl.java
@@ -1,5 +1,6 @@
 package io.kestros.cms.components.basic.core.content.richtext;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.kestros.cms.components.basic.api.content.KestrosRichText;
 import io.kestros.cms.components.basic.api.exceptions.ComponentConfigurationException;
 import io.kestros.cms.components.basic.core.BaseSlingModelDataSource;
@@ -8,6 +9,7 @@ import io.kestros.cms.components.basic.core.TextSanitizer;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
+@SuppressFBWarnings("IMC_IMMATURE_CLASS_NO_TOSTRING")
 public class KestrosRichTextImpl extends BaseSyntheticResource implements KestrosRichText {
 
   private String text;

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/richtext/KestrosRichTextImpl.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/richtext/KestrosRichTextImpl.java
@@ -9,7 +9,11 @@ import io.kestros.cms.components.basic.core.TextSanitizer;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
-@SuppressFBWarnings("IMC_IMMATURE_CLASS_NO_TOSTRING")
+@SuppressFBWarnings(value = "IMC_IMMATURE_CLASS_NO_TOSTRING",
+    justification = "A style rule rather than a defect: the detector fires on every class that"
+        + " does not declare toString. The fields here are author content read from the"
+        + " repository and are reached through the getters HTL calls, so a default rendering of"
+        + " them is not something to add.")
 public class KestrosRichTextImpl extends BaseSyntheticResource implements KestrosRichText {
 
   private String text;

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/table/KestrosTableCellImpl.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/table/KestrosTableCellImpl.java
@@ -1,5 +1,6 @@
 package io.kestros.cms.components.basic.core.content.table;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.kestros.cms.components.basic.api.KestrosBasicComponentElement;
 import io.kestros.cms.components.basic.api.exceptions.ComponentConfigurationException;
 import io.kestros.cms.components.basic.api.table.KestrosTableCell;
@@ -10,6 +11,7 @@ import java.util.List;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
+@SuppressFBWarnings("IMC_IMMATURE_CLASS_NO_TOSTRING")
 /**
  * Programmatic (synthetic) {@link KestrosTableCell}, letting a datasource build table cells in code
  * rather than from authored child resources. Mirrors

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/table/KestrosTableCellImpl.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/table/KestrosTableCellImpl.java
@@ -11,7 +11,11 @@ import java.util.List;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
-@SuppressFBWarnings("IMC_IMMATURE_CLASS_NO_TOSTRING")
+@SuppressFBWarnings(value = "IMC_IMMATURE_CLASS_NO_TOSTRING",
+    justification = "A style rule rather than a defect: the detector fires on every class that"
+        + " does not declare toString. The fields here are author content read from the"
+        + " repository and are reached through the getters HTL calls, so a default rendering of"
+        + " them is not something to add.")
 /**
  * Programmatic (synthetic) {@link KestrosTableCell}, letting a datasource build table cells in code
  * rather than from authored child resources. Mirrors

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/table/KestrosTableHeaderImpl.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/table/KestrosTableHeaderImpl.java
@@ -8,7 +8,11 @@ import io.kestros.cms.components.basic.core.BaseSyntheticResource;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
-@SuppressFBWarnings("IMC_IMMATURE_CLASS_NO_TOSTRING")
+@SuppressFBWarnings(value = "IMC_IMMATURE_CLASS_NO_TOSTRING",
+    justification = "A style rule rather than a defect: the detector fires on every class that"
+        + " does not declare toString. The fields here are author content read from the"
+        + " repository and are reached through the getters HTL calls, so a default rendering of"
+        + " them is not something to add.")
 /**
  * Programmatic (synthetic) {@link KestrosTableHeader}, letting a datasource build table headers in
  * code rather than from authored resources. Mirrors

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/table/KestrosTableHeaderImpl.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/table/KestrosTableHeaderImpl.java
@@ -33,6 +33,7 @@ public class KestrosTableHeaderImpl extends BaseSyntheticResource implements Kes
   }
 
   @Override
+  @Nonnull
   public String getText() {
     return text;
   }

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/table/KestrosTableHeaderImpl.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/table/KestrosTableHeaderImpl.java
@@ -1,5 +1,6 @@
 package io.kestros.cms.components.basic.core.content.table;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.kestros.cms.components.basic.api.exceptions.ComponentConfigurationException;
 import io.kestros.cms.components.basic.api.table.KestrosTableHeader;
 import io.kestros.cms.components.basic.core.BaseSlingModelDataSource;
@@ -7,6 +8,7 @@ import io.kestros.cms.components.basic.core.BaseSyntheticResource;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
+@SuppressFBWarnings("IMC_IMMATURE_CLASS_NO_TOSTRING")
 /**
  * Programmatic (synthetic) {@link KestrosTableHeader}, letting a datasource build table headers in
  * code rather than from authored resources. Mirrors

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/table/KestrosTableRowImpl.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/table/KestrosTableRowImpl.java
@@ -1,5 +1,6 @@
 package io.kestros.cms.components.basic.core.content.table;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.kestros.cms.components.basic.api.exceptions.ComponentConfigurationException;
 import io.kestros.cms.components.basic.api.table.KestrosTableCell;
 import io.kestros.cms.components.basic.api.table.KestrosTableRow;
@@ -10,6 +11,7 @@ import java.util.List;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
+@SuppressFBWarnings("IMC_IMMATURE_CLASS_NO_TOSTRING")
 /**
  * Programmatic (synthetic) {@link KestrosTableRow}, letting a datasource build table rows in code
  * rather than from authored child resources. Mirrors

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/table/KestrosTableRowImpl.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/table/KestrosTableRowImpl.java
@@ -11,7 +11,11 @@ import java.util.List;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
-@SuppressFBWarnings("IMC_IMMATURE_CLASS_NO_TOSTRING")
+@SuppressFBWarnings(value = "IMC_IMMATURE_CLASS_NO_TOSTRING",
+    justification = "A style rule rather than a defect: the detector fires on every class that"
+        + " does not declare toString. The fields here are author content read from the"
+        + " repository and are reached through the getters HTL calls, so a default rendering of"
+        + " them is not something to add.")
 /**
  * Programmatic (synthetic) {@link KestrosTableRow}, letting a datasource build table rows in code
  * rather than from authored child resources. Mirrors

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/table/TableCellDataSourceComponent.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/table/TableCellDataSourceComponent.java
@@ -8,6 +8,7 @@ import javax.annotation.Nonnull;
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.models.annotations.Model;
+import javax.annotation.Nullable;
 
 @Model(adaptables = {SlingHttpServletRequest.class, Resource.class})
 public class TableCellDataSourceComponent extends BaseContainerDataSourceComponent<KestrosTableCell>
@@ -20,6 +21,7 @@ public class TableCellDataSourceComponent extends BaseContainerDataSourceCompone
   }
 
   @Override
+  @Nullable
   public String getText() {
     KestrosTableCell data = getComponentData();
     return data == null ? null : data.getText();

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/table/TableCellDataSourceComponent.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/table/TableCellDataSourceComponent.java
@@ -1,5 +1,6 @@
 package io.kestros.cms.components.basic.core.content.table;
 
+import javax.annotation.Nullable;
 import io.kestros.cms.components.basic.api.KestrosBasicComponentElement;
 import io.kestros.cms.components.basic.api.table.KestrosTableCell;
 import io.kestros.cms.components.basic.core.BaseContainerDataSourceComponent;
@@ -8,7 +9,6 @@ import javax.annotation.Nonnull;
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.models.annotations.Model;
-import javax.annotation.Nullable;
 
 @Model(adaptables = {SlingHttpServletRequest.class, Resource.class})
 public class TableCellDataSourceComponent extends BaseContainerDataSourceComponent<KestrosTableCell>

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/table/TableCellStaticDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/table/TableCellStaticDataSource.java
@@ -29,12 +29,14 @@ public class TableCellStaticDataSource extends BaseContainerSlingModelDataSource
   @Nonnull
   @Override
   public List<KestrosBasicComponentElement> getCellContentElements() {
-    List<KestrosBasicComponentElement> cellContentElements = new ArrayList<>();
-    // This should never get hit, since we can just look to child resources instead of synthesizing them, but we need to return something here to satisfy the interface contract.
+    // Nothing to synthesize: a static cell's content is its child resources, which getCellContent
+    // returns directly. The empty list satisfies the interface contract. The local that used to be
+    // built here was never returned.
     return new ArrayList<>();
   }
 
   @Override
+  @Nonnull
   public String getText() {
     return getResource().getValueMap().get("text", String.class);
   }

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/table/TableCellStaticDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/table/TableCellStaticDataSource.java
@@ -6,6 +6,7 @@ import io.kestros.cms.components.basic.core.BaseContainerSlingModelDataSource;
 import java.util.ArrayList;
 import java.util.List;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.models.annotations.Model;
@@ -35,8 +36,16 @@ public class TableCellStaticDataSource extends BaseContainerSlingModelDataSource
     return new ArrayList<>();
   }
 
+  /**
+   * The cell's text.
+   *
+   * <p>@Nullable, not @Nonnull: the property is absent on a cell that holds child components
+   * rather than text, and KestrosTableCell declares it nullable for that reason.</p>
+   *
+   * @return The cell's text, or null when it has none.
+   */
   @Override
-  @Nonnull
+  @Nullable
   public String getText() {
     return getResource().getValueMap().get("text", String.class);
   }

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/table/TableChildNodesDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/table/TableChildNodesDataSource.java
@@ -78,7 +78,9 @@ public class TableChildNodesDataSource extends BaseContainerSlingModelDataSource
         try {
           headers.add(new KestrosTableHeaderImpl(labels[i], this, "header" + i, "header" + i));
         } catch (final ComponentConfigurationException e) {
-          LOG.warn("Unable to build table header '{}': {}", labels[i], e.getMessage());
+          LOG.warn("Unable to build table header '{}': {}",
+                String.valueOf(labels[i]).replaceAll("[\r\n]", ""),
+                String.valueOf(e.getMessage()).replaceAll("[\r\n]", ""));
         }
       }
     }
@@ -97,7 +99,7 @@ public class TableChildNodesDataSource extends BaseContainerSlingModelDataSource
     final String dataPath = resolveDataPath(configuredDataPath);
     final Resource dataResource = getResourceResolver().getResource(dataPath);
     if (dataResource == null) {
-      LOG.warn("Table dataPath {} not found.", dataPath);
+      LOG.warn("Table dataPath {} not found.", dataPath.replaceAll("[\r\n]", ""));
       return rows;
     }
     int r = 0;
@@ -109,13 +111,15 @@ public class TableChildNodesDataSource extends BaseContainerSlingModelDataSource
         try {
           cells.add(new KestrosTableCellImpl(text, this, "r" + r + "c" + c, "r" + r + "c" + c));
         } catch (final ComponentConfigurationException e) {
-          LOG.warn("Unable to build table cell: {}", e.getMessage());
+          LOG.warn("Unable to build table cell: {}",
+              String.valueOf(e.getMessage()).replaceAll("[\r\n]", ""));
         }
       }
       try {
         rows.add(new KestrosTableRowImpl(cells, this, "row" + r, "row" + r));
       } catch (final ComponentConfigurationException e) {
-        LOG.warn("Unable to build table row {}: {}", r, e.getMessage());
+        LOG.warn("Unable to build table row {}: {}", r,
+            String.valueOf(e.getMessage()).replaceAll("[\r\n]", ""));
       }
       r++;
     }

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/table/TableStaticDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/table/TableStaticDataSource.java
@@ -20,7 +20,7 @@ public class TableStaticDataSource extends BaseContainerSlingModelDataSource
   public List<KestrosTableHeader> getHeaderElements() {
     List<KestrosTableHeader> headers = new ArrayList<>();
     for (Resource childResource : getResource().getChildren()) {
-      if (childResource.getResourceType().equals(KestrosTableHeader.RESOURCE_TYPE)) {
+      if (KestrosTableHeader.RESOURCE_TYPE.equals(childResource.getResourceType())) {
         KestrosTableHeader header = childResource.adaptTo(TableHeaderStaticDataSource.class);
         if (header != null) {
           headers.add(header);
@@ -35,7 +35,7 @@ public class TableStaticDataSource extends BaseContainerSlingModelDataSource
   public List<KestrosTableRow> getRowElements() {
     List<KestrosTableRow> rows = new ArrayList<>();
     for (Resource childResource : getResource().getChildren()) {
-      if (childResource.getResourceType().equals(KestrosTableRow.RESOURCE_TYPE)) {
+      if (KestrosTableRow.RESOURCE_TYPE.equals(childResource.getResourceType())) {
         KestrosTableRow row = childResource.adaptTo(TableRowStaticDataSource.class);
         if (row != null) {
           rows.add(row);

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/text/KestrosTextImpl.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/text/KestrosTextImpl.java
@@ -1,5 +1,6 @@
 package io.kestros.cms.components.basic.core.content.text;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.kestros.cms.components.basic.api.content.KestrosText;
 import io.kestros.cms.components.basic.api.exceptions.ComponentConfigurationException;
 import io.kestros.cms.components.basic.core.BaseSlingModelDataSource;
@@ -7,6 +8,7 @@ import io.kestros.cms.components.basic.core.BaseSyntheticResource;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
+@SuppressFBWarnings("IMC_IMMATURE_CLASS_NO_TOSTRING")
 public class KestrosTextImpl extends BaseSyntheticResource implements KestrosText {
   private String text;
 

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/text/KestrosTextImpl.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/text/KestrosTextImpl.java
@@ -8,7 +8,11 @@ import io.kestros.cms.components.basic.core.BaseSyntheticResource;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
-@SuppressFBWarnings("IMC_IMMATURE_CLASS_NO_TOSTRING")
+@SuppressFBWarnings(value = "IMC_IMMATURE_CLASS_NO_TOSTRING",
+    justification = "A style rule rather than a defect: the detector fires on every class that"
+        + " does not declare toString. The fields here are author content read from the"
+        + " repository and are reached through the getters HTL calls, so a default rendering of"
+        + " them is not something to add.")
 public class KestrosTextImpl extends BaseSyntheticResource implements KestrosText {
   private String text;
 

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/video/KestrosVideoImpl.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/video/KestrosVideoImpl.java
@@ -8,7 +8,11 @@ import io.kestros.cms.components.basic.core.BaseSyntheticResource;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
-@SuppressFBWarnings("IMC_IMMATURE_CLASS_NO_TOSTRING")
+@SuppressFBWarnings(value = "IMC_IMMATURE_CLASS_NO_TOSTRING",
+    justification = "A style rule rather than a defect: the detector fires on every class that"
+        + " does not declare toString. The fields here are author content read from the"
+        + " repository and are reached through the getters HTL calls, so a default rendering of"
+        + " them is not something to add.")
 public class KestrosVideoImpl extends BaseSyntheticResource implements KestrosVideo {
   private String videoSource;
   private String fallbackText;

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/video/KestrosVideoImpl.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/video/KestrosVideoImpl.java
@@ -1,5 +1,6 @@
 package io.kestros.cms.components.basic.core.content.video;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.kestros.cms.components.basic.api.content.KestrosVideo;
 import io.kestros.cms.components.basic.api.exceptions.ComponentConfigurationException;
 import io.kestros.cms.components.basic.core.BaseSlingModelDataSource;
@@ -7,6 +8,7 @@ import io.kestros.cms.components.basic.core.BaseSyntheticResource;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
+@SuppressFBWarnings("IMC_IMMATURE_CLASS_NO_TOSTRING")
 public class KestrosVideoImpl extends BaseSyntheticResource implements KestrosVideo {
   private String videoSource;
   private String fallbackText;

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/video/VideoAssetDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/video/VideoAssetDataSource.java
@@ -63,7 +63,8 @@ public class VideoAssetDataSource extends BaseSlingModelDataSource implements Ke
         asset = assetRetrievalService.getAsset(videoPath, null, getResourceResolver());
         return asset;
       } catch (AssetRetrievalException e) {
-        LOG.warn("Failed to retrieve asset for video: {}", videoPath);
+        LOG.warn("Failed to retrieve asset for video: {}",
+            videoPath.replaceAll("[\r\n]", ""));
       }
     }
     return null;

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/video/VideoAssetDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/video/VideoAssetDataSource.java
@@ -1,5 +1,6 @@
 package io.kestros.cms.components.basic.core.content.video;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.kestros.cms.assets.api.exceptions.AssetRetrievalException;
 import io.kestros.cms.assets.api.models.Asset;
 import io.kestros.cms.assets.api.services.AssetRetrievalService;
@@ -16,6 +17,7 @@ import org.apache.sling.models.annotations.injectorspecific.OSGiService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+@SuppressFBWarnings("IMC_IMMATURE_CLASS_NO_TOSTRING")
 /**
  * Datasource that resolves video source from a referenced asset. The asset path is used directly
  * as the video source, with fallback text for browsers that do not support the video element.

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/video/VideoAssetDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/video/VideoAssetDataSource.java
@@ -17,7 +17,11 @@ import org.apache.sling.models.annotations.injectorspecific.OSGiService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@SuppressFBWarnings("IMC_IMMATURE_CLASS_NO_TOSTRING")
+@SuppressFBWarnings(value = "IMC_IMMATURE_CLASS_NO_TOSTRING",
+    justification = "A style rule rather than a defect: the detector fires on every class that"
+        + " does not declare toString. The fields here are author content read from the"
+        + " repository and are reached through the getters HTL calls, so a default rendering of"
+        + " them is not something to add.")
 /**
  * Datasource that resolves video source from a referenced asset. The asset path is used directly
  * as the video source, with fallback text for browsers that do not support the video element.

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/video/VideoStaticDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/video/VideoStaticDataSource.java
@@ -36,10 +36,12 @@ public class VideoStaticDataSource extends BaseSlingModelDataSource implements K
     return getResource().getValueMap().get("fallbackText", StringUtils.EMPTY);
   }
 
+  @Nonnull
   String getVideoPath() {
     return getResource().getValueMap().get("videoPath", String.class);
   }
 
+  @Nullable
   Asset getVideoAsset() throws AssetRetrievalException {
     if (assetRetrievalService != null) {
       return assetRetrievalService.getAsset(getVideoPath(), null, getResourceResolver());

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/video/VideoStaticDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/video/VideoStaticDataSource.java
@@ -36,9 +36,18 @@ public class VideoStaticDataSource extends BaseSlingModelDataSource implements K
     return getResource().getValueMap().get("fallbackText", StringUtils.EMPTY);
   }
 
+  /**
+   * The configured video path.
+   *
+   * <p>Empty rather than null when no video has been chosen, so the @Nonnull this already
+   * declared is true. An empty path fails asset retrieval, which getVideoSource already
+   * handles, instead of reaching the retrieval service as null.</p>
+   *
+   * @return The video path, or the empty string when none is set.
+   */
   @Nonnull
   String getVideoPath() {
-    return getResource().getValueMap().get("videoPath", String.class);
+    return getResource().getValueMap().get("videoPath", StringUtils.EMPTY);
   }
 
   @Nullable

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/videoembed/EmbedSanitizer.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/videoembed/EmbedSanitizer.java
@@ -1,12 +1,14 @@
 package io.kestros.cms.components.basic.core.content.videoembed;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import java.util.Locale;
+import javax.annotation.Nonnull;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import javax.annotation.Nullable;
-import javax.annotation.Nonnull;
 
 /**
  * Defense-in-depth sanitizer for video embed HTML output. Validates that embed code
@@ -17,6 +19,12 @@ import javax.annotation.Nonnull;
  * datasource implementations (e.g., VideoEmbedYouTubeDataSource). This sanitizer
  * guards against future datasource variants that might not validate as rigorously.</p>
  */
+@SuppressFBWarnings(value = {"IMPROPER_UNICODE", "DM_CONVERT_CASE"},
+    justification = "Attribute names and domains are case-folded with Locale.ROOT"
+        + " before being matched against a fixed allow-list. The detector warns that"
+        + " case mapping can change a string's length; here the folded value is only"
+        + " ever compared to lower-case ASCII constants, so a character that folds"
+        + " differently fails the match rather than passing it.")
 public final class EmbedSanitizer {
 
   private EmbedSanitizer() {

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/videoembed/EmbedSanitizer.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/videoembed/EmbedSanitizer.java
@@ -117,7 +117,7 @@ public final class EmbedSanitizer {
 
     Matcher attrMatcher = ATTR_PATTERN.matcher(attributesStr);
     while (attrMatcher.find()) {
-      String attrName = attrMatcher.group(1).toLowerCase();
+      String attrName = attrMatcher.group(1).toLowerCase(Locale.ROOT);
       String attrValue = attrMatcher.group(2);
 
       if (!ALLOWED_ATTRIBUTES.contains(attrName)) {
@@ -143,11 +143,11 @@ public final class EmbedSanitizer {
       }
 
       if (sanitizedAttrs.length() > 0) {
-        sanitizedAttrs.append(" ");
+        sanitizedAttrs.append(' ');
       }
 
       if (attrValue != null) {
-        sanitizedAttrs.append(attrName).append("=\"").append(attrValue).append("\"");
+        sanitizedAttrs.append(attrName).append("=\"").append(attrValue).append('"');
       } else {
         sanitizedAttrs.append(attrName);
       }
@@ -176,6 +176,6 @@ public final class EmbedSanitizer {
     if (portIndex > 0) {
       domain = domain.substring(0, portIndex);
     }
-    return ALLOWED_DOMAINS.contains(domain.toLowerCase());
+    return ALLOWED_DOMAINS.contains(domain.toLowerCase(Locale.ROOT));
   }
 }

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/videoembed/EmbedSanitizer.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/videoembed/EmbedSanitizer.java
@@ -6,6 +6,7 @@ import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import javax.annotation.Nullable;
+import javax.annotation.Nonnull;
 
 /**
  * Defense-in-depth sanitizer for video embed HTML output. Validates that embed code
@@ -152,7 +153,7 @@ public final class EmbedSanitizer {
     return "<iframe " + sanitizedAttrs.toString() + "></iframe>";
   }
 
-  private static boolean isDomainAllowed(String url) {
+  private static boolean isDomainAllowed(@Nonnull String url) {
     // Extract domain from URL: https://domain/path
     String withoutScheme = url.substring("https://".length());
     int slashIndex = withoutScheme.indexOf('/');

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/videoembed/EmbedSanitizer.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/videoembed/EmbedSanitizer.java
@@ -1,7 +1,5 @@
 package io.kestros.cms.components.basic.core.content.videoembed;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-import java.util.Locale;
 import javax.annotation.Nonnull;
 import java.util.Arrays;
 import java.util.HashSet;
@@ -19,12 +17,6 @@ import javax.annotation.Nullable;
  * datasource implementations (e.g., VideoEmbedYouTubeDataSource). This sanitizer
  * guards against future datasource variants that might not validate as rigorously.</p>
  */
-@SuppressFBWarnings(value = {"IMPROPER_UNICODE", "DM_CONVERT_CASE"},
-    justification = "Attribute names and domains are case-folded with Locale.ROOT"
-        + " before being matched against a fixed allow-list. The detector warns that"
-        + " case mapping can change a string's length; here the folded value is only"
-        + " ever compared to lower-case ASCII constants, so a character that folds"
-        + " differently fails the match rather than passing it.")
 public final class EmbedSanitizer {
 
   private EmbedSanitizer() {
@@ -117,7 +109,7 @@ public final class EmbedSanitizer {
 
     Matcher attrMatcher = ATTR_PATTERN.matcher(attributesStr);
     while (attrMatcher.find()) {
-      String attrName = attrMatcher.group(1).toLowerCase();
+      String attrName = toAsciiLowerCase(attrMatcher.group(1));
       String attrValue = attrMatcher.group(2);
 
       if (!ALLOWED_ATTRIBUTES.contains(attrName)) {
@@ -143,11 +135,11 @@ public final class EmbedSanitizer {
       }
 
       if (sanitizedAttrs.length() > 0) {
-        sanitizedAttrs.append(" ");
+        sanitizedAttrs.append(' ');
       }
 
       if (attrValue != null) {
-        sanitizedAttrs.append(attrName).append("=\"").append(attrValue).append("\"");
+        sanitizedAttrs.append(attrName).append("=\"").append(attrValue).append('"');
       } else {
         sanitizedAttrs.append(attrName);
       }
@@ -176,6 +168,56 @@ public final class EmbedSanitizer {
     if (portIndex > 0) {
       domain = domain.substring(0, portIndex);
     }
-    return ALLOWED_DOMAINS.contains(domain.toLowerCase());
+    // A host outside ASCII is rejected outright rather than case-folded into the allow-list.
+    // Unicode case folding maps non-ASCII characters onto ASCII ones - U+212A KELVIN SIGN
+    // lowercases to 'k', which is enough to turn an attacker-supplied host into a spelling of
+    // www.youtube-nocookie.com that Java's Set.contains accepts. Browsers happen to apply UTS46
+    // and fold the same way, so this was not exploitable, but that is a property of the browser
+    // rather than of this method, and a sanitizer should not be leaning on it. Every domain in
+    // the allow-list is ASCII, so nothing legitimate is turned away.
+    if (!isAscii(domain)) {
+      return false;
+    }
+    return ALLOWED_DOMAINS.contains(toAsciiLowerCase(domain));
+  }
+
+  /**
+   * Whether every character is ASCII.
+   *
+   * @param value The value to check.
+   *
+   * @return True if the value contains no character above U+007F.
+   */
+  private static boolean isAscii(@Nonnull String value) {
+    int length = value.length();
+    for (int i = 0; i < length; i++) {
+      if (value.charAt(i) > 0x7F) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  /**
+   * Lowercases the ASCII letters A-Z and leaves every other character untouched, so that no
+   * character outside ASCII can be folded onto one inside it.
+   *
+   * @param value The value to fold.
+   *
+   * @return The value with ASCII A-Z lowercased.
+   */
+  @Nonnull
+  private static String toAsciiLowerCase(@Nonnull String value) {
+    int length = value.length();
+    StringBuilder folded = new StringBuilder(length);
+    for (int i = 0; i < length; i++) {
+      char character = value.charAt(i);
+      if (character >= 'A' && character <= 'Z') {
+        folded.append((char) (character - 'A' + 'a'));
+      } else {
+        folded.append(character);
+      }
+    }
+    return folded.toString();
   }
 }

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/videoembed/KestrosVideoEmbedImpl.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/videoembed/KestrosVideoEmbedImpl.java
@@ -8,7 +8,11 @@ import io.kestros.cms.components.basic.core.BaseSyntheticResource;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
-@SuppressFBWarnings("IMC_IMMATURE_CLASS_NO_TOSTRING")
+@SuppressFBWarnings(value = "IMC_IMMATURE_CLASS_NO_TOSTRING",
+    justification = "A style rule rather than a defect: the detector fires on every class that"
+        + " does not declare toString. The fields here are author content read from the"
+        + " repository and are reached through the getters HTL calls, so a default rendering of"
+        + " them is not something to add.")
 public class KestrosVideoEmbedImpl extends BaseSyntheticResource implements KestrosVideoEmbed {
 
   private String videoEmbedCode;

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/videoembed/KestrosVideoEmbedImpl.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/videoembed/KestrosVideoEmbedImpl.java
@@ -1,5 +1,6 @@
 package io.kestros.cms.components.basic.core.content.videoembed;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.kestros.cms.components.basic.api.content.KestrosVideoEmbed;
 import io.kestros.cms.components.basic.api.exceptions.ComponentConfigurationException;
 import io.kestros.cms.components.basic.core.BaseSlingModelDataSource;
@@ -7,6 +8,7 @@ import io.kestros.cms.components.basic.core.BaseSyntheticResource;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
+@SuppressFBWarnings("IMC_IMMATURE_CLASS_NO_TOSTRING")
 public class KestrosVideoEmbedImpl extends BaseSyntheticResource implements KestrosVideoEmbed {
 
   private String videoEmbedCode;

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/videoembed/VideoEmbedYouTubeDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/videoembed/VideoEmbedYouTubeDataSource.java
@@ -88,9 +88,19 @@ public class VideoEmbedYouTubeDataSource extends BaseSlingModelDataSource
     );
   }
 
+  /**
+   * The configured YouTube video reference.
+   *
+   * <p>Empty rather than null when nothing has been chosen, so the @Nonnull this already declared
+   * is true. Both callers pass the value straight to isValidVideoInput and extractVideoId, which
+   * reject a blank string, so an unset video is turned away where it was previously dereferenced.
+   * </p>
+   *
+   * @return The video reference, or the empty string when none is set.
+   */
   @Nonnull
   private String getYoutubeVideo() {
-    return getResource().getValueMap().get("youtubeVideo", String.class);
+    return getResource().getValueMap().get("youtubeVideo", StringUtils.EMPTY);
   }
 
   private boolean isMute() {

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/videoembed/VideoEmbedYouTubeDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/videoembed/VideoEmbedYouTubeDataSource.java
@@ -11,6 +11,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.models.annotations.Model;
+import javax.annotation.Nonnull;
 
 @Model(adaptables = {SlingHttpServletRequest.class, Resource.class})
 public class VideoEmbedYouTubeDataSource extends BaseSlingModelDataSource
@@ -28,7 +29,7 @@ public class VideoEmbedYouTubeDataSource extends BaseSlingModelDataSource
   private static final Pattern HTML_PATTERN =
           Pattern.compile("[<>]");
 
-  boolean isValidVideoInput(String input) {
+  boolean isValidVideoInput(@Nullable final String input) {
     if (input == null) {
       return false;
     }
@@ -87,12 +88,13 @@ public class VideoEmbedYouTubeDataSource extends BaseSlingModelDataSource
     );
   }
 
+  @Nonnull
   private String getYoutubeVideo() {
     return getResource().getValueMap().get("youtubeVideo", String.class);
   }
 
   private boolean isMute() {
-    return getResource().getValueMap().get("mute", false);
+    return getResource().getValueMap().get("mute", Boolean.FALSE);
   }
 
 
@@ -101,10 +103,11 @@ public class VideoEmbedYouTubeDataSource extends BaseSlingModelDataSource
        ------------------ */
 
   private boolean isAllowFullscreen() {
-    return getResource().getValueMap().get("allowFullScreen", true);
+    return getResource().getValueMap().get("allowFullScreen", Boolean.TRUE);
   }
 
-  private String buildEmbedUrl(String videoId) {
+  @Nonnull
+  private String buildEmbedUrl(@Nonnull String videoId) {
 
 
     String base = "https://www.youtube.com/embed/";
@@ -118,7 +121,8 @@ public class VideoEmbedYouTubeDataSource extends BaseSlingModelDataSource
   }
 
 
-  private String extractVideoId(String value) {
+  @Nullable
+  private String extractVideoId(@Nonnull String value) {
     if (StringUtils.isBlank(value)) {
       return null;
     }

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/videoembed/VideoEmbedYouTubeDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/videoembed/VideoEmbedYouTubeDataSource.java
@@ -1,5 +1,6 @@
 package io.kestros.cms.components.basic.core.content.videoembed;
 
+import javax.annotation.Nonnull;
 import io.kestros.cms.components.basic.api.content.KestrosVideoEmbed;
 import io.kestros.cms.components.basic.core.BaseSlingModelDataSource;
 import java.util.ArrayList;
@@ -11,7 +12,6 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.models.annotations.Model;
-import javax.annotation.Nonnull;
 
 @Model(adaptables = {SlingHttpServletRequest.class, Resource.class})
 public class VideoEmbedYouTubeDataSource extends BaseSlingModelDataSource
@@ -132,7 +132,7 @@ public class VideoEmbedYouTubeDataSource extends BaseSlingModelDataSource
     }
 
     if (value.contains("youtu.be/")) {
-      return value.substring(value.lastIndexOf("/") + 1);
+      return value.substring(value.lastIndexOf('/') + 1);
     }
 
     int index = value.indexOf("v=");

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/lists/cardlist/CardListAssetsDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/lists/cardlist/CardListAssetsDataSource.java
@@ -51,6 +51,10 @@ public class CardListAssetsDataSource extends BaseContainerSlingModelDataSource 
   AssetCollection getCollection() {
     if (collection == null) {
       String collectionPath = getResource().getValueMap().get("collectionPath", String.class);
+      if (collectionPath == null) {
+        // No collection has been chosen yet; the retrieval service takes a non-null path.
+        return null;
+      }
       try {
         collection = assetRetrievalService.getCollection(collectionPath, getResourceResolver());
       } catch (AssetCollectionRetrievalException e) {

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/lists/cardlist/CardListAssetsDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/lists/cardlist/CardListAssetsDataSource.java
@@ -1,9 +1,12 @@
 package io.kestros.cms.components.basic.core.lists.cardlist;
 
+import javax.annotation.Nullable;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.kestros.cms.assets.api.exceptions.AssetCollectionRetrievalException;
 import io.kestros.cms.assets.api.models.Asset;
 import io.kestros.cms.assets.api.models.AssetCollection;
 import io.kestros.cms.assets.api.services.AssetRetrievalService;
+import io.kestros.cms.components.basic.api.exceptions.ComponentElementRenderingException;
 import io.kestros.cms.components.basic.api.KestrosBasicComponentElement;
 import io.kestros.cms.components.basic.api.content.AnchorTarget;
 import io.kestros.cms.components.basic.api.content.KestrosCard;
@@ -11,6 +14,7 @@ import io.kestros.cms.components.basic.api.content.KestrosHeading;
 import io.kestros.cms.components.basic.api.content.KestrosImage;
 import io.kestros.cms.components.basic.api.exceptions.ComponentConfigurationException;
 import io.kestros.cms.components.basic.api.lists.KestrosCardList;
+import io.kestros.cms.components.basic.core.AssetSorter;
 import io.kestros.cms.components.basic.core.BaseContainerSlingModelDataSource;
 import io.kestros.cms.components.basic.core.content.card.KestrosCardImpl;
 import io.kestros.cms.components.basic.core.content.heading.KestrosHeadingImpl;
@@ -18,26 +22,32 @@ import io.kestros.cms.components.basic.core.content.image.KestrosImageImpl;
 import io.kestros.cms.componenttypes.api.models.ComponentVariation;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.Comparator;
-import java.util.Date;
 import java.util.List;
 import javax.annotation.Nonnull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.models.annotations.Model;
 import org.apache.sling.models.annotations.injectorspecific.OSGiService;
 
+@SuppressFBWarnings("IMC_IMMATURE_CLASS_NO_TOSTRING")
 @Model(adaptables = {SlingHttpServletRequest.class, Resource.class})
 public class CardListAssetsDataSource extends BaseContainerSlingModelDataSource implements
                                                                                 KestrosCardList {
+  private static final Logger LOG =
+      LoggerFactory.getLogger(CardListAssetsDataSource.class);
+
   @OSGiService
   private AssetRetrievalService assetRetrievalService;
   private AssetCollection collection;
 
+  @Nonnull
   String getHeadingLevel() {
     return getResource().getValueMap().get("headingType", "h2");
   }
 
+  @Nullable
   AssetCollection getCollection() {
     if (collection == null) {
       String collectionPath = getResource().getValueMap().get("collectionPath", String.class);
@@ -50,6 +60,10 @@ public class CardListAssetsDataSource extends BaseContainerSlingModelDataSource 
     return collection;
   }
 
+  @SuppressFBWarnings(value = "EXS_EXCEPTION_SOFTENING_NO_CHECKED",
+      justification = "Called from HTL, which cannot handle a checked exception. The checked"
+          + " cause is wrapped in a typed ComponentElementRenderingException so the failure"
+          + " stays identifiable, per the ruling on DataSourceComponent.")
   @Nonnull
   @Override
   public List<KestrosCard> getCardElements() {
@@ -60,7 +74,7 @@ public class CardListAssetsDataSource extends BaseContainerSlingModelDataSource 
     List<Asset> assets = new ArrayList<>(col.getChildAssets());
 
     String sortBy = getResource().getValueMap().get("sortBy", "");
-    boolean reverse = getResource().getValueMap().get("reverse", false);
+    boolean reverse = getResource().getValueMap().get("reverse", Boolean.FALSE);
     int limit = 0;
     try {
       limit = Integer.parseInt(getResource().getValueMap().get("limit", "0"));
@@ -68,32 +82,7 @@ public class CardListAssetsDataSource extends BaseContainerSlingModelDataSource 
       limit = 0;
     }
 
-    if (!sortBy.isEmpty()) {
-      switch (sortBy) {
-        case "createdDate":
-          assets.sort(Comparator.comparing(a -> {
-            Date date = a.getCreatedDate();
-            return date != null ? date.getTime() : 0L;
-          }));
-          break;
-        case "lastModified":
-          assets.sort(Comparator.comparing(a -> {
-            Date date = a.getModifiedDate();
-            return date != null ? date.getTime() : 0L;
-          }));
-          break;
-        default:
-          assets.sort(Comparator.comparing(a -> {
-            switch (sortBy) {
-              case "name":
-                return a.getName() != null ? a.getName() : "";
-              default:
-                return a.getTitle() != null ? a.getTitle() : a.getName();
-            }
-          }));
-          break;
-      }
-    }
+    AssetSorter.sort(assets, sortBy);
 
     if (reverse) {
       Collections.reverse(assets);
@@ -102,41 +91,33 @@ public class CardListAssetsDataSource extends BaseContainerSlingModelDataSource 
       assets = assets.subList(0, limit);
     }
 
-    List<KestrosCard> cards = new ArrayList<>();
-    String parentPath = getPath();
+    final List<KestrosCard> cards = new ArrayList<>(assets.size());
 
-    for (Asset asset : assets) {
-      String imagePath = asset.getPath();
-      String altText = null;
-      String caption = null;
-      String imageTitle = null;
-      String href = null;
-      String ariaLabel = null;
-      String anchorTitle = null;
-      AnchorTarget target = null;
-
-      List<ComponentVariation> titleVariations = getElementVariations("titleVariations",
-          KestrosImage.RESOURCE_TYPE);
-      String titleLayout = getLayout("title");
+    for (final Asset asset : assets) {
       KestrosHeading titleElement = null;
       try {
         titleElement = new KestrosHeadingImpl(asset.getTitle(), "h2",
-            this,"title", "titleElement");
+            this, "title", "titleElement");
       } catch (ComponentConfigurationException e) {
-        // do nothing.
+        // A card without its heading still renders; leave it unset.
       }
 
-      List<ComponentVariation> imageVariations = getElementVariations("imageVariations",
-          KestrosImage.RESOURCE_TYPE);
-      String imageLayout = getLayout("image");
-      String imageId = null;
-      KestrosImage image = null;
+      final KestrosImage image;
       try {
-        image = new KestrosImageImpl(imagePath, altText, caption, imageTitle,
-            href, ariaLabel, anchorTitle, target,
-            this, "image", "imageElement",assetRetrievalService);
+        // Arguments after the path are altText, caption, imageTitle, href, ariaLabel, anchorTitle
+        // and target. They were locals initialised to null and passed straight through; the
+        // variations, layout and id locals alongside them were computed and never used.
+        image = new KestrosImageImpl(asset.getPath(), null, null, null,
+            null, null, null, null,
+            this, "image", "imageElement", assetRetrievalService);
       } catch (ComponentConfigurationException e) {
-        return null;
+        // Was `return null` from a @Nonnull getter, so one unbuildable image discarded the whole
+        // list and handed HTL a null. Skip the card instead, which is what the sibling card lists
+        // already do.
+        LOG.warn("Skipping card for asset {}: its image could not be built. {}",
+            String.valueOf(asset.getPath()).replaceAll("[\r\n]", ""),
+            String.valueOf(e.getMessage()).replaceAll("[\r\n]", ""));
+        continue;
       }
       try {
         cards.add(
@@ -144,8 +125,9 @@ public class CardListAssetsDataSource extends BaseContainerSlingModelDataSource 
                 null,
                 this,
                 "card", null));
-      } catch (Exception e) {
-        throw new RuntimeException(e);
+      } catch (ComponentConfigurationException e) {
+        throw new ComponentElementRenderingException(
+            "Unable to build a card for asset " + asset.getPath() + ".", e);
       }
     }
     return new ArrayList<>(cards);

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/lists/cardlist/CardListAssetsDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/lists/cardlist/CardListAssetsDataSource.java
@@ -31,7 +31,11 @@ import org.apache.sling.api.resource.Resource;
 import org.apache.sling.models.annotations.Model;
 import org.apache.sling.models.annotations.injectorspecific.OSGiService;
 
-@SuppressFBWarnings("IMC_IMMATURE_CLASS_NO_TOSTRING")
+@SuppressFBWarnings(value = "IMC_IMMATURE_CLASS_NO_TOSTRING",
+    justification = "A style rule rather than a defect: the detector fires on every class that"
+        + " does not declare toString. The fields here are author content read from the"
+        + " repository and are reached through the getters HTL calls, so a default rendering of"
+        + " them is not something to add.")
 @Model(adaptables = {SlingHttpServletRequest.class, Resource.class})
 public class CardListAssetsDataSource extends BaseContainerSlingModelDataSource implements
                                                                                 KestrosCardList {

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/lists/cardlist/CardListChildPagesDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/lists/cardlist/CardListChildPagesDataSource.java
@@ -50,7 +50,11 @@ public class CardListChildPagesDataSource extends BaseContainerSlingModelDataSou
         }
       } else {
         try {
-          rootPage = getResource().adaptTo(BaseComponent.class).getContainingPage();
+          BaseComponent component = getResource().adaptTo(BaseComponent.class);
+          if (component == null) {
+            return null;
+          }
+          rootPage = component.getContainingPage();
         } catch (NoValidAncestorException e) {
           return null;
         }

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/lists/cardlist/CardListChildPagesDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/lists/cardlist/CardListChildPagesDataSource.java
@@ -24,7 +24,11 @@ import org.apache.sling.models.annotations.Model;
 import org.apache.sling.models.annotations.Optional;
 import org.apache.sling.models.annotations.injectorspecific.OSGiService;
 
-@SuppressFBWarnings("IMC_IMMATURE_CLASS_NO_TOSTRING")
+@SuppressFBWarnings(value = "IMC_IMMATURE_CLASS_NO_TOSTRING",
+    justification = "A style rule rather than a defect: the detector fires on every class that"
+        + " does not declare toString. The fields here are author content read from the"
+        + " repository and are reached through the getters HTL calls, so a default rendering of"
+        + " them is not something to add.")
 @Model(adaptables = {SlingHttpServletRequest.class, Resource.class})
 public class CardListChildPagesDataSource extends BaseContainerSlingModelDataSource implements
                                                                                     KestrosCardList {

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/lists/cardlist/CardListChildPagesDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/lists/cardlist/CardListChildPagesDataSource.java
@@ -1,19 +1,19 @@
 package io.kestros.cms.components.basic.core.lists.cardlist;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.kestros.cms.components.basic.api.content.KestrosButton;
 import io.kestros.cms.components.basic.api.content.KestrosButtonGroup;
 import io.kestros.cms.components.basic.api.content.KestrosCard;
 import io.kestros.cms.components.basic.api.content.KestrosImage;
 import io.kestros.cms.components.basic.api.lists.KestrosCardList;
+import io.kestros.cms.components.basic.core.ContentPageSorter;
 import io.kestros.cms.components.basic.core.BaseContainerSlingModelDataSource;
 import io.kestros.cms.components.basic.core.content.card.KestrosCardImpl;
 import io.kestros.cms.sitebuilding.api.models.BaseComponent;
 import io.kestros.cms.sitebuilding.api.models.BaseContentPage;
 import io.kestros.commons.structuredslingmodels.exceptions.NoValidAncestorException;
 import java.util.ArrayList;
-import java.util.Calendar;
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.List;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -21,11 +21,13 @@ import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.models.annotations.Model;
 
+@SuppressFBWarnings("IMC_IMMATURE_CLASS_NO_TOSTRING")
 @Model(adaptables = {SlingHttpServletRequest.class, Resource.class})
 public class CardListChildPagesDataSource extends BaseContainerSlingModelDataSource implements
                                                                                     KestrosCardList {
   private BaseContentPage rootPage;
 
+  @Nullable
   BaseContentPage getRootPage() {
     if (rootPage == null) {
       String pagesPath = getResource().getValueMap().get("pagesPath", String.class);
@@ -54,6 +56,10 @@ public class CardListChildPagesDataSource extends BaseContainerSlingModelDataSou
     return getResource().getValueMap().get("readMoreText", String.class);
   }
 
+  @SuppressFBWarnings(value = "EXS_EXCEPTION_SOFTENING_NO_CHECKED",
+      justification = "Called from HTL, which cannot handle a checked exception. The checked"
+          + " cause is wrapped in a typed ComponentElementRenderingException so the failure"
+          + " stays identifiable, per the ruling on DataSourceComponent.")
   @Nonnull
   @Override
   public List<KestrosCard> getCardElements() {
@@ -64,7 +70,7 @@ public class CardListChildPagesDataSource extends BaseContainerSlingModelDataSou
     List<BaseContentPage> pages = new ArrayList<>(root.getChildPages());
 
     String sortBy = getResource().getValueMap().get("sortBy", "");
-    boolean reverse = getResource().getValueMap().get("reverse", false);
+    boolean reverse = getResource().getValueMap().get("reverse", Boolean.FALSE);
     int limit = 0;
     try {
       limit = Integer.parseInt(getResource().getValueMap().get("limit", "0"));
@@ -72,36 +78,7 @@ public class CardListChildPagesDataSource extends BaseContainerSlingModelDataSou
       limit = 0;
     }
 
-    if (!sortBy.isEmpty()) {
-      switch (sortBy) {
-        case "createdDate":
-          pages.sort(Comparator.comparing(p -> {
-            Calendar cal = p.getResource().getChild("jcr:content") != null
-                ? p.getResource().getChild("jcr:content").getValueMap()
-                    .get("jcr:created", Calendar.class) : null;
-            return cal != null ? cal.getTimeInMillis() : 0L;
-          }));
-          break;
-        case "lastModified":
-          pages.sort(Comparator.comparing(p -> {
-            Calendar cal = p.getResource().getChild("jcr:content") != null
-                ? p.getResource().getChild("jcr:content").getValueMap()
-                    .get("jcr:lastModified", Calendar.class) : null;
-            return cal != null ? cal.getTimeInMillis() : 0L;
-          }));
-          break;
-        default:
-          pages.sort(Comparator.comparing(p -> {
-            switch (sortBy) {
-              case "name":
-                return p.getName() != null ? p.getName() : "";
-              default:
-                return p.getDisplayTitle() != null ? p.getDisplayTitle() : p.getName();
-            }
-          }));
-          break;
-      }
-    }
+    ContentPageSorter.sort(pages, sortBy);
 
     if (reverse) {
       Collections.reverse(pages);

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/lists/cardlist/CardListTagSearchDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/lists/cardlist/CardListTagSearchDataSource.java
@@ -1,31 +1,40 @@
 package io.kestros.cms.components.basic.core.lists.cardlist;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import io.kestros.cms.components.basic.api.exceptions.ComponentConfigurationException;
 import io.kestros.cms.components.basic.api.content.KestrosCard;
 import io.kestros.cms.components.basic.api.lists.KestrosCardList;
+import io.kestros.cms.components.basic.core.ContentPageSorter;
 import io.kestros.cms.components.basic.core.BaseContainerSlingModelDataSource;
 import io.kestros.cms.components.basic.core.content.card.KestrosCardImpl;
 import io.kestros.cms.sitebuilding.api.models.BaseComponent;
 import io.kestros.cms.sitebuilding.api.models.BaseContentPage;
 import io.kestros.cms.tagging.api.models.KestrosTag;
 import io.kestros.cms.tagging.api.services.TagRetrievalService;
+import io.kestros.commons.structuredslingmodels.exceptions.NoParentResourceException;
 import io.kestros.commons.structuredslingmodels.exceptions.NoValidAncestorException;
+import java.util.Arrays;
 import java.util.ArrayList;
-import java.util.Calendar;
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.models.annotations.Model;
 import org.apache.sling.models.annotations.injectorspecific.OSGiService;
 
+@SuppressFBWarnings("IMC_IMMATURE_CLASS_NO_TOSTRING")
 @Model(adaptables = {SlingHttpServletRequest.class, Resource.class})
 public class CardListTagSearchDataSource extends BaseContainerSlingModelDataSource implements
                                                                                    KestrosCardList {
+
+  private static final Logger LOG =
+      LoggerFactory.getLogger(CardListTagSearchDataSource.class);
 
   @OSGiService
   @org.apache.sling.models.annotations.Optional
@@ -38,6 +47,7 @@ public class CardListTagSearchDataSource extends BaseContainerSlingModelDataSour
     return getResource().getValueMap().get("readMoreText", String.class);
   }
 
+  @Nullable
   BaseContentPage getContainingPage() {
     if (containingPage == null) {
       try {
@@ -61,6 +71,7 @@ public class CardListTagSearchDataSource extends BaseContainerSlingModelDataSour
     return tags;
   }
 
+  @Nullable
   String getRootPath() {
     String pagesPath = getResource().getValueMap().get("pagesPath", String.class);
     if (pagesPath != null) {
@@ -70,13 +81,15 @@ public class CardListTagSearchDataSource extends BaseContainerSlingModelDataSour
     if (page != null) {
       try {
         return page.getParent().getPath();
-      } catch (Exception e) {
+      } catch (NoParentResourceException e) {
+        // A page with no parent searches from itself.
         return page.getPath();
       }
     }
     return null;
   }
 
+  @Nullable
   BaseContentPage getRootPage() {
     String rootPath = getRootPath();
     if (rootPath == null) {
@@ -89,8 +102,9 @@ public class CardListTagSearchDataSource extends BaseContainerSlingModelDataSour
     return null;
   }
 
+  @Nonnull
   List<BaseContentPage> getTaggedPages() {
-    List<BaseContentPage> taggedPages = new ArrayList<>();
+    final List<BaseContentPage> taggedPages = new ArrayList<>();
     if (tagRetrievalService == null) {
       return taggedPages;
     }
@@ -100,10 +114,8 @@ public class CardListTagSearchDataSource extends BaseContainerSlingModelDataSour
       return taggedPages;
     }
 
-    Set<String> filterTagPaths = new HashSet<>();
-    for (String tagPath : configuredTags) {
-      filterTagPaths.add(tagPath);
-    }
+    final Set<String> filterTagPaths =
+        new HashSet<>(Arrays.asList(configuredTags));
 
     BaseContentPage currentPage = getContainingPage();
     BaseContentPage rootPage = getRootPage();
@@ -135,7 +147,7 @@ public class CardListTagSearchDataSource extends BaseContainerSlingModelDataSour
     List<BaseContentPage> pages = new ArrayList<>(getTaggedPages());
 
     String sortBy = getResource().getValueMap().get("sortBy", "");
-    boolean reverse = getResource().getValueMap().get("reverse", false);
+    boolean reverse = getResource().getValueMap().get("reverse", Boolean.FALSE);
     int limit = 0;
     try {
       limit = Integer.parseInt(getResource().getValueMap().get("limit", "0"));
@@ -143,36 +155,7 @@ public class CardListTagSearchDataSource extends BaseContainerSlingModelDataSour
       limit = 0;
     }
 
-    if (!sortBy.isEmpty()) {
-      switch (sortBy) {
-        case "createdDate":
-          pages.sort(Comparator.comparing(p -> {
-            Calendar cal = p.getResource().getChild("jcr:content") != null
-                ? p.getResource().getChild("jcr:content").getValueMap()
-                    .get("jcr:created", Calendar.class) : null;
-            return cal != null ? cal.getTimeInMillis() : 0L;
-          }));
-          break;
-        case "lastModified":
-          pages.sort(Comparator.comparing(p -> {
-            Calendar cal = p.getResource().getChild("jcr:content") != null
-                ? p.getResource().getChild("jcr:content").getValueMap()
-                    .get("jcr:lastModified", Calendar.class) : null;
-            return cal != null ? cal.getTimeInMillis() : 0L;
-          }));
-          break;
-        default:
-          pages.sort(Comparator.comparing(p -> {
-            switch (sortBy) {
-              case "name":
-                return p.getName() != null ? p.getName() : "";
-              default:
-                return p.getDisplayTitle() != null ? p.getDisplayTitle() : p.getName();
-            }
-          }));
-          break;
-      }
-    }
+    ContentPageSorter.sort(pages, sortBy);
 
     if (reverse) {
       Collections.reverse(pages);
@@ -190,8 +173,10 @@ public class CardListTagSearchDataSource extends BaseContainerSlingModelDataSour
                 this,
                 "card",
                 page.getName()));
-      } catch (Exception e) {
-        // Skip cards that fail to construct — null-safe
+      } catch (ComponentConfigurationException e) {
+        LOG.debug("Skipping the {} for {}: it could not be built. {}", "card",
+            String.valueOf(page.getPath()).replaceAll("[\r\n]", ""),
+            String.valueOf(e.getMessage()).replaceAll("[\r\n]", ""));
       }
     }
     return new ArrayList<>(cards);

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/lists/cardlist/CardListTagSearchDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/lists/cardlist/CardListTagSearchDataSource.java
@@ -28,7 +28,11 @@ import org.apache.sling.api.resource.Resource;
 import org.apache.sling.models.annotations.Model;
 import org.apache.sling.models.annotations.injectorspecific.OSGiService;
 
-@SuppressFBWarnings("IMC_IMMATURE_CLASS_NO_TOSTRING")
+@SuppressFBWarnings(value = "IMC_IMMATURE_CLASS_NO_TOSTRING",
+    justification = "A style rule rather than a defect: the detector fires on every class that"
+        + " does not declare toString. The fields here are author content read from the"
+        + " repository and are reached through the getters HTL calls, so a default rendering of"
+        + " them is not something to add.")
 @Model(adaptables = {SlingHttpServletRequest.class, Resource.class})
 public class CardListTagSearchDataSource extends BaseContainerSlingModelDataSource implements
                                                                                    KestrosCardList {

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/lists/cardlist/KestrosCardListImpl.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/lists/cardlist/KestrosCardListImpl.java
@@ -10,7 +10,11 @@ import java.util.ArrayList;
 import java.util.List;
 import javax.annotation.Nonnull;
 
-@SuppressFBWarnings("IMC_IMMATURE_CLASS_NO_TOSTRING")
+@SuppressFBWarnings(value = "IMC_IMMATURE_CLASS_NO_TOSTRING",
+    justification = "A style rule rather than a defect: the detector fires on every class that"
+        + " does not declare toString. The fields here are author content read from the"
+        + " repository and are reached through the getters HTL calls, so a default rendering of"
+        + " them is not something to add.")
 public class KestrosCardListImpl extends BaseContainerSyntheticResource implements KestrosCardList {
 
   private List<KestrosCard> cards;

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/lists/cardlist/KestrosCardListImpl.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/lists/cardlist/KestrosCardListImpl.java
@@ -1,5 +1,6 @@
 package io.kestros.cms.components.basic.core.lists.cardlist;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.kestros.cms.components.basic.api.content.KestrosCard;
 import io.kestros.cms.components.basic.api.exceptions.ComponentConfigurationException;
 import io.kestros.cms.components.basic.api.lists.KestrosCardList;
@@ -9,6 +10,7 @@ import java.util.ArrayList;
 import java.util.List;
 import javax.annotation.Nonnull;
 
+@SuppressFBWarnings("IMC_IMMATURE_CLASS_NO_TOSTRING")
 public class KestrosCardListImpl extends BaseContainerSyntheticResource implements KestrosCardList {
 
   private List<KestrosCard> cards;

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/lists/cardlist/KestrosCardListImpl.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/lists/cardlist/KestrosCardListImpl.java
@@ -19,7 +19,7 @@ public class KestrosCardListImpl extends BaseContainerSyntheticResource implemen
       @Nonnull String resourcePrefix, String forcedResourceName)
       throws ComponentConfigurationException {
     super(dataSource, resourcePrefix, forcedResourceName);
-    this.cards = cards;
+    this.cards = new ArrayList<>(cards);
   }
 
 

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/lists/linklist/KestrosLinkListImpl.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/lists/linklist/KestrosLinkListImpl.java
@@ -19,7 +19,7 @@ public class KestrosLinkListImpl extends BaseContainerSyntheticResource implemen
       @Nonnull String resourcePrefix, String forcedResourceName)
       throws ComponentConfigurationException {
     super(dataSource, resourcePrefix, forcedResourceName);
-    this.links = links;
+    this.links = new ArrayList<>(links);
   }
 
 

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/lists/linklist/KestrosLinkListImpl.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/lists/linklist/KestrosLinkListImpl.java
@@ -10,7 +10,11 @@ import java.util.ArrayList;
 import java.util.List;
 import javax.annotation.Nonnull;
 
-@SuppressFBWarnings("IMC_IMMATURE_CLASS_NO_TOSTRING")
+@SuppressFBWarnings(value = "IMC_IMMATURE_CLASS_NO_TOSTRING",
+    justification = "A style rule rather than a defect: the detector fires on every class that"
+        + " does not declare toString. The fields here are author content read from the"
+        + " repository and are reached through the getters HTL calls, so a default rendering of"
+        + " them is not something to add.")
 public class KestrosLinkListImpl extends BaseContainerSyntheticResource implements KestrosLinkList {
 
   private List<KestrosLink> links;

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/lists/linklist/KestrosLinkListImpl.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/lists/linklist/KestrosLinkListImpl.java
@@ -1,5 +1,6 @@
 package io.kestros.cms.components.basic.core.lists.linklist;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.kestros.cms.components.basic.api.content.KestrosLink;
 import io.kestros.cms.components.basic.api.exceptions.ComponentConfigurationException;
 import io.kestros.cms.components.basic.api.lists.KestrosLinkList;
@@ -9,6 +10,7 @@ import java.util.ArrayList;
 import java.util.List;
 import javax.annotation.Nonnull;
 
+@SuppressFBWarnings("IMC_IMMATURE_CLASS_NO_TOSTRING")
 public class KestrosLinkListImpl extends BaseContainerSyntheticResource implements KestrosLinkList {
 
   private List<KestrosLink> links;

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/lists/linklist/LinkListChildPageDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/lists/linklist/LinkListChildPageDataSource.java
@@ -20,7 +20,9 @@ import org.apache.sling.api.resource.Resource;
 import org.apache.sling.models.annotations.Model;
 import org.apache.sling.models.annotations.injectorspecific.OSGiService;
 
-@SuppressFBWarnings("FCBL_FIELD_COULD_BE_LOCAL")
+@SuppressFBWarnings(value = "FCBL_FIELD_COULD_BE_LOCAL",
+    justification = "Both fields are @OSGiService injection points. Sling Models writes them"
+        + " after the object is constructed, so neither can be a local variable.")
 @Model(adaptables = {SlingHttpServletRequest.class, Resource.class})
 public class LinkListChildPageDataSource extends BaseContainerSlingModelDataSource
     implements KestrosLinkList {

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/lists/linklist/LinkListChildPageDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/lists/linklist/LinkListChildPageDataSource.java
@@ -1,8 +1,11 @@
 package io.kestros.cms.components.basic.core.lists.linklist;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import javax.annotation.Nonnull;
 import io.kestros.cms.components.basic.api.content.AnchorTarget;
 import io.kestros.cms.components.basic.api.content.KestrosLink;
 import io.kestros.cms.components.basic.api.lists.KestrosLinkList;
+import io.kestros.cms.components.basic.core.ContentPageSorter;
 import io.kestros.cms.components.basic.core.BaseContainerSlingModelDataSource;
 import io.kestros.cms.components.basic.core.LinkUtils;
 import io.kestros.cms.components.basic.core.content.link.KestrosLinkImpl;
@@ -10,15 +13,14 @@ import io.kestros.cms.componenttypes.api.services.ComponentUiFrameworkViewRetrie
 import io.kestros.cms.componenttypes.api.services.ComponentVariationRetrievalService;
 import io.kestros.cms.sitebuilding.api.models.BaseContentPage;
 import java.util.ArrayList;
-import java.util.Calendar;
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.List;
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.models.annotations.Model;
 import org.apache.sling.models.annotations.injectorspecific.OSGiService;
 
+@SuppressFBWarnings("FCBL_FIELD_COULD_BE_LOCAL")
 @Model(adaptables = {SlingHttpServletRequest.class, Resource.class})
 public class LinkListChildPageDataSource extends BaseContainerSlingModelDataSource
     implements KestrosLinkList {
@@ -28,15 +30,22 @@ public class LinkListChildPageDataSource extends BaseContainerSlingModelDataSour
   @OSGiService
   private ComponentUiFrameworkViewRetrievalService componentUiFrameworkViewRetrievalService;
 
+  @Nonnull
   public String getRootPath() {
     return getResource().getValueMap().get("pagesPath", String.class);
   }
 
+  @Nonnull
   public AnchorTarget getTarget() {
     return AnchorTarget.lookup(getResource());
   }
 
+  @SuppressFBWarnings(value = "EXS_EXCEPTION_SOFTENING_NO_CHECKED",
+      justification = "Called from HTL, which cannot handle a checked exception. The checked"
+          + " cause is wrapped in a typed ComponentElementRenderingException so the failure"
+          + " stays identifiable, per the ruling on DataSourceComponent.")
   @Override
+  @Nonnull
   public List<KestrosLink> getLinkElements() {
     List<BaseContentPage> pages = new ArrayList<>();
     String rootPath = getRootPath();
@@ -48,7 +57,7 @@ public class LinkListChildPageDataSource extends BaseContainerSlingModelDataSour
       return new ArrayList<>();
     }
     for (Resource childResource : rootResource.getChildren()) {
-      if (childResource.getName().equals("jcr:content")) {
+      if ("jcr:content".equals(childResource.getName())) {
         continue;
       }
       BaseContentPage page = childResource.adaptTo(BaseContentPage.class);
@@ -58,7 +67,7 @@ public class LinkListChildPageDataSource extends BaseContainerSlingModelDataSour
     }
 
     String sortBy = getResource().getValueMap().get("sortBy", "");
-    boolean reverse = getResource().getValueMap().get("reverse", false);
+    boolean reverse = getResource().getValueMap().get("reverse", Boolean.FALSE);
     int limit = 0;
     try {
       limit = Integer.parseInt(getResource().getValueMap().get("limit", "0"));
@@ -66,36 +75,7 @@ public class LinkListChildPageDataSource extends BaseContainerSlingModelDataSour
       limit = 0;
     }
 
-    if (!sortBy.isEmpty()) {
-      switch (sortBy) {
-        case "createdDate":
-          pages.sort(Comparator.comparing(p -> {
-            Calendar cal = p.getResource().getChild("jcr:content") != null
-                ? p.getResource().getChild("jcr:content").getValueMap()
-                    .get("jcr:created", Calendar.class) : null;
-            return cal != null ? cal.getTimeInMillis() : 0L;
-          }));
-          break;
-        case "lastModified":
-          pages.sort(Comparator.comparing(p -> {
-            Calendar cal = p.getResource().getChild("jcr:content") != null
-                ? p.getResource().getChild("jcr:content").getValueMap()
-                    .get("jcr:lastModified", Calendar.class) : null;
-            return cal != null ? cal.getTimeInMillis() : 0L;
-          }));
-          break;
-        default:
-          pages.sort(Comparator.comparing(p -> {
-            switch (sortBy) {
-              case "name":
-                return p.getName() != null ? p.getName() : "";
-              default:
-                return p.getDisplayTitle() != null ? p.getDisplayTitle() : p.getName();
-            }
-          }));
-          break;
-      }
-    }
+    ContentPageSorter.sort(pages, sortBy);
 
     if (reverse) {
       Collections.reverse(pages);
@@ -104,8 +84,9 @@ public class LinkListChildPageDataSource extends BaseContainerSlingModelDataSour
       pages = pages.subList(0, limit);
     }
 
-    List<KestrosLink> links = new ArrayList<>();
-    for (BaseContentPage page : pages) {
+    final List<BaseContentPage> sourceLinks = pages;
+    final List<KestrosLink> links = new ArrayList<>(sourceLinks.size());
+    for (BaseContentPage page : sourceLinks) {
       KestrosLink link = null;
       try {
         link = new KestrosLinkImpl(page.getDisplayTitle(),

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/lists/linklist/LinkListChildPageDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/lists/linklist/LinkListChildPageDataSource.java
@@ -9,8 +9,6 @@ import io.kestros.cms.components.basic.core.ContentPageSorter;
 import io.kestros.cms.components.basic.core.BaseContainerSlingModelDataSource;
 import io.kestros.cms.components.basic.core.LinkUtils;
 import io.kestros.cms.components.basic.core.content.link.KestrosLinkImpl;
-import io.kestros.cms.componenttypes.api.services.ComponentUiFrameworkViewRetrievalService;
-import io.kestros.cms.componenttypes.api.services.ComponentVariationRetrievalService;
 import io.kestros.cms.sitebuilding.api.models.BaseContentPage;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -19,19 +17,10 @@ import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.models.annotations.Model;
-import org.apache.sling.models.annotations.injectorspecific.OSGiService;
 
-@SuppressFBWarnings(value = "FCBL_FIELD_COULD_BE_LOCAL",
-    justification = "Both fields are @OSGiService injection points. Sling Models writes them"
-        + " after the object is constructed, so neither can be a local variable.")
 @Model(adaptables = {SlingHttpServletRequest.class, Resource.class})
 public class LinkListChildPageDataSource extends BaseContainerSlingModelDataSource
     implements KestrosLinkList {
-
-  @OSGiService
-  private ComponentVariationRetrievalService componentVariationRetrievalService;
-  @OSGiService
-  private ComponentUiFrameworkViewRetrievalService componentUiFrameworkViewRetrievalService;
 
   /**
    * The path the child pages are read from.

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/lists/linklist/LinkListChildPageDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/lists/linklist/LinkListChildPageDataSource.java
@@ -16,6 +16,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.models.annotations.Model;
 import org.apache.sling.models.annotations.injectorspecific.OSGiService;
@@ -30,9 +31,17 @@ public class LinkListChildPageDataSource extends BaseContainerSlingModelDataSour
   @OSGiService
   private ComponentUiFrameworkViewRetrievalService componentUiFrameworkViewRetrievalService;
 
+  /**
+   * The path the child pages are read from.
+   *
+   * <p>Empty rather than null when no path has been configured, so the @Nonnull this already
+   * declared is true. getLinkElements treats empty the same way it used to treat null.</p>
+   *
+   * @return The configured path, or the empty string when none is set.
+   */
   @Nonnull
   public String getRootPath() {
-    return getResource().getValueMap().get("pagesPath", String.class);
+    return getResource().getValueMap().get("pagesPath", StringUtils.EMPTY);
   }
 
   @Nonnull
@@ -49,7 +58,7 @@ public class LinkListChildPageDataSource extends BaseContainerSlingModelDataSour
   public List<KestrosLink> getLinkElements() {
     List<BaseContentPage> pages = new ArrayList<>();
     String rootPath = getRootPath();
-    if (rootPath == null) {
+    if (StringUtils.isEmpty(rootPath)) {
       return new ArrayList<>();
     }
     Resource rootResource = getResourceResolver().getResource(rootPath);

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/lists/linklist/LinkListTagSearchDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/lists/linklist/LinkListTagSearchDataSource.java
@@ -30,7 +30,11 @@ import org.apache.sling.api.resource.Resource;
 import org.apache.sling.models.annotations.Model;
 import org.apache.sling.models.annotations.injectorspecific.OSGiService;
 
-@SuppressFBWarnings("IMC_IMMATURE_CLASS_NO_TOSTRING")
+@SuppressFBWarnings(value = "IMC_IMMATURE_CLASS_NO_TOSTRING",
+    justification = "A style rule rather than a defect: the detector fires on every class that"
+        + " does not declare toString. The fields here are author content read from the"
+        + " repository and are reached through the getters HTL calls, so a default rendering of"
+        + " them is not something to add.")
 /**
  * Tag search datasource for the link list component. Finds pages matching configured
  * tags and renders them as link elements.

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/lists/linklist/LinkListTagSearchDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/lists/linklist/LinkListTagSearchDataSource.java
@@ -1,8 +1,12 @@
 package io.kestros.cms.components.basic.core.lists.linklist;
 
+import javax.annotation.Nullable;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import io.kestros.cms.components.basic.api.exceptions.ComponentConfigurationException;
 import io.kestros.cms.components.basic.api.content.AnchorTarget;
 import io.kestros.cms.components.basic.api.content.KestrosLink;
 import io.kestros.cms.components.basic.api.lists.KestrosLinkList;
+import io.kestros.cms.components.basic.core.ContentPageSorter;
 import io.kestros.cms.components.basic.core.BaseContainerSlingModelDataSource;
 import io.kestros.cms.components.basic.core.LinkUtils;
 import io.kestros.cms.components.basic.core.content.link.KestrosLinkImpl;
@@ -10,20 +14,23 @@ import io.kestros.cms.sitebuilding.api.models.BaseComponent;
 import io.kestros.cms.sitebuilding.api.models.BaseContentPage;
 import io.kestros.cms.tagging.api.models.KestrosTag;
 import io.kestros.cms.tagging.api.services.TagRetrievalService;
+import io.kestros.commons.structuredslingmodels.exceptions.NoParentResourceException;
 import io.kestros.commons.structuredslingmodels.exceptions.NoValidAncestorException;
+import java.util.Arrays;
 import java.util.ArrayList;
-import java.util.Calendar;
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import javax.annotation.Nonnull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.models.annotations.Model;
 import org.apache.sling.models.annotations.injectorspecific.OSGiService;
 
+@SuppressFBWarnings("IMC_IMMATURE_CLASS_NO_TOSTRING")
 /**
  * Tag search datasource for the link list component. Finds pages matching configured
  * tags and renders them as link elements.
@@ -32,12 +39,16 @@ import org.apache.sling.models.annotations.injectorspecific.OSGiService;
 public class LinkListTagSearchDataSource extends BaseContainerSlingModelDataSource
     implements KestrosLinkList {
 
+  private static final Logger LOG =
+      LoggerFactory.getLogger(LinkListTagSearchDataSource.class);
+
   @OSGiService
   @org.apache.sling.models.annotations.Optional
   private TagRetrievalService tagRetrievalService;
 
   private BaseContentPage containingPage;
 
+  @Nullable
   BaseContentPage getContainingPage() {
     if (containingPage == null) {
       try {
@@ -46,6 +57,9 @@ public class LinkListTagSearchDataSource extends BaseContainerSlingModelDataSour
           containingPage = component.getContainingPage();
         }
       } catch (NoValidAncestorException e) {
+        LOG.debug("No containing page for {}; the list has no results. {}",
+            String.valueOf(getResource().getPath()).replaceAll("[\r\n]", ""),
+            String.valueOf(e.getMessage()).replaceAll("[\r\n]", ""));
         return null;
       }
     }
@@ -61,6 +75,7 @@ public class LinkListTagSearchDataSource extends BaseContainerSlingModelDataSour
     return tags;
   }
 
+  @Nullable
   String getRootPath() {
     String pagesPath = getResource().getValueMap().get("pagesPath", String.class);
     if (pagesPath != null) {
@@ -70,13 +85,15 @@ public class LinkListTagSearchDataSource extends BaseContainerSlingModelDataSour
     if (page != null) {
       try {
         return page.getParent().getPath();
-      } catch (Exception e) {
+      } catch (NoParentResourceException e) {
+        // A page with no parent searches from itself.
         return page.getPath();
       }
     }
     return null;
   }
 
+  @Nullable
   BaseContentPage getRootPage() {
     String rootPath = getRootPath();
     if (rootPath == null) {
@@ -89,12 +106,14 @@ public class LinkListTagSearchDataSource extends BaseContainerSlingModelDataSour
     return null;
   }
 
+  @Nonnull
   public AnchorTarget getTarget() {
     return AnchorTarget.lookup(getResource());
   }
 
+  @Nonnull
   List<BaseContentPage> getTaggedPages() {
-    List<BaseContentPage> taggedPages = new ArrayList<>();
+    final List<BaseContentPage> taggedPages = new ArrayList<>();
     if (tagRetrievalService == null) {
       return taggedPages;
     }
@@ -104,10 +123,8 @@ public class LinkListTagSearchDataSource extends BaseContainerSlingModelDataSour
       return taggedPages;
     }
 
-    Set<String> filterTagPaths = new HashSet<>();
-    for (String tagPath : configuredTags) {
-      filterTagPaths.add(tagPath);
-    }
+    final Set<String> filterTagPaths =
+        new HashSet<>(Arrays.asList(configuredTags));
 
     BaseContentPage currentPage = getContainingPage();
     BaseContentPage rootPage = getRootPage();
@@ -139,7 +156,7 @@ public class LinkListTagSearchDataSource extends BaseContainerSlingModelDataSour
     List<BaseContentPage> pages = new ArrayList<>(getTaggedPages());
 
     String sortBy = getResource().getValueMap().get("sortBy", "");
-    boolean reverse = getResource().getValueMap().get("reverse", false);
+    boolean reverse = getResource().getValueMap().get("reverse", Boolean.FALSE);
     int limit = 0;
     try {
       limit = Integer.parseInt(getResource().getValueMap().get("limit", "0"));
@@ -147,36 +164,7 @@ public class LinkListTagSearchDataSource extends BaseContainerSlingModelDataSour
       limit = 0;
     }
 
-    if (!sortBy.isEmpty()) {
-      switch (sortBy) {
-        case "createdDate":
-          pages.sort(Comparator.comparing(p -> {
-            Calendar cal = p.getResource().getChild("jcr:content") != null
-                ? p.getResource().getChild("jcr:content").getValueMap()
-                    .get("jcr:created", Calendar.class) : null;
-            return cal != null ? cal.getTimeInMillis() : 0L;
-          }));
-          break;
-        case "lastModified":
-          pages.sort(Comparator.comparing(p -> {
-            Calendar cal = p.getResource().getChild("jcr:content") != null
-                ? p.getResource().getChild("jcr:content").getValueMap()
-                    .get("jcr:lastModified", Calendar.class) : null;
-            return cal != null ? cal.getTimeInMillis() : 0L;
-          }));
-          break;
-        default:
-          pages.sort(Comparator.comparing(p -> {
-            switch (sortBy) {
-              case "name":
-                return p.getName() != null ? p.getName() : "";
-              default:
-                return p.getDisplayTitle() != null ? p.getDisplayTitle() : p.getName();
-            }
-          }));
-          break;
-      }
-    }
+    ContentPageSorter.sort(pages, sortBy);
 
     if (reverse) {
       Collections.reverse(pages);
@@ -185,15 +173,18 @@ public class LinkListTagSearchDataSource extends BaseContainerSlingModelDataSour
       pages = pages.subList(0, limit);
     }
 
-    List<KestrosLink> links = new ArrayList<>();
-    for (BaseContentPage page : pages) {
+    final List<BaseContentPage> sourceLinks = pages;
+    final List<KestrosLink> links = new ArrayList<>(sourceLinks.size());
+    for (BaseContentPage page : sourceLinks) {
       try {
         links.add(new KestrosLinkImpl(page,
             this,
             "link",
             page.getName()));
-      } catch (Exception e) {
-        // Skip links that fail to construct
+      } catch (ComponentConfigurationException e) {
+        LOG.debug("Skipping the link for {}: it could not be built. {}",
+            String.valueOf(page.getPath()).replaceAll("[\r\n]", ""),
+            String.valueOf(e.getMessage()).replaceAll("[\r\n]", ""));
       }
     }
     return links;

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/navigation/breadcrumbs/BreadCrumbDataSourceComponent.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/navigation/breadcrumbs/BreadCrumbDataSourceComponent.java
@@ -14,11 +14,13 @@ public class BreadCrumbDataSourceComponent
     extends BaseDataSourceComponent<KestrosBreadCrumb> implements KestrosBreadCrumb {
 
   @Override
+  @Nonnull
   public Boolean isFirstItem() {
     return getComponentData().isFirstItem();
   }
 
   @Override
+  @Nonnull
   public Boolean isLastItem() {
     return getComponentData().isLastItem();
   }

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/navigation/breadcrumbs/BreadCrumbStaticDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/navigation/breadcrumbs/BreadCrumbStaticDataSource.java
@@ -1,11 +1,11 @@
 package io.kestros.cms.components.basic.core.navigation.breadcrumbs;
 
+import javax.annotation.Nonnull;
 import io.kestros.cms.components.basic.api.navigation.KestrosBreadCrumb;
 import io.kestros.cms.components.basic.core.content.link.LinkStaticDataSource;
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.models.annotations.Model;
-import javax.annotation.Nonnull;
 
 @Model(adaptables = {SlingHttpServletRequest.class, Resource.class})
 public class BreadCrumbStaticDataSource extends LinkStaticDataSource

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/navigation/breadcrumbs/BreadCrumbStaticDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/navigation/breadcrumbs/BreadCrumbStaticDataSource.java
@@ -5,17 +5,20 @@ import io.kestros.cms.components.basic.core.content.link.LinkStaticDataSource;
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.models.annotations.Model;
+import javax.annotation.Nonnull;
 
 @Model(adaptables = {SlingHttpServletRequest.class, Resource.class})
 public class BreadCrumbStaticDataSource extends LinkStaticDataSource
     implements KestrosBreadCrumb {
 
   @Override
+  @Nonnull
   public Boolean isFirstItem() {
     return getResource().getValueMap().get("firstItem", Boolean.FALSE);
   }
 
   @Override
+  @Nonnull
   public Boolean isLastItem() {
     return getResource().getValueMap().get("lastItem", Boolean.FALSE);
   }

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/navigation/breadcrumbs/BreadCrumbsPagePathDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/navigation/breadcrumbs/BreadCrumbsPagePathDataSource.java
@@ -1,6 +1,5 @@
 package io.kestros.cms.components.basic.core.navigation.breadcrumbs;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.kestros.cms.components.basic.api.exceptions.ComponentConfigurationException;
 import io.kestros.cms.components.basic.api.content.KestrosLink;
 import io.kestros.cms.components.basic.api.navigation.KestrosBreadCrumb;
@@ -16,26 +15,13 @@ import org.slf4j.LoggerFactory;
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.models.annotations.Model;
-import org.apache.sling.models.annotations.Optional;
-import org.apache.sling.models.annotations.injectorspecific.Self;
 
-@SuppressFBWarnings(value = "FCBL_FIELD_COULD_BE_LOCAL",
-    justification = "Both fields are @Self @Optional injection points. Sling Models writes them"
-        + " after the object is constructed, so neither can be a local variable.")
 @Model(adaptables = {SlingHttpServletRequest.class, Resource.class})
 public class BreadCrumbsPagePathDataSource extends BaseSlingModelDataSource
     implements KestrosBreadCrumbs {
 
   private static final Logger LOG =
       LoggerFactory.getLogger(BreadCrumbsPagePathDataSource.class);
-
-  @Self
-  @Optional
-  private SlingHttpServletRequest slingHttpServletRequest;
-
-  @Self
-  @Optional
-  private Resource resource;
 
   @Nonnull
   @Override

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/navigation/breadcrumbs/BreadCrumbsPagePathDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/navigation/breadcrumbs/BreadCrumbsPagePathDataSource.java
@@ -39,8 +39,8 @@ public class BreadCrumbsPagePathDataSource extends BaseSlingModelDataSource
   @Override
   public List<KestrosBreadCrumb> getLinkElements() {
     List<KestrosBreadCrumb> crumbs = new ArrayList<>();
-    Boolean first = true;
-    Boolean last = false;
+    boolean first = true;
+    boolean last = false;
     int index = 0;
     List<BaseContentPage> ancestorPages = getAncestorPages();
     for (BaseContentPage page : ancestorPages) {
@@ -55,8 +55,10 @@ public class BreadCrumbsPagePathDataSource extends BaseSlingModelDataSource
         crumbs.add(crumb);
         first = false;
         index++;
-      } catch (Exception e) {
-        // Ignore exception and continue.
+      } catch (ComponentConfigurationException e) {
+        LOG.debug("Skipping a breadcrumb for {}: it could not be built. {}",
+            String.valueOf(page.getPath()).replaceAll("[\r\n]", ""),
+            String.valueOf(e.getMessage()).replaceAll("[\r\n]", ""));
       }
     }
     return new ArrayList<>(crumbs);

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/navigation/breadcrumbs/BreadCrumbsPagePathDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/navigation/breadcrumbs/BreadCrumbsPagePathDataSource.java
@@ -1,5 +1,7 @@
 package io.kestros.cms.components.basic.core.navigation.breadcrumbs;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import io.kestros.cms.components.basic.api.exceptions.ComponentConfigurationException;
 import io.kestros.cms.components.basic.api.content.KestrosLink;
 import io.kestros.cms.components.basic.api.navigation.KestrosBreadCrumb;
 import io.kestros.cms.components.basic.api.navigation.KestrosBreadCrumbs;
@@ -9,15 +11,21 @@ import io.kestros.cms.sitebuilding.api.models.BaseContentPage;
 import java.util.ArrayList;
 import java.util.List;
 import javax.annotation.Nonnull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.models.annotations.Model;
 import org.apache.sling.models.annotations.Optional;
 import org.apache.sling.models.annotations.injectorspecific.Self;
 
+@SuppressFBWarnings("FCBL_FIELD_COULD_BE_LOCAL")
 @Model(adaptables = {SlingHttpServletRequest.class, Resource.class})
 public class BreadCrumbsPagePathDataSource extends BaseSlingModelDataSource
     implements KestrosBreadCrumbs {
+
+  private static final Logger LOG =
+      LoggerFactory.getLogger(BreadCrumbsPagePathDataSource.class);
 
   @Self
   @Optional

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/navigation/breadcrumbs/BreadCrumbsPagePathDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/navigation/breadcrumbs/BreadCrumbsPagePathDataSource.java
@@ -19,7 +19,9 @@ import org.apache.sling.models.annotations.Model;
 import org.apache.sling.models.annotations.Optional;
 import org.apache.sling.models.annotations.injectorspecific.Self;
 
-@SuppressFBWarnings("FCBL_FIELD_COULD_BE_LOCAL")
+@SuppressFBWarnings(value = "FCBL_FIELD_COULD_BE_LOCAL",
+    justification = "Both fields are @Self @Optional injection points. Sling Models writes them"
+        + " after the object is constructed, so neither can be a local variable.")
 @Model(adaptables = {SlingHttpServletRequest.class, Resource.class})
 public class BreadCrumbsPagePathDataSource extends BaseSlingModelDataSource
     implements KestrosBreadCrumbs {

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/navigation/breadcrumbs/BreadCrumbsPagePathDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/navigation/breadcrumbs/BreadCrumbsPagePathDataSource.java
@@ -61,6 +61,7 @@ public class BreadCrumbsPagePathDataSource extends BaseSlingModelDataSource
     return List.of();
   }
 
+  @Nonnull
   List<BaseContentPage> getAncestorPages() {
     List<BaseContentPage> pages = new ArrayList<>();
     BaseContentPage page = getCurrentOrContainingPage();

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/navigation/breadcrumbs/KestrosBreadCrumbImpl.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/navigation/breadcrumbs/KestrosBreadCrumbImpl.java
@@ -29,11 +29,13 @@ public class KestrosBreadCrumbImpl extends BaseSyntheticResource implements Kest
   }
 
   @Override
+  @Nonnull
   public Boolean isFirstItem() {
     return firstItem;
   }
 
   @Override
+  @Nonnull
   public Boolean isLastItem() {
     return lastItem;
   }

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/navigation/breadcrumbs/KestrosBreadCrumbImpl.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/navigation/breadcrumbs/KestrosBreadCrumbImpl.java
@@ -1,5 +1,6 @@
 package io.kestros.cms.components.basic.core.navigation.breadcrumbs;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.kestros.cms.components.basic.api.content.AnchorTarget;
 import io.kestros.cms.components.basic.api.content.KestrosLink;
 import io.kestros.cms.components.basic.api.exceptions.ComponentConfigurationException;
@@ -9,6 +10,7 @@ import io.kestros.cms.components.basic.core.BaseSyntheticResource;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
+@SuppressFBWarnings("IMC_IMMATURE_CLASS_NO_TOSTRING")
 public class KestrosBreadCrumbImpl extends BaseSyntheticResource implements KestrosBreadCrumb {
 
   private KestrosLink link;

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/navigation/breadcrumbs/KestrosBreadCrumbImpl.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/navigation/breadcrumbs/KestrosBreadCrumbImpl.java
@@ -10,7 +10,11 @@ import io.kestros.cms.components.basic.core.BaseSyntheticResource;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
-@SuppressFBWarnings("IMC_IMMATURE_CLASS_NO_TOSTRING")
+@SuppressFBWarnings(value = "IMC_IMMATURE_CLASS_NO_TOSTRING",
+    justification = "A style rule rather than a defect: the detector fires on every class that"
+        + " does not declare toString. The fields here are author content read from the"
+        + " repository and are reached through the getters HTL calls, so a default rendering of"
+        + " them is not something to add.")
 public class KestrosBreadCrumbImpl extends BaseSyntheticResource implements KestrosBreadCrumb {
 
   private KestrosLink link;

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/navigation/breadcrumbs/KestrosBreadCrumbsImpl.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/navigation/breadcrumbs/KestrosBreadCrumbsImpl.java
@@ -12,7 +12,11 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.apache.sling.api.SlingHttpServletRequest;
 
-@SuppressFBWarnings("IMC_IMMATURE_CLASS_NO_TOSTRING")
+@SuppressFBWarnings(value = "IMC_IMMATURE_CLASS_NO_TOSTRING",
+    justification = "A style rule rather than a defect: the detector fires on every class that"
+        + " does not declare toString. The fields here are author content read from the"
+        + " repository and are reached through the getters HTL calls, so a default rendering of"
+        + " them is not something to add.")
 public class KestrosBreadCrumbsImpl extends BaseContainerSyntheticResource
     implements KestrosBreadCrumbs {
 

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/navigation/breadcrumbs/KestrosBreadCrumbsImpl.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/navigation/breadcrumbs/KestrosBreadCrumbsImpl.java
@@ -22,7 +22,7 @@ public class KestrosBreadCrumbsImpl extends BaseContainerSyntheticResource
       @Nonnull String resourcePrefix, String forcedResourceName)
       throws ComponentConfigurationException {
     super(dataSource, resourcePrefix, forcedResourceName);
-    this.breadCrumbs = breadCrumbs;
+    this.breadCrumbs = new ArrayList<>(breadCrumbs);
   }
 
   @Nonnull

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/navigation/breadcrumbs/KestrosBreadCrumbsImpl.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/navigation/breadcrumbs/KestrosBreadCrumbsImpl.java
@@ -1,5 +1,6 @@
 package io.kestros.cms.components.basic.core.navigation.breadcrumbs;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.kestros.cms.components.basic.api.exceptions.ComponentConfigurationException;
 import io.kestros.cms.components.basic.api.navigation.KestrosBreadCrumb;
 import io.kestros.cms.components.basic.api.navigation.KestrosBreadCrumbs;
@@ -11,6 +12,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.apache.sling.api.SlingHttpServletRequest;
 
+@SuppressFBWarnings("IMC_IMMATURE_CLASS_NO_TOSTRING")
 public class KestrosBreadCrumbsImpl extends BaseContainerSyntheticResource
     implements KestrosBreadCrumbs {
 

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/navigation/nav/KestrosNavigationImpl.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/navigation/nav/KestrosNavigationImpl.java
@@ -1,5 +1,6 @@
 package io.kestros.cms.components.basic.core.navigation.nav;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.kestros.cms.components.basic.api.content.KestrosLink;
 import io.kestros.cms.components.basic.api.exceptions.ComponentConfigurationException;
 import io.kestros.cms.components.basic.api.navigation.KestrosNavigation;
@@ -11,6 +12,7 @@ import java.util.ArrayList;
 import java.util.List;
 import javax.annotation.Nonnull;
 
+@SuppressFBWarnings("IMC_IMMATURE_CLASS_NO_TOSTRING")
 public class KestrosNavigationImpl extends BaseContainerSyntheticResource
     implements KestrosNavigation {
 

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/navigation/nav/KestrosNavigationImpl.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/navigation/nav/KestrosNavigationImpl.java
@@ -12,7 +12,11 @@ import java.util.ArrayList;
 import java.util.List;
 import javax.annotation.Nonnull;
 
-@SuppressFBWarnings("IMC_IMMATURE_CLASS_NO_TOSTRING")
+@SuppressFBWarnings(value = "IMC_IMMATURE_CLASS_NO_TOSTRING",
+    justification = "A style rule rather than a defect: the detector fires on every class that"
+        + " does not declare toString. The fields here are author content read from the"
+        + " repository and are reached through the getters HTL calls, so a default rendering of"
+        + " them is not something to add.")
 public class KestrosNavigationImpl extends BaseContainerSyntheticResource
     implements KestrosNavigation {
 

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/navigation/nav/KestrosNavigationImpl.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/navigation/nav/KestrosNavigationImpl.java
@@ -22,7 +22,7 @@ public class KestrosNavigationImpl extends BaseContainerSyntheticResource
       @Nonnull String resourcePrefix, String forcedResourceName)
       throws ComponentConfigurationException {
     super(dataSource, resourcePrefix, forcedResourceName);
-    this.navigationLinks = navigationLinks;
+    this.navigationLinks = new ArrayList<>(navigationLinks);
   }
 
   @Nonnull

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/navigation/nav/NavigationItemDataSourceComponent.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/navigation/nav/NavigationItemDataSourceComponent.java
@@ -16,8 +16,12 @@ public class NavigationItemDataSourceComponent
         implements KestrosNavigationItem {
 
   @Override
+  @Nonnull
   public Boolean isActive() {
-    return null;
+    // Was `return null` from a method the interface declares @Nonnull, so any Java caller doing
+    // `if (item.isActive())` unboxed a null and threw. FALSE preserves what HTL already rendered.
+    // Nothing computes active state for a navigation item yet - that gap is unchanged here.
+    return Boolean.FALSE;
   }
 
   @Nonnull

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/navigation/nav/NavigationItemStaticDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/navigation/nav/NavigationItemStaticDataSource.java
@@ -21,8 +21,12 @@ public class NavigationItemStaticDataSource extends BaseContainerSlingModelDataS
   private LinkStaticDataSource link;
 
   @Override
+  @Nonnull
   public Boolean isActive() {
-    return null;
+    // Was `return null` from a method the interface declares @Nonnull, so any Java caller doing
+    // `if (item.isActive())` unboxed a null and threw. FALSE preserves what HTL already rendered.
+    // Nothing computes active state for a navigation item yet - that gap is unchanged here.
+    return Boolean.FALSE;
   }
 
   @Nonnull

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/navigation/nav/NavigationStaticDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/navigation/nav/NavigationStaticDataSource.java
@@ -21,8 +21,8 @@ public class NavigationStaticDataSource extends BaseContainerSlingModelDataSourc
   public List<KestrosNavigationItem> getNavigationLinkElements() {
     List<KestrosNavigationItem> links = new ArrayList<>();
     for (Resource childResource : getResource().getChildren()) {
-      if (childResource.getValueMap().get("sling:resourceType", StringUtils.EMPTY).equals(
-          KestrosNavigationItem.RESOURCE_TYPE)) {
+      if (KestrosNavigationItem.RESOURCE_TYPE.equals(
+          childResource.getValueMap().get("sling:resourceType", StringUtils.EMPTY))) {
         KestrosNavigationItem link = childResource.adaptTo(NavigationItemStaticDataSource.class);
         if (link != null) {
           links.add(link);

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/navigation/topnav/KestrosTopNavigationImpl.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/navigation/topnav/KestrosTopNavigationImpl.java
@@ -1,5 +1,6 @@
 package io.kestros.cms.components.basic.core.navigation.topnav;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.kestros.cms.components.basic.api.content.KestrosImage;
 import io.kestros.cms.components.basic.api.exceptions.ComponentConfigurationException;
 import io.kestros.cms.components.basic.api.navigation.KestrosTopNavigation;
@@ -11,6 +12,7 @@ import java.util.List;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
+@SuppressFBWarnings("IMC_IMMATURE_CLASS_NO_TOSTRING")
 public class KestrosTopNavigationImpl extends BaseContainerSyntheticResource
         implements KestrosTopNavigation {
 

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/navigation/topnav/KestrosTopNavigationImpl.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/navigation/topnav/KestrosTopNavigationImpl.java
@@ -12,7 +12,11 @@ import java.util.List;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
-@SuppressFBWarnings("IMC_IMMATURE_CLASS_NO_TOSTRING")
+@SuppressFBWarnings(value = "IMC_IMMATURE_CLASS_NO_TOSTRING",
+    justification = "A style rule rather than a defect: the detector fires on every class that"
+        + " does not declare toString. The fields here are author content read from the"
+        + " repository and are reached through the getters HTL calls, so a default rendering of"
+        + " them is not something to add.")
 public class KestrosTopNavigationImpl extends BaseContainerSyntheticResource
         implements KestrosTopNavigation {
 

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/navigation/topnav/KestrosTopNavigationImpl.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/navigation/topnav/KestrosTopNavigationImpl.java
@@ -28,7 +28,7 @@ public class KestrosTopNavigationImpl extends BaseContainerSyntheticResource
     super(dataSource, resourcePrefix, forcedResourceName);
     this.logo = logo;
     this.brandName = brandName;
-    this.navigationLinks = navigationLinks;
+    this.navigationLinks = new ArrayList<>(navigationLinks);
   }
 
   @Nonnull

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/navigation/topnav/KestrosTopNavigationItemImpl.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/navigation/topnav/KestrosTopNavigationItemImpl.java
@@ -1,5 +1,6 @@
 package io.kestros.cms.components.basic.core.navigation.topnav;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.kestros.cms.components.basic.api.content.AnchorTarget;
 import io.kestros.cms.components.basic.api.content.KestrosLink;
 import io.kestros.cms.components.basic.api.exceptions.ComponentConfigurationException;
@@ -11,6 +12,7 @@ import java.util.List;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
+@SuppressFBWarnings("IMC_IMMATURE_CLASS_NO_TOSTRING")
 public class KestrosTopNavigationItemImpl extends BaseContainerSyntheticResource
     implements KestrosTopNavigationItem {
   private KestrosLink link;

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/navigation/topnav/KestrosTopNavigationItemImpl.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/navigation/topnav/KestrosTopNavigationItemImpl.java
@@ -24,7 +24,7 @@ public class KestrosTopNavigationItemImpl extends BaseContainerSyntheticResource
       throws ComponentConfigurationException {
     super(dataSource, resourcePrefix, forcedResourceName);
     this.link = link;
-    this.childItems = childItems;
+    this.childItems = new ArrayList<>(childItems);
   }
 
   @Nonnull

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/navigation/topnav/KestrosTopNavigationItemImpl.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/navigation/topnav/KestrosTopNavigationItemImpl.java
@@ -12,7 +12,11 @@ import java.util.List;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
-@SuppressFBWarnings("IMC_IMMATURE_CLASS_NO_TOSTRING")
+@SuppressFBWarnings(value = "IMC_IMMATURE_CLASS_NO_TOSTRING",
+    justification = "A style rule rather than a defect: the detector fires on every class that"
+        + " does not declare toString. The fields here are author content read from the"
+        + " repository and are reached through the getters HTL calls, so a default rendering of"
+        + " them is not something to add.")
 public class KestrosTopNavigationItemImpl extends BaseContainerSyntheticResource
     implements KestrosTopNavigationItem {
   private KestrosLink link;

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/navigation/topnav/TopNavigationDataSourceComponent.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/navigation/topnav/TopNavigationDataSourceComponent.java
@@ -4,6 +4,7 @@ import io.kestros.cms.components.basic.api.content.KestrosImage;
 import io.kestros.cms.components.basic.api.navigation.KestrosTopNavigation;
 import io.kestros.cms.components.basic.api.navigation.KestrosTopNavigationItem;
 import io.kestros.cms.components.basic.core.BaseContainerDataSourceComponent;
+import java.util.ArrayList;
 import java.util.List;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -24,7 +25,7 @@ public class TopNavigationDataSourceComponent
     if (navigationLinks == null) {
       navigationLinks = getComponentData().getNavigationLinkElements();
     }
-    return navigationLinks;
+    return new ArrayList<>(navigationLinks);
   }
 
   @Nullable

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/navigation/topnav/TopNavigationItemDataSourceComponent.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/navigation/topnav/TopNavigationItemDataSourceComponent.java
@@ -3,6 +3,7 @@ package io.kestros.cms.components.basic.core.navigation.topnav;
 import io.kestros.cms.components.basic.api.content.AnchorTarget;
 import io.kestros.cms.components.basic.api.navigation.KestrosTopNavigationItem;
 import io.kestros.cms.components.basic.core.BaseContainerDataSourceComponent;
+import java.util.ArrayList;
 import java.util.List;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -23,7 +24,7 @@ public class TopNavigationItemDataSourceComponent
     if (navigationItems == null) {
       navigationItems = getComponentData().getNavigationItems();
     }
-    return navigationItems;
+    return new ArrayList<>(navigationItems);
   }
 
   @Nullable

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/structure/accordion/AccordionPanelStaticDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/structure/accordion/AccordionPanelStaticDataSource.java
@@ -20,13 +20,13 @@ public class AccordionPanelStaticDataSource extends BaseSlingModelDataSource
   @Nonnull
   @Override
   public Boolean isExpanded() {
-    return getResource().getValueMap().get("panelExpanded", false);
+    return getResource().getValueMap().get("panelExpanded", Boolean.FALSE);
   }
 
   @Nonnull
   @Override
   public Boolean isDisabled() {
-    return getResource().getValueMap().get("panelDisabled", false);
+    return getResource().getValueMap().get("panelDisabled", Boolean.FALSE);
   }
 
   @Nullable

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/structure/accordion/KestrosAccordionImpl.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/structure/accordion/KestrosAccordionImpl.java
@@ -20,7 +20,7 @@ public class KestrosAccordionImpl extends BaseContainerSyntheticResource
       @Nonnull String resourcePrefix, String forcedResourceName)
       throws ComponentConfigurationException {
     super(dataSource, resourcePrefix, forcedResourceName);
-    this.panels = panels;
+    this.panels = new ArrayList<>(panels);
   }
 
 

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/structure/accordion/KestrosAccordionImpl.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/structure/accordion/KestrosAccordionImpl.java
@@ -1,5 +1,6 @@
 package io.kestros.cms.components.basic.core.structure.accordion;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.kestros.cms.components.basic.api.exceptions.ComponentConfigurationException;
 import io.kestros.cms.components.basic.api.structure.KestrosAccordion;
 import io.kestros.cms.components.basic.api.structure.KestrosAccordionPanel;
@@ -9,6 +10,7 @@ import java.util.ArrayList;
 import java.util.List;
 import javax.annotation.Nonnull;
 
+@SuppressFBWarnings("IMC_IMMATURE_CLASS_NO_TOSTRING")
 public class KestrosAccordionImpl extends BaseContainerSyntheticResource
     implements KestrosAccordion {
 

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/structure/accordion/KestrosAccordionImpl.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/structure/accordion/KestrosAccordionImpl.java
@@ -10,7 +10,11 @@ import java.util.ArrayList;
 import java.util.List;
 import javax.annotation.Nonnull;
 
-@SuppressFBWarnings("IMC_IMMATURE_CLASS_NO_TOSTRING")
+@SuppressFBWarnings(value = "IMC_IMMATURE_CLASS_NO_TOSTRING",
+    justification = "A style rule rather than a defect: the detector fires on every class that"
+        + " does not declare toString. The fields here are author content read from the"
+        + " repository and are reached through the getters HTL calls, so a default rendering of"
+        + " them is not something to add.")
 public class KestrosAccordionImpl extends BaseContainerSyntheticResource
     implements KestrosAccordion {
 

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/structure/accordion/KestrosAccordionPanelImpl.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/structure/accordion/KestrosAccordionPanelImpl.java
@@ -1,5 +1,6 @@
 package io.kestros.cms.components.basic.core.structure.accordion;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.kestros.cms.components.basic.api.exceptions.ComponentConfigurationException;
 import io.kestros.cms.components.basic.api.structure.KestrosAccordionPanel;
 import io.kestros.cms.components.basic.core.BaseSlingModelDataSource;
@@ -7,6 +8,7 @@ import io.kestros.cms.components.basic.core.BaseSyntheticResource;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
+@SuppressFBWarnings("IMC_IMMATURE_CLASS_NO_TOSTRING")
 public class KestrosAccordionPanelImpl extends BaseSyntheticResource
     implements KestrosAccordionPanel {
 

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/structure/accordion/KestrosAccordionPanelImpl.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/structure/accordion/KestrosAccordionPanelImpl.java
@@ -8,7 +8,11 @@ import io.kestros.cms.components.basic.core.BaseSyntheticResource;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
-@SuppressFBWarnings("IMC_IMMATURE_CLASS_NO_TOSTRING")
+@SuppressFBWarnings(value = "IMC_IMMATURE_CLASS_NO_TOSTRING",
+    justification = "A style rule rather than a defect: the detector fires on every class that"
+        + " does not declare toString. The fields here are author content read from the"
+        + " repository and are reached through the getters HTL calls, so a default rendering of"
+        + " them is not something to add.")
 public class KestrosAccordionPanelImpl extends BaseSyntheticResource
     implements KestrosAccordionPanel {
 

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/structure/container/KestrosContainerImpl.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/structure/container/KestrosContainerImpl.java
@@ -1,5 +1,6 @@
 package io.kestros.cms.components.basic.core.structure.container;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.kestros.cms.components.basic.api.KestrosBasicComponentElement;
 import io.kestros.cms.components.basic.api.exceptions.ComponentConfigurationException;
 import io.kestros.cms.components.basic.api.structure.KestrosContainer;
@@ -9,6 +10,7 @@ import java.util.ArrayList;
 import java.util.List;
 import javax.annotation.Nonnull;
 
+@SuppressFBWarnings("IMC_IMMATURE_CLASS_NO_TOSTRING")
 public class KestrosContainerImpl extends BaseContainerSyntheticResource
     implements KestrosContainer {
 

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/structure/container/KestrosContainerImpl.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/structure/container/KestrosContainerImpl.java
@@ -20,7 +20,7 @@ public class KestrosContainerImpl extends BaseContainerSyntheticResource
       @Nonnull String resourcePrefix, String forcedResourceName)
       throws ComponentConfigurationException {
     super(dataSource, resourcePrefix, forcedResourceName);
-    this.childElements = childElements;
+    this.childElements = new ArrayList<>(childElements);
   }
 
   @Nonnull

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/structure/container/KestrosContainerImpl.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/structure/container/KestrosContainerImpl.java
@@ -10,7 +10,11 @@ import java.util.ArrayList;
 import java.util.List;
 import javax.annotation.Nonnull;
 
-@SuppressFBWarnings("IMC_IMMATURE_CLASS_NO_TOSTRING")
+@SuppressFBWarnings(value = "IMC_IMMATURE_CLASS_NO_TOSTRING",
+    justification = "A style rule rather than a defect: the detector fires on every class that"
+        + " does not declare toString. The fields here are author content read from the"
+        + " repository and are reached through the getters HTL calls, so a default rendering of"
+        + " them is not something to add.")
 public class KestrosContainerImpl extends BaseContainerSyntheticResource
     implements KestrosContainer {
 

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/structure/grid/KestrosGridImpl.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/structure/grid/KestrosGridImpl.java
@@ -9,7 +9,6 @@ import io.kestros.cms.components.basic.core.BaseSlingModelDataSource;
 import java.util.ArrayList;
 import java.util.List;
 import javax.annotation.Nonnull;
-import java.util.ArrayList;
 
 public class KestrosGridImpl extends BaseContainerSyntheticResource implements KestrosGrid {
 

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/structure/grid/KestrosGridImpl.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/structure/grid/KestrosGridImpl.java
@@ -11,7 +11,11 @@ import java.util.ArrayList;
 import java.util.List;
 import javax.annotation.Nonnull;
 
-@SuppressFBWarnings("IMC_IMMATURE_CLASS_NO_TOSTRING")
+@SuppressFBWarnings(value = "IMC_IMMATURE_CLASS_NO_TOSTRING",
+    justification = "A style rule rather than a defect: the detector fires on every class that"
+        + " does not declare toString. The fields here are author content read from the"
+        + " repository and are reached through the getters HTL calls, so a default rendering of"
+        + " them is not something to add.")
 public class KestrosGridImpl extends BaseContainerSyntheticResource implements KestrosGrid {
 
   private final List<KestrosContainer> columns;

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/structure/grid/KestrosGridImpl.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/structure/grid/KestrosGridImpl.java
@@ -1,16 +1,18 @@
 package io.kestros.cms.components.basic.core.structure.grid;
 
+import io.kestros.cms.components.basic.api.KestrosBasicComponentElement;
 import io.kestros.cms.components.basic.api.exceptions.ComponentConfigurationException;
 import io.kestros.cms.components.basic.api.structure.KestrosContainer;
 import io.kestros.cms.components.basic.api.structure.KestrosGrid;
 import io.kestros.cms.components.basic.core.BaseContainerSyntheticResource;
 import io.kestros.cms.components.basic.core.BaseSlingModelDataSource;
+import java.util.ArrayList;
 import java.util.List;
 import javax.annotation.Nonnull;
 
 public class KestrosGridImpl extends BaseContainerSyntheticResource implements KestrosGrid {
 
-  private List<KestrosContainer> columns;
+  private final List<KestrosContainer> columns;
 
   public KestrosGridImpl(
       @Nonnull List<KestrosContainer> columns,
@@ -18,7 +20,22 @@ public class KestrosGridImpl extends BaseContainerSyntheticResource implements K
       @Nonnull String resourcePrefix, String forcedResourceName)
       throws ComponentConfigurationException {
     super(dataSource, resourcePrefix, forcedResourceName);
-    this.columns = columns;
+    this.columns = new ArrayList<>(columns);
   }
 
+  /**
+   * The columns the grid was built with.
+   *
+   * <p>KestrosGrid inherits an empty default, so before this override a grid stored the columns it
+   * was constructed with and then rendered none of them - getChildren() reads getChildElements()
+   * and got back the default empty list. KestrosContainerImpl already returned its children this
+   * way; the grid is the same kind of container and now behaves like one.</p>
+   *
+   * @return The columns, as a copy.
+   */
+  @Nonnull
+  @Override
+  public List<KestrosBasicComponentElement> getChildElements() {
+    return new ArrayList<>(columns);
+  }
 }

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/structure/grid/KestrosGridImpl.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/structure/grid/KestrosGridImpl.java
@@ -1,5 +1,7 @@
 package io.kestros.cms.components.basic.core.structure.grid;
 
+import java.util.ArrayList;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.kestros.cms.components.basic.api.exceptions.ComponentConfigurationException;
 import io.kestros.cms.components.basic.api.structure.KestrosContainer;
 import io.kestros.cms.components.basic.api.structure.KestrosGrid;
@@ -7,8 +9,8 @@ import io.kestros.cms.components.basic.core.BaseContainerSyntheticResource;
 import io.kestros.cms.components.basic.core.BaseSlingModelDataSource;
 import java.util.List;
 import javax.annotation.Nonnull;
-import java.util.ArrayList;
 
+@SuppressFBWarnings("IMC_IMMATURE_CLASS_NO_TOSTRING")
 public class KestrosGridImpl extends BaseContainerSyntheticResource implements KestrosGrid {
 
   private List<KestrosContainer> columns;

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/structure/grid/KestrosGridImpl.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/structure/grid/KestrosGridImpl.java
@@ -7,6 +7,7 @@ import io.kestros.cms.components.basic.core.BaseContainerSyntheticResource;
 import io.kestros.cms.components.basic.core.BaseSlingModelDataSource;
 import java.util.List;
 import javax.annotation.Nonnull;
+import java.util.ArrayList;
 
 public class KestrosGridImpl extends BaseContainerSyntheticResource implements KestrosGrid {
 
@@ -18,7 +19,7 @@ public class KestrosGridImpl extends BaseContainerSyntheticResource implements K
       @Nonnull String resourcePrefix, String forcedResourceName)
       throws ComponentConfigurationException {
     super(dataSource, resourcePrefix, forcedResourceName);
-    this.columns = columns;
+    this.columns = new ArrayList<>(columns);
   }
 
 }

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/structure/section/KestrosSectionImpl.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/structure/section/KestrosSectionImpl.java
@@ -10,7 +10,11 @@ import java.util.List;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
-@SuppressFBWarnings("IMC_IMMATURE_CLASS_NO_TOSTRING")
+@SuppressFBWarnings(value = "IMC_IMMATURE_CLASS_NO_TOSTRING",
+    justification = "A style rule rather than a defect: the detector fires on every class that"
+        + " does not declare toString. The fields here are author content read from the"
+        + " repository and are reached through the getters HTL calls, so a default rendering of"
+        + " them is not something to add.")
 public class KestrosSectionImpl extends KestrosContainerImpl implements KestrosSection {
 
   private String backgroundImage;

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/structure/section/KestrosSectionImpl.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/structure/section/KestrosSectionImpl.java
@@ -1,5 +1,6 @@
 package io.kestros.cms.components.basic.core.structure.section;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.kestros.cms.components.basic.api.KestrosBasicComponentElement;
 import io.kestros.cms.components.basic.api.exceptions.ComponentConfigurationException;
 import io.kestros.cms.components.basic.api.structure.KestrosSection;
@@ -9,6 +10,7 @@ import java.util.List;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
+@SuppressFBWarnings("IMC_IMMATURE_CLASS_NO_TOSTRING")
 public class KestrosSectionImpl extends KestrosContainerImpl implements KestrosSection {
 
   private String backgroundImage;

--- a/kestros-basic-components/src/test/java/io/kestros/cms/components/basic/api/KestrosBasicComponentElementTest.java
+++ b/kestros-basic-components/src/test/java/io/kestros/cms/components/basic/api/KestrosBasicComponentElementTest.java
@@ -102,6 +102,9 @@ public class KestrosBasicComponentElementTest extends BaseSyntheticTest {
 
   @Test
   public void testTestGetLayout() {
+    // The property-scoped overload falls back to "default" rather than null, which is what
+    // lets the interface declare it @Nonnull.
+    assertEquals("default", alert.getLayout("absentProperty"));
   }
 
   @Test

--- a/kestros-basic-components/src/test/java/io/kestros/cms/components/basic/api/content/AnchorTargetTest.java
+++ b/kestros-basic-components/src/test/java/io/kestros/cms/components/basic/api/content/AnchorTargetTest.java
@@ -28,6 +28,23 @@ public class AnchorTargetTest {
   @Test
   public void testLookupByStringValueIsCaseInsensitive() {
     assertEquals(AnchorTarget.NEW_WINDOW, AnchorTarget.lookup("_BLANK"));
+    assertEquals(AnchorTarget.NEW_WINDOW, AnchorTarget.lookup("_BlAnK"));
+    assertEquals(AnchorTarget.SAME_WINDOW, AnchorTarget.lookup("_SELF"));
+  }
+
+  /**
+   * Case-insensitivity is ASCII-only: a non-ASCII character that Unicode case-folds onto an ASCII
+   * one must not match. Both inputs below matched before the fold was narrowed, because
+   * String.equalsIgnoreCase folds the whole Unicode range - U+212A KELVIN SIGN lowercases to 'k'
+   * and U+017F LATIN SMALL LETTER LONG S uppercases to 'S'. Both must now fall through to the
+   * SAME_WINDOW default. This test fails against the previous implementation.
+   */
+  @Test
+  public void testLookupByStringValueDoesNotFoldNonAsciiOntoAscii() {
+    assertEquals("U+212A KELVIN SIGN must not match the 'k' of _blank", AnchorTarget.SAME_WINDOW,
+        AnchorTarget.lookup("_blan\u212A"));
+    assertEquals("U+017F LONG S must not match the 's' of _self", AnchorTarget.SAME_WINDOW,
+        AnchorTarget.lookup("_\u017Felf"));
   }
 
   @Test

--- a/kestros-basic-components/src/test/java/io/kestros/cms/components/basic/core/BaseSlingModelDataSourceTest.java
+++ b/kestros-basic-components/src/test/java/io/kestros/cms/components/basic/core/BaseSlingModelDataSourceTest.java
@@ -3,12 +3,21 @@ package io.kestros.cms.components.basic.core;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
 
 import io.kestros.cms.assets.api.exceptions.AssetCollectionRetrievalException;
+import io.kestros.cms.components.basic.api.exceptions.ComponentElementRenderingException;
 import io.kestros.cms.components.basic.core.content.alert.AlertStaticDataSource;
+import io.kestros.cms.sitebuilding.api.models.BaseComponent;
 import java.util.HashMap;
 import java.util.Map;
 import org.apache.sling.api.resource.Resource;
+import org.apache.sling.api.resource.ValueMap;
 import org.junit.Test;
 
 public class BaseSlingModelDataSourceTest extends BaseDataSourceTest {
@@ -90,9 +99,74 @@ public class BaseSlingModelDataSourceTest extends BaseDataSourceTest {
   }
 
   @Test
+  public void testGetParentPathWhenResourceHasNoParent() {
+    alert = context.resourceResolver().getResource("/").adaptTo(AlertStaticDataSource.class);
+    assertNotNull(alert);
+    try {
+      alert.getParentPath();
+      fail("getParentPath returned a value for a resource that has no parent.");
+    } catch (ComponentElementRenderingException exception) {
+      assertTrue(exception.getMessage(),
+          exception.getMessage().contains("the resource has no parent"));
+    }
+  }
+
+  @Test
   public void testGetVariations() {
 
   }
+
+  @Test
+  public void testGetVariationsWhenResourceDoesNotAdaptToComponent() {
+    try {
+      dataSourceOnUnadaptableResource().getVariations();
+      fail("getVariations returned for a resource that does not adapt to a component.");
+    } catch (ComponentElementRenderingException exception) {
+      assertTrue(exception.getMessage(),
+          exception.getMessage().contains("does not adapt to a"));
+    }
+  }
+
+  @Test
+  public void testGetUiFrameworkWhenResourceDoesNotAdaptToComponent() {
+    try {
+      dataSourceOnUnadaptableResource().getUiFramework();
+      fail("getUiFramework returned for a resource that does not adapt to a component.");
+    } catch (ComponentElementRenderingException exception) {
+      assertTrue(exception.getMessage(),
+          exception.getMessage().contains("Unable to resolve the UI framework"));
+    }
+  }
+
+  @Test
+  public void testGetCurrentOrContainingPageWhenNoPageCanBeResolved() {
+    try {
+      dataSourceOnUnadaptableResource().getCurrentOrContainingPage();
+      fail("getCurrentOrContainingPage returned where no page could be resolved.");
+    } catch (ComponentElementRenderingException exception) {
+      assertTrue(exception.getMessage(),
+          exception.getMessage().contains("Unable to resolve the current or containing page"));
+    }
+  }
+
+  /**
+   * A data source adapted from a resource - so there is no request - whose resource carries no
+   * properties and does not adapt to a component. Sling resolves every resource to a component in
+   * the mock repository, so the failure has to be built rather than found.
+   *
+   * @return Data source whose resource adapts to nothing.
+   */
+  private AlertStaticDataSource dataSourceOnUnadaptableResource() {
+    resource = context.create().resource("/content/alert/static/unadaptable", properties);
+    AlertStaticDataSource dataSource = spy(resource.adaptTo(AlertStaticDataSource.class));
+    Resource unadaptable = mock(Resource.class);
+    when(unadaptable.getPath()).thenReturn("/content/alert/static/unadaptable");
+    when(unadaptable.getValueMap()).thenReturn(ValueMap.EMPTY);
+    when(unadaptable.adaptTo(BaseComponent.class)).thenReturn(null);
+    doReturn(unadaptable).when(dataSource).getResource();
+    return dataSource;
+  }
+
 
   @Test
   public void testGetLayout() {

--- a/kestros-basic-components/src/test/java/io/kestros/cms/components/basic/core/BaseSyntheticResourceTest.java
+++ b/kestros-basic-components/src/test/java/io/kestros/cms/components/basic/core/BaseSyntheticResourceTest.java
@@ -1,6 +1,7 @@
 package io.kestros.cms.components.basic.core;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.mockito.Mockito.mock;
@@ -51,7 +52,7 @@ public class BaseSyntheticResourceTest extends BaseSyntheticTest {
       exception = e;
     }
     assertNotNull(exception);
-    assertEquals("Missing required property", exception.getMessage());
+    assertTrue(exception.getMessage().startsWith("Unable to build a synthetic resource under"));
   }
 
   @Test
@@ -69,7 +70,7 @@ public class BaseSyntheticResourceTest extends BaseSyntheticTest {
       exception = e;
     }
     assertNotNull(exception);
-    assertEquals("Missing required property", exception.getMessage());
+    assertTrue(exception.getMessage().startsWith("Unable to build a synthetic resource under"));
   }
 
   @Test
@@ -87,7 +88,7 @@ public class BaseSyntheticResourceTest extends BaseSyntheticTest {
       exception = e;
     }
     assertNotNull(exception);
-    assertEquals("Missing required property", exception.getMessage());
+    assertTrue(exception.getMessage().startsWith("Unable to build a synthetic resource under"));
   }
 
   @Test

--- a/kestros-basic-components/src/test/java/io/kestros/cms/components/basic/core/PropertyBackedSyntheticResourceTest.java
+++ b/kestros-basic-components/src/test/java/io/kestros/cms/components/basic/core/PropertyBackedSyntheticResourceTest.java
@@ -1,0 +1,60 @@
+package io.kestros.cms.components.basic.core;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.sling.api.resource.ResourceMetadata;
+import org.apache.sling.testing.mock.sling.junit.SlingContext;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class PropertyBackedSyntheticResourceTest {
+
+  @Rule
+  public SlingContext context = new SlingContext();
+
+  private Map<String, Object> properties;
+  private PropertyBackedSyntheticResource resource;
+
+  @Before
+  public void setUp() {
+    properties = new HashMap<>();
+    properties.put("heading", "Original Heading");
+    resource = new PropertyBackedSyntheticResource(context.resourceResolver(),
+        new ResourceMetadata(), "kestros/components/heading", properties);
+  }
+
+  @Test
+  public void testGetValueMap() {
+    assertEquals("Original Heading", resource.getValueMap().get("heading", String.class));
+  }
+
+  @Test
+  public void testGetValueMapWhenCallerWritesToTheMapItWasGiven() {
+    resource.getValueMap().put("heading", "Rewritten Heading");
+
+    assertEquals("Original Heading", resource.getValueMap().get("heading", String.class));
+  }
+
+  @Test
+  public void testGetValueMapWhenCallerRemovesFromTheMapItWasGiven() {
+    resource.getValueMap().remove("heading");
+
+    assertEquals("Original Heading", resource.getValueMap().get("heading", String.class));
+  }
+
+  @Test
+  public void testGetValueMapWhenTheSuppliedMapChangesAfterConstruction() {
+    properties.put("heading", "Rewritten Heading");
+
+    assertEquals("Original Heading", resource.getValueMap().get("heading", String.class));
+  }
+
+  @Test
+  public void testGetValueMapWhenPropertyIsAbsent() {
+    assertNull(resource.getValueMap().get("missing", String.class));
+  }
+}

--- a/kestros-basic-components/src/test/java/io/kestros/cms/components/basic/core/PropertyBackedSyntheticResourceTest.java
+++ b/kestros-basic-components/src/test/java/io/kestros/cms/components/basic/core/PropertyBackedSyntheticResourceTest.java
@@ -1,7 +1,9 @@
 package io.kestros.cms.components.basic.core;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -56,5 +58,31 @@ public class PropertyBackedSyntheticResourceTest {
   @Test
   public void testGetValueMapWhenPropertyIsAbsent() {
     assertNull(resource.getValueMap().get("missing", String.class));
+  }
+
+  @Test
+  public void testEqualsAndHashCode() {
+    PropertyBackedSyntheticResource same = new PropertyBackedSyntheticResource(
+        context.resourceResolver(), new ResourceMetadata(), "kestros/components/heading",
+        properties);
+
+    assertEquals(resource, same);
+    assertEquals(resource.hashCode(), same.hashCode());
+  }
+
+  @Test
+  public void testEqualsWhenPropertiesDiffer() {
+    Map<String, Object> other = new HashMap<>();
+    other.put("heading", "Another Heading");
+    PropertyBackedSyntheticResource different = new PropertyBackedSyntheticResource(
+        context.resourceResolver(), new ResourceMetadata(), "kestros/components/heading", other);
+
+    assertNotEquals(resource, different);
+  }
+
+  @Test
+  public void testToStringNamesTheTypeAndPropertyCount() {
+    assertTrue(resource.toString().contains("kestros/components/heading"));
+    assertTrue(resource.toString().contains("properties=1"));
   }
 }

--- a/kestros-basic-components/src/test/java/io/kestros/cms/components/basic/core/PropertyBackedSyntheticResourceTest.java
+++ b/kestros-basic-components/src/test/java/io/kestros/cms/components/basic/core/PropertyBackedSyntheticResourceTest.java
@@ -71,6 +71,11 @@ public class PropertyBackedSyntheticResourceTest {
   }
 
   @Test
+  public void testEqualsWhenComparedToNull() {
+    assertNotEquals(null, resource);
+  }
+
+  @Test
   public void testEqualsWhenPropertiesDiffer() {
     Map<String, Object> other = new HashMap<>();
     other.put("heading", "Another Heading");

--- a/kestros-basic-components/src/test/java/io/kestros/cms/components/basic/core/content/image/KestrosImageImplTest.java
+++ b/kestros-basic-components/src/test/java/io/kestros/cms/components/basic/core/content/image/KestrosImageImplTest.java
@@ -109,4 +109,14 @@ public class KestrosImageImplTest extends BaseSyntheticTest {
     new KestrosImageImpl("", "Alt text", null, null, null, null, null,
         AnchorTarget.SAME_WINDOW, dataSource, "image", "failElement", assetRetrievalService);
   }
+
+  @Test(expected = ComponentConfigurationException.class)
+  public void testConstructorThrowsWhenResourceHasNoImagePath()
+      throws ComponentConfigurationException {
+    Resource resource = context.create().resource("/content/parent3");
+    context.currentResource(resource);
+    CardListStaticDataSource dataSource = context.request().adaptTo(CardListStaticDataSource.class);
+
+    new KestrosImageImpl(resource, dataSource, "image", "noPathElement", assetRetrievalService);
+  }
 }

--- a/kestros-basic-components/src/test/java/io/kestros/cms/components/basic/core/content/link/KestrosLinkImplTest.java
+++ b/kestros-basic-components/src/test/java/io/kestros/cms/components/basic/core/content/link/KestrosLinkImplTest.java
@@ -25,6 +25,7 @@ import io.kestros.cms.components.basic.api.content.AnchorTarget;
 import io.kestros.cms.components.basic.api.exceptions.ComponentConfigurationException;
 import io.kestros.cms.components.basic.core.BaseSyntheticTest;
 import io.kestros.cms.components.basic.core.lists.cardlist.CardListStaticDataSource;
+import io.kestros.cms.sitebuilding.api.models.BaseContentPage;
 import org.apache.sling.api.resource.Resource;
 import org.junit.Test;
 
@@ -88,5 +89,28 @@ public class KestrosLinkImplTest extends BaseSyntheticTest {
   @Test
   public void testGetLang() {
     assertEquals("en", link.getLang());
+  }
+
+  @Test
+  public void testGetTargetWhenNoneWasSupplied() throws ComponentConfigurationException {
+    CardListStaticDataSource dataSource = context.request().adaptTo(CardListStaticDataSource.class);
+
+    KestrosLinkImpl targetless = new KestrosLinkImpl("Link Text", "/content/page.html", null,
+        null, null, null, null, null, dataSource, "link", "targetlessElement");
+
+    assertEquals(AnchorTarget.SAME_WINDOW, targetless.getTarget());
+    assertEquals("_self", targetless.getTargetAsString());
+  }
+
+  @Test
+  public void testGetTargetOnALinkBuiltFromAPage() throws ComponentConfigurationException {
+    CardListStaticDataSource dataSource = context.request().adaptTo(CardListStaticDataSource.class);
+    BaseContentPage page = context.create().resource("/content/sites/test/page",
+        "jcr:primaryType", "kes:Page").adaptTo(BaseContentPage.class);
+
+    KestrosLinkImpl pageLink = new KestrosLinkImpl(page, dataSource, "link", "pageLinkElement");
+
+    assertEquals(AnchorTarget.SAME_WINDOW, pageLink.getTarget());
+    assertNull(pageLink.getTitle());
   }
 }

--- a/kestros-basic-components/src/test/java/io/kestros/cms/components/basic/core/content/videoembed/EmbedSanitizerTest.java
+++ b/kestros-basic-components/src/test/java/io/kestros/cms/components/basic/core/content/videoembed/EmbedSanitizerTest.java
@@ -144,4 +144,26 @@ public class EmbedSanitizerTest {
 
     assertNull("SVG XSS should be rejected", EmbedSanitizer.sanitize(input));
   }
+
+  /**
+   * A host that is not ASCII must be rejected outright, not case-folded into the allow-list.
+   * "www.youtube-nocooKie.com" below uses U+212A KELVIN SIGN in place of the 'k'. Java's
+   * toLowerCase folds it to 'k', so the previous implementation accepted this host as
+   * www.youtube-nocookie.com. This test fails against that implementation.
+   */
+  @Test
+  public void testNonAsciiHostFoldingOntoAllowedDomainIsRejected() {
+    String input = "<iframe src=\"https://www.youtube-nocoo\u212Aie.com/embed/abc\"></iframe>";
+
+    assertNull("A host containing U+212A must not fold onto www.youtube-nocookie.com",
+        EmbedSanitizer.sanitize(input));
+  }
+
+  @Test
+  public void testAsciiHostCaseIsStillAccepted() {
+    String input = "<iframe src=\"https://WWW.YouTube.com/embed/abc\"></iframe>";
+
+    assertNotNull("ASCII case variation of an allowed host must still be accepted",
+        EmbedSanitizer.sanitize(input));
+  }
 }

--- a/kestros-basic-components/src/test/java/io/kestros/cms/components/basic/core/structure/grid/KestrosGridImplTest.java
+++ b/kestros-basic-components/src/test/java/io/kestros/cms/components/basic/core/structure/grid/KestrosGridImplTest.java
@@ -57,4 +57,18 @@ public class KestrosGridImplTest extends BaseSyntheticTest {
     assertNotNull(syntheticResource);
     assertEquals("/synthetics/parent/gridElement", syntheticResource.getPath());
   }
+
+  @Test
+  public void testGetChildElements() {
+    List<KestrosBasicComponentElement> childElements = grid.getChildElements();
+
+    assertEquals(2, childElements.size());
+    assertEquals("col1", childElements.get(0).getForcedResourceName());
+    assertEquals("col2", childElements.get(1).getForcedResourceName());
+  }
+
+  @Test
+  public void testGetChildrenRendersTheColumns() {
+    assertEquals(2, grid.getChildren().size());
+  }
 }


### PR DESCRIPTION
What is left once the four issue types are separated out: javadoc and imports. 31 files, no behaviour change.

Stacks on 4/5. With this merged the stack is byte-identical in Java to the original #103.