### PR TITLE
Resolve the asset behind a page card's image

### DIFF
--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/card/KestrosCardImpl.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/card/KestrosCardImpl.java
@@ -117,19 +117,6 @@ public class KestrosCardImpl extends BaseContainerSyntheticResource implements K
   }
 
   /**
-   * Resolves the asset behind a page's image, so the card can carry the asset's own title and
-   * description.
-   *
-   * <p>A card whose asset cannot be resolved still renders its image - it simply loses the title
-   * and description - and the failure is logged rather than swallowed. Danny, 2026-08-04: dropping
-   * the card would surprise an author more than a missing caption, and silence is what hid this
-   * for months.
-   *
-   * @param page Page the card is built from.
-   * @return The page image's asset, or null when there is no service, no image path, or the asset
-   *         cannot be resolved.
-   */
-  /**
    * The asset's title and description, already read. Reading them is part of resolving the asset:
    * an asset that resolves but whose properties cannot be read is just as unreadable as one that
    * does not resolve, and the caller must not have to guard the getters separately.
@@ -149,16 +136,18 @@ public class KestrosCardImpl extends BaseContainerSyntheticResource implements K
    * the asset inside the same guard.
    *
    * <p>The properties are read here rather than by the caller deliberately. When they were read at
-   * the call site, an asset that resolved but threw from {@code getTitle()} escaped the constructor,
+   * the call site, an asset that resolved but threw from {@code getTitle()} escaped the
+   * constructor,
    * and {@code CardListChildPagesDataSource} turns anything escaping into a RuntimeException that
    * loses the whole card list. One unreadable asset blanked the page.
    *
    * @param page Page the card is built from.
-   * @return The asset's title and description, both null when there is no service, no image path, or
+   * @return The asset's title and description, both null when there is no service, no image
+   *         path, or
    *         the asset cannot be resolved or read.
    */
   @Nonnull
-  AssetText readAssetTextForPage(@Nonnull final BaseContentPage page) {
+  final AssetText readAssetTextForPage(@Nonnull final BaseContentPage page) {
     final Asset asset = getAssetForPage(page);
     if (asset == null) {
       return new AssetText(null, null);
@@ -166,15 +155,30 @@ public class KestrosCardImpl extends BaseContainerSyntheticResource implements K
     try {
       return new AssetText(asset.getTitle(), asset.getDescription());
     } catch (final RuntimeException e) {
+      final String safePath = page.getPath().replaceAll("[\r\n]", "");
       LOG.warn("Resolved the asset for card image on {} but could not read its properties. {}: {} "
-              + "The image renders without the asset's title or description.", page.getPath(),
-              e.getClass().getSimpleName(), e.getMessage());
+              + "The image renders without the asset's title or description.", safePath,
+              e.getClass().getSimpleName(), e.getMessage(), e);
       return new AssetText(null, null);
     }
   }
 
+  /**
+   * Resolves the asset behind a page's image, so the card can carry the asset's own title and
+   * description.
+   *
+   * <p>A card whose asset cannot be resolved still renders its image - it simply loses the title
+   * and description - and the failure is logged rather than swallowed. Danny, 2026-08-04: dropping
+   * the card would surprise an author more than a missing caption, and silence is what hid this
+   * for months.
+   *
+   * @param page Page the card is built from.
+   * @return The page image's asset, or null when there is no service, no image path, or the asset
+   *         cannot be resolved.
+   */
   @Nullable
-  Asset getAssetForPage(@Nonnull final BaseContentPage page) {
+  final Asset getAssetForPage(@Nonnull final BaseContentPage page) {
+    final String safePath = page.getPath().replaceAll("[\r\n]", "");
     final String imagePath = page.getImagePath();
     if (StringUtils.isBlank(imagePath)) {
       return null;
@@ -182,22 +186,22 @@ public class KestrosCardImpl extends BaseContainerSyntheticResource implements K
     if (assetRetrievalService == null) {
       LOG.warn("Unable to resolve the asset for card image on {}. No AssetRetrievalService "
               + "available; the image renders without the asset's title or description.",
-              page.getPath());
+              safePath);
       return null;
     }
     try {
       return assetRetrievalService.getAsset(imagePath, null, page.getResourceResolver());
     } catch (final AssetRetrievalException e) {
       LOG.warn("Unable to resolve asset {} for card image on {}. {} The image renders without the "
-              + "asset's title or description.", imagePath, page.getPath(), e.getMessage());
+              + "asset's title or description.", imagePath, safePath, e.getMessage(), e);
       return null;
     } catch (final RuntimeException e) {
       // A card that cannot resolve its asset must still render. CardListChildPagesDataSource wraps
       // anything escaping this constructor in a RuntimeException, which loses the WHOLE card list -
       // so one unreadable asset would blank the page rather than drop one caption.
       LOG.warn("Unexpected failure resolving asset {} for card image on {}. {}: {} The image "
-              + "renders without the asset's title or description.", imagePath, page.getPath(),
-              e.getClass().getSimpleName(), e.getMessage());
+              + "renders without the asset's title or description.", imagePath, safePath,
+              e.getClass().getSimpleName(), e.getMessage(), e);
       return null;
     }
   }

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/card/KestrosCardImpl.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/card/KestrosCardImpl.java
@@ -1,5 +1,7 @@
 package io.kestros.cms.components.basic.core.content.card;
 
+import io.kestros.cms.assets.api.exceptions.AssetRetrievalException;
+import io.kestros.cms.assets.api.models.Asset;
 import io.kestros.cms.assets.api.services.AssetRetrievalService;
 import io.kestros.cms.components.basic.api.content.AnchorTarget;
 import io.kestros.cms.components.basic.api.content.KestrosButton;
@@ -23,8 +25,12 @@ import javax.annotation.Nullable;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.sling.models.annotations.Optional;
 import org.apache.sling.models.annotations.injectorspecific.OSGiService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class KestrosCardImpl extends BaseContainerSyntheticResource implements KestrosCard {
+
+  private static final Logger LOG = LoggerFactory.getLogger(KestrosCardImpl.class);
 
   private KestrosHeading title;
   private String description;
@@ -40,7 +46,37 @@ public class KestrosCardImpl extends BaseContainerSyntheticResource implements K
           @Nonnull BaseSlingModelDataSource dataSource,
           @Nonnull String resourcePrefix,
           @Nullable String forcedResourceName) throws ComponentConfigurationException {
+    this(page, buttonText, dataSource, resourcePrefix, forcedResourceName, null);
+  }
+
+  /**
+   * Builds a card from a page, resolving the page's image against the asset repository so the card
+   * can show the asset's own title and description.
+   *
+   * <p>Callers that have an {@link AssetRetrievalService} should use this constructor. The
+   * five-argument one delegates here with a null service, which is why cards built by callers
+   * without one lose the asset's title and description.
+   *
+   * @param page Page to build the card from.
+   * @param buttonText Text for the card's button, or null for no button.
+   * @param dataSource Data source the card belongs to.
+   * @param resourcePrefix Resource prefix.
+   * @param forcedResourceName Forced resource name, or null.
+   * @param assetRetrievalService Service used to look up the image's asset. Null is tolerated: the
+   *         image still renders, without the asset's title or description.
+   * @throws ComponentConfigurationException Card could not be configured.
+   */
+  public KestrosCardImpl(BaseContentPage page, @Nullable String buttonText,
+          @Nonnull BaseSlingModelDataSource dataSource,
+          @Nonnull String resourcePrefix,
+          @Nullable String forcedResourceName,
+          @Nullable AssetRetrievalService assetRetrievalService)
+          throws ComponentConfigurationException {
     super(dataSource, resourcePrefix, forcedResourceName);
+
+    if (assetRetrievalService != null) {
+      this.assetRetrievalService = assetRetrievalService;
+    }
 
     this.description = page.getDisplayDescription();
     try {
@@ -49,12 +85,16 @@ public class KestrosCardImpl extends BaseContainerSyntheticResource implements K
     } catch (final ComponentConfigurationException e) {
       this.title = null;
     }
+    final Asset asset = getAssetForPage(page);
     try {
-      this.image = new KestrosImageImpl(page.getImagePath(), null, null, null,
+      this.image = new KestrosImageImpl(page.getImagePath(),
+              asset != null ? asset.getTitle() : null,
+              asset != null ? asset.getDescription() : null,
+              asset != null ? asset.getTitle() : null,
               null, null, null, AnchorTarget.SAME_WINDOW,
               dataSource,
               "image",
-              "imageElement", assetRetrievalService);
+              "imageElement", this.assetRetrievalService);
     } catch (final ComponentConfigurationException e) {
       this.image = null;
     }
@@ -73,6 +113,40 @@ public class KestrosCardImpl extends BaseContainerSyntheticResource implements K
       }
     } catch (final ComponentConfigurationException e) {
       this.buttonGroup = null;
+    }
+  }
+
+  /**
+   * Resolves the asset behind a page's image, so the card can carry the asset's own title and
+   * description.
+   *
+   * <p>A card whose asset cannot be resolved still renders its image - it simply loses the title
+   * and description - and the failure is logged rather than swallowed. Danny, 2026-08-04: dropping
+   * the card would surprise an author more than a missing caption, and silence is what hid this
+   * for months.
+   *
+   * @param page Page the card is built from.
+   * @return The page image's asset, or null when there is no service, no image path, or the asset
+   *         cannot be resolved.
+   */
+  @Nullable
+  Asset getAssetForPage(@Nonnull final BaseContentPage page) {
+    if (assetRetrievalService == null) {
+      LOG.warn("Unable to resolve the asset for card image on {}. No AssetRetrievalService "
+              + "available; the image renders without the asset's title or description.",
+              page.getPath());
+      return null;
+    }
+    final String imagePath = page.getImagePath();
+    if (StringUtils.isBlank(imagePath)) {
+      return null;
+    }
+    try {
+      return assetRetrievalService.getAsset(imagePath, null, page.getResourceResolver());
+    } catch (final AssetRetrievalException e) {
+      LOG.warn("Unable to resolve asset {} for card image on {}. {} The image renders without the "
+              + "asset's title or description.", imagePath, page.getPath(), e.getMessage());
+      return null;
     }
   }
 

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/card/KestrosCardImpl.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/card/KestrosCardImpl.java
@@ -23,8 +23,6 @@ import java.util.List;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.sling.models.annotations.Optional;
-import org.apache.sling.models.annotations.injectorspecific.OSGiService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -38,8 +36,12 @@ public class KestrosCardImpl extends BaseContainerSyntheticResource implements K
   private String layout;
   private KestrosImage image;
   private KestrosButtonGroup buttonGroup;
-  @OSGiService
-  @Optional
+  /**
+   * Set from the constructor, never injected: this class is not a Sling Model and is only ever
+   * built with {@code new}. It previously carried {@code @OSGiService @Optional}, which looked like
+   * injection and did nothing - the exact confusion this card was opened to remove.
+   */
+  @Nullable
   private AssetRetrievalService assetRetrievalService;
 
   public KestrosCardImpl(BaseContentPage page, @Nullable String buttonText,
@@ -74,9 +76,7 @@ public class KestrosCardImpl extends BaseContainerSyntheticResource implements K
           throws ComponentConfigurationException {
     super(dataSource, resourcePrefix, forcedResourceName);
 
-    if (assetRetrievalService != null) {
-      this.assetRetrievalService = assetRetrievalService;
-    }
+    this.assetRetrievalService = assetRetrievalService;
 
     this.description = page.getDisplayDescription();
     try {
@@ -131,14 +131,14 @@ public class KestrosCardImpl extends BaseContainerSyntheticResource implements K
    */
   @Nullable
   Asset getAssetForPage(@Nonnull final BaseContentPage page) {
+    final String imagePath = page.getImagePath();
+    if (StringUtils.isBlank(imagePath)) {
+      return null;
+    }
     if (assetRetrievalService == null) {
       LOG.warn("Unable to resolve the asset for card image on {}. No AssetRetrievalService "
               + "available; the image renders without the asset's title or description.",
               page.getPath());
-      return null;
-    }
-    final String imagePath = page.getImagePath();
-    if (StringUtils.isBlank(imagePath)) {
       return null;
     }
     try {
@@ -147,8 +147,17 @@ public class KestrosCardImpl extends BaseContainerSyntheticResource implements K
       LOG.warn("Unable to resolve asset {} for card image on {}. {} The image renders without the "
               + "asset's title or description.", imagePath, page.getPath(), e.getMessage());
       return null;
+    } catch (final RuntimeException e) {
+      // A card that cannot resolve its asset must still render. CardListChildPagesDataSource wraps
+      // anything escaping this constructor in a RuntimeException, which loses the WHOLE card list -
+      // so one unreadable asset would blank the page rather than drop one caption.
+      LOG.warn("Unexpected failure resolving asset {} for card image on {}. {}: {} The image "
+              + "renders without the asset's title or description.", imagePath, page.getPath(),
+              e.getClass().getSimpleName(), e.getMessage());
+      return null;
     }
   }
+
 
   public KestrosCardImpl(String description, KestrosHeading title, KestrosImage image,
           KestrosButtonGroup buttonGroup,

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/card/KestrosCardImpl.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/card/KestrosCardImpl.java
@@ -85,12 +85,12 @@ public class KestrosCardImpl extends BaseContainerSyntheticResource implements K
     } catch (final ComponentConfigurationException e) {
       this.title = null;
     }
-    final Asset asset = getAssetForPage(page);
+    final AssetText assetText = readAssetTextForPage(page);
     try {
       this.image = new KestrosImageImpl(page.getImagePath(),
-              asset != null ? asset.getTitle() : null,
-              asset != null ? asset.getDescription() : null,
-              asset != null ? asset.getTitle() : null,
+              assetText.title,
+              assetText.description,
+              assetText.title,
               null, null, null, AnchorTarget.SAME_WINDOW,
               dataSource,
               "image",
@@ -129,6 +129,50 @@ public class KestrosCardImpl extends BaseContainerSyntheticResource implements K
    * @return The page image's asset, or null when there is no service, no image path, or the asset
    *         cannot be resolved.
    */
+  /**
+   * The asset's title and description, already read. Reading them is part of resolving the asset:
+   * an asset that resolves but whose properties cannot be read is just as unreadable as one that
+   * does not resolve, and the caller must not have to guard the getters separately.
+   */
+  static final class AssetText {
+    private final String title;
+    private final String description;
+
+    AssetText(@Nullable final String title, @Nullable final String description) {
+      this.title = title;
+      this.description = description;
+    }
+  }
+
+  /**
+   * Resolves the page's image asset AND reads its title and description, with every call against
+   * the asset inside the same guard.
+   *
+   * <p>The properties are read here rather than by the caller deliberately. When they were read at
+   * the call site, an asset that resolved but threw from {@code getTitle()} escaped the constructor,
+   * and {@code CardListChildPagesDataSource} turns anything escaping into a RuntimeException that
+   * loses the whole card list. One unreadable asset blanked the page.
+   *
+   * @param page Page the card is built from.
+   * @return The asset's title and description, both null when there is no service, no image path, or
+   *         the asset cannot be resolved or read.
+   */
+  @Nonnull
+  AssetText readAssetTextForPage(@Nonnull final BaseContentPage page) {
+    final Asset asset = getAssetForPage(page);
+    if (asset == null) {
+      return new AssetText(null, null);
+    }
+    try {
+      return new AssetText(asset.getTitle(), asset.getDescription());
+    } catch (final RuntimeException e) {
+      LOG.warn("Resolved the asset for card image on {} but could not read its properties. {}: {} "
+              + "The image renders without the asset's title or description.", page.getPath(),
+              e.getClass().getSimpleName(), e.getMessage());
+      return new AssetText(null, null);
+    }
+  }
+
   @Nullable
   Asset getAssetForPage(@Nonnull final BaseContentPage page) {
     final String imagePath = page.getImagePath();

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/card/KestrosCardImpl.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/card/KestrosCardImpl.java
@@ -117,6 +117,19 @@ public class KestrosCardImpl extends BaseContainerSyntheticResource implements K
   }
 
   /**
+   * Strips CR and LF from a value before it is logged. Applied to every untrusted value, not only
+   * the JCR path: {@code imagePath} is an author-controlled property and an exception message can
+   * carry anything, so those are the ones that can actually forge a log line.
+   *
+   * @param value Value about to be logged.
+   * @return The value with CR and LF removed, or null unchanged.
+   */
+  @Nullable
+  private static String forLog(@Nullable final String value) {
+    return value == null ? null : value.replaceAll("[\r\n]", "");
+  }
+
+  /**
    * The asset's title and description, already read. Reading them is part of resolving the asset:
    * an asset that resolves but whose properties cannot be read is just as unreadable as one that
    * does not resolve, and the caller must not have to guard the getters separately.
@@ -137,14 +150,13 @@ public class KestrosCardImpl extends BaseContainerSyntheticResource implements K
    *
    * <p>The properties are read here rather than by the caller deliberately. When they were read at
    * the call site, an asset that resolved but threw from {@code getTitle()} escaped the
-   * constructor,
-   * and {@code CardListChildPagesDataSource} turns anything escaping into a RuntimeException that
+   * constructor, and {@code CardListChildPagesDataSource} turns anything escaping into a
+   * RuntimeException that
    * loses the whole card list. One unreadable asset blanked the page.
    *
    * @param page Page the card is built from.
    * @return The asset's title and description, both null when there is no service, no image
-   *         path, or
-   *         the asset cannot be resolved or read.
+   *         path, or the asset cannot be resolved or read.
    */
   @Nonnull
   final AssetText readAssetTextForPage(@Nonnull final BaseContentPage page) {
@@ -155,10 +167,10 @@ public class KestrosCardImpl extends BaseContainerSyntheticResource implements K
     try {
       return new AssetText(asset.getTitle(), asset.getDescription());
     } catch (final RuntimeException e) {
-      final String safePath = page.getPath().replaceAll("[\r\n]", "");
+      final String safePath = forLog(page.getPath());
       LOG.warn("Resolved the asset for card image on {} but could not read its properties. {}: {} "
               + "The image renders without the asset's title or description.", safePath,
-              e.getClass().getSimpleName(), e.getMessage(), e);
+              e.getClass().getSimpleName(), forLog(e.getMessage()), e);
       return new AssetText(null, null);
     }
   }
@@ -178,11 +190,11 @@ public class KestrosCardImpl extends BaseContainerSyntheticResource implements K
    */
   @Nullable
   final Asset getAssetForPage(@Nonnull final BaseContentPage page) {
-    final String safePath = page.getPath().replaceAll("[\r\n]", "");
     final String imagePath = page.getImagePath();
     if (StringUtils.isBlank(imagePath)) {
       return null;
     }
+    final String safePath = forLog(page.getPath());
     if (assetRetrievalService == null) {
       LOG.warn("Unable to resolve the asset for card image on {}. No AssetRetrievalService "
               + "available; the image renders without the asset's title or description.",
@@ -193,15 +205,17 @@ public class KestrosCardImpl extends BaseContainerSyntheticResource implements K
       return assetRetrievalService.getAsset(imagePath, null, page.getResourceResolver());
     } catch (final AssetRetrievalException e) {
       LOG.warn("Unable to resolve asset {} for card image on {}. {} The image renders without the "
-              + "asset's title or description.", imagePath, safePath, e.getMessage(), e);
+              + "asset's title or description.", forLog(imagePath), safePath,
+              forLog(e.getMessage()), e);
       return null;
     } catch (final RuntimeException e) {
       // A card that cannot resolve its asset must still render. CardListChildPagesDataSource wraps
       // anything escaping this constructor in a RuntimeException, which loses the WHOLE card list -
       // so one unreadable asset would blank the page rather than drop one caption.
       LOG.warn("Unexpected failure resolving asset {} for card image on {}. {}: {} The image "
-              + "renders without the asset's title or description.", imagePath, safePath,
-              e.getClass().getSimpleName(), e.getMessage(), e);
+              + "renders without the asset's title or description.", forLog(imagePath),
+              safePath,
+              e.getClass().getSimpleName(), forLog(e.getMessage()), e);
       return null;
     }
   }

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/lists/cardlist/CardListChildPagesDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/lists/cardlist/CardListChildPagesDataSource.java
@@ -21,6 +21,7 @@ import javax.annotation.Nullable;
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.models.annotations.Model;
+import org.apache.sling.models.annotations.Optional;
 import org.apache.sling.models.annotations.injectorspecific.OSGiService;
 
 @Model(adaptables = {SlingHttpServletRequest.class, Resource.class})
@@ -28,7 +29,7 @@ public class CardListChildPagesDataSource extends BaseContainerSlingModelDataSou
                                                                                     KestrosCardList {
 
   @OSGiService
-  @org.apache.sling.models.annotations.Optional
+  @Optional
   private AssetRetrievalService assetRetrievalService;
 
   private BaseContentPage rootPage;

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/lists/cardlist/CardListChildPagesDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/lists/cardlist/CardListChildPagesDataSource.java
@@ -1,5 +1,6 @@
 package io.kestros.cms.components.basic.core.lists.cardlist;
 
+import io.kestros.cms.assets.api.services.AssetRetrievalService;
 import io.kestros.cms.components.basic.api.content.KestrosButton;
 import io.kestros.cms.components.basic.api.content.KestrosButtonGroup;
 import io.kestros.cms.components.basic.api.content.KestrosCard;
@@ -20,10 +21,16 @@ import javax.annotation.Nullable;
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.models.annotations.Model;
+import org.apache.sling.models.annotations.injectorspecific.OSGiService;
 
 @Model(adaptables = {SlingHttpServletRequest.class, Resource.class})
 public class CardListChildPagesDataSource extends BaseContainerSlingModelDataSource implements
                                                                                     KestrosCardList {
+
+  @OSGiService
+  @org.apache.sling.models.annotations.Optional
+  private AssetRetrievalService assetRetrievalService;
+
   private BaseContentPage rootPage;
 
   BaseContentPage getRootPage() {
@@ -127,7 +134,8 @@ public class CardListChildPagesDataSource extends BaseContainerSlingModelDataSou
 //                getElementVariations("buttonVariations", KestrosButton.RESOURCE_TYPE),
 //                getLayout("button"),
 //                null,
-                page.getName()));
+                page.getName(),
+                assetRetrievalService));
       } catch (Exception e) {
         throw new RuntimeException(e);
       }

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/lists/cardlist/CardListTagSearchDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/lists/cardlist/CardListTagSearchDataSource.java
@@ -1,5 +1,6 @@
 package io.kestros.cms.components.basic.core.lists.cardlist;
 
+import io.kestros.cms.assets.api.services.AssetRetrievalService;
 import io.kestros.cms.components.basic.api.content.KestrosCard;
 import io.kestros.cms.components.basic.api.lists.KestrosCardList;
 import io.kestros.cms.components.basic.core.BaseContainerSlingModelDataSource;
@@ -30,6 +31,10 @@ public class CardListTagSearchDataSource extends BaseContainerSlingModelDataSour
   @OSGiService
   @org.apache.sling.models.annotations.Optional
   private TagRetrievalService tagRetrievalService;
+
+  @OSGiService
+  @org.apache.sling.models.annotations.Optional
+  private AssetRetrievalService assetRetrievalService;
 
   private BaseContentPage containingPage;
 
@@ -189,7 +194,8 @@ public class CardListTagSearchDataSource extends BaseContainerSlingModelDataSour
                 getReadMoreText(),
                 this,
                 "card",
-                page.getName()));
+                page.getName(),
+                assetRetrievalService));
       } catch (Exception e) {
         // Skip cards that fail to construct — null-safe
       }

--- a/kestros-basic-components/src/test/java/io/kestros/cms/components/basic/core/content/card/KestrosCardImplTest.java
+++ b/kestros-basic-components/src/test/java/io/kestros/cms/components/basic/core/content/card/KestrosCardImplTest.java
@@ -251,4 +251,26 @@ public class KestrosCardImplTest extends BaseSyntheticTest {
             appender.list.stream().noneMatch(
                     event -> event.getFormattedMessage().contains("No AssetRetrievalService")));
   }
+
+  /**
+   * The defect the previous round missed: the asset resolved, but reading its properties threw, and
+   * that read sat outside the guard. It escaped the constructor and blanked the whole card list.
+   */
+  @Test
+  public void testCardStillBuildsWhenTheResolvedAssetCannotBeRead() throws Exception {
+    Asset unreadable = mock(Asset.class);
+    when(unreadable.getTitle()).thenThrow(new IllegalStateException("asset resolver closed"));
+    AssetRetrievalService service = mock(AssetRetrievalService.class);
+    when(service.getAsset("/content/assets/photo.jpg", null,
+            context.resourceResolver())).thenReturn(unreadable);
+
+    KestrosCardImpl pageCard = new KestrosCardImpl(pageWithImage(), "Read more", newDataSource(),
+            "card", "unreadableAssetCard", service);
+
+    KestrosImage cardImage = pageCard.getImageElement();
+    assertNotNull("the card must still be built", cardImage);
+    assertEquals("the image path still comes from the page", "/content/assets/photo.jpg",
+            cardImage.getImagePath());
+    assertNull("an unreadable asset yields no title", cardImage.getAltText());
+  }
 }

--- a/kestros-basic-components/src/test/java/io/kestros/cms/components/basic/core/content/card/KestrosCardImplTest.java
+++ b/kestros-basic-components/src/test/java/io/kestros/cms/components/basic/core/content/card/KestrosCardImplTest.java
@@ -2,7 +2,19 @@ package io.kestros.cms.components.basic.core.content.card;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
 
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import io.kestros.cms.assets.api.exceptions.AssetRetrievalException;
+import io.kestros.cms.assets.api.models.Asset;
+import io.kestros.cms.assets.api.services.AssetRetrievalService;
 import io.kestros.cms.components.basic.api.content.AnchorTarget;
 import io.kestros.cms.components.basic.api.content.KestrosButtonGroup;
 import io.kestros.cms.components.basic.api.content.KestrosHeading;
@@ -14,8 +26,11 @@ import io.kestros.cms.components.basic.core.content.heading.KestrosHeadingImpl;
 import io.kestros.cms.components.basic.core.content.image.KestrosImageImpl;
 import io.kestros.cms.components.basic.core.lists.cardlist.CardListStaticDataSource;
 import io.kestros.cms.componenttypes.api.models.ComponentVariation;
+import io.kestros.cms.sitebuilding.api.models.BaseContentPage;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import org.apache.sling.api.resource.Resource;
 import org.junit.Test;
 
@@ -106,6 +121,93 @@ public class KestrosCardImplTest extends BaseSyntheticTest {
   @Test
   public void testGetButtonGroupElement() {
     assertNotNull(card.getButtonGroupElement());
+  }
+
+  private CardListStaticDataSource newDataSource() {
+    Resource resource = context.create().resource("/content/page-card-parent");
+    context.currentResource(resource);
+    return context.request().adaptTo(CardListStaticDataSource.class);
+  }
+
+  /**
+   * A real adapted page rather than a bare mock: BaseResource.getResourceResolver() is final, so a
+   * mock NPEs the moment the card asks it for a resolver.
+   */
+  private BaseContentPage pageWithImage() {
+    Map<String, Object> pageProperties = new HashMap<>();
+    pageProperties.put("jcr:primaryType", "kes:Page");
+    Resource pageResource = context.create().resource("/content/pages/page", pageProperties);
+    BaseContentPage page = spy(pageResource.adaptTo(BaseContentPage.class));
+    doReturn("Page Title").when(page).getDisplayTitle();
+    doReturn("Page Description").when(page).getDisplayDescription();
+    doReturn("/content/assets/photo.jpg").when(page).getImagePath();
+    return page;
+  }
+
+  private ListAppender<ILoggingEvent> attachAppenderToCardLogger() {
+    ch.qos.logback.classic.Logger logger
+            = (ch.qos.logback.classic.Logger) org.slf4j.LoggerFactory.getLogger(
+            KestrosCardImpl.class);
+    logger.setLevel(Level.TRACE);
+    ListAppender<ILoggingEvent> appender = new ListAppender<>();
+    appender.start();
+    logger.addAppender(appender);
+    return appender;
+  }
+
+  @Test
+  public void testCardBuiltFromPageShowsTheAssetsTitleAndDescription() throws Exception {
+    Asset asset = mock(Asset.class);
+    when(asset.getTitle()).thenReturn("Asset Title");
+    when(asset.getDescription()).thenReturn("Asset Description");
+    AssetRetrievalService service = mock(AssetRetrievalService.class);
+    when(service.getAsset("/content/assets/photo.jpg", null,
+            context.resourceResolver())).thenReturn(asset);
+
+    KestrosCardImpl pageCard = new KestrosCardImpl(pageWithImage(), "Read more", newDataSource(), "card",
+            "pageCard", service);
+
+    KestrosImage cardImage = pageCard.getImageElement();
+    assertNotNull(cardImage);
+    assertEquals("Asset Title", cardImage.getImageTitle());
+    assertEquals("Asset Title", cardImage.getAltText());
+    assertEquals("Asset Description", cardImage.getCaption());
+  }
+
+  @Test
+  public void testCardBuiltFromPageStillRendersTheImageWhenTheAssetCannotBeResolved()
+          throws Exception {
+    ListAppender<ILoggingEvent> appender = attachAppenderToCardLogger();
+    AssetRetrievalService service = mock(AssetRetrievalService.class);
+    when(service.getAsset("/content/assets/photo.jpg", null,
+            context.resourceResolver())).thenThrow(new AssetRetrievalException("no such asset"));
+
+    KestrosCardImpl pageCard = new KestrosCardImpl(pageWithImage(), "Read more", newDataSource(), "card",
+            "pageCard", service);
+
+    KestrosImage cardImage = pageCard.getImageElement();
+    assertNotNull("the image must still render when the asset cannot be resolved", cardImage);
+    assertEquals("/content/assets/photo.jpg", cardImage.getImagePath());
+    assertNull(cardImage.getImageTitle());
+
+    assertTrue("an unresolvable asset must be logged, not swallowed",
+            appender.list.stream().anyMatch(
+                    event -> Level.WARN.equals(event.getLevel()) && event.getMessage().contains(
+                            "Unable to resolve asset")));
+  }
+
+  @Test
+  public void testCardBuiltFromPageWarnsWhenThereIsNoAssetRetrievalService() throws Exception {
+    ListAppender<ILoggingEvent> appender = attachAppenderToCardLogger();
+
+    KestrosCardImpl pageCard = new KestrosCardImpl(pageWithImage(), "Read more", newDataSource(), "card",
+            "pageCard");
+
+    assertNotNull(pageCard.getImageElement());
+    assertTrue("a missing AssetRetrievalService must be logged, not silently ignored",
+            appender.list.stream().anyMatch(
+                    event -> Level.WARN.equals(event.getLevel()) && event.getMessage().contains(
+                            "No AssetRetrievalService")));
   }
 
 }

--- a/kestros-basic-components/src/test/java/io/kestros/cms/components/basic/core/content/card/KestrosCardImplTest.java
+++ b/kestros-basic-components/src/test/java/io/kestros/cms/components/basic/core/content/card/KestrosCardImplTest.java
@@ -210,4 +210,45 @@ public class KestrosCardImplTest extends BaseSyntheticTest {
                             "No AssetRetrievalService")));
   }
 
+  /**
+   * An unchecked failure from the asset service must not escape the constructor.
+   * CardListChildPagesDataSource wraps anything thrown here in a RuntimeException, which loses the
+   * whole card list, so one unreadable asset would blank the page rather than drop one caption.
+   */
+  @Test
+  public void testCardStillBuildsWhenTheAssetServiceThrowsAnUncheckedException() throws Exception {
+    AssetRetrievalService service = mock(AssetRetrievalService.class);
+    when(service.getAsset("/content/assets/photo.jpg", null,
+            context.resourceResolver())).thenThrow(new IllegalStateException("resolver closed"));
+
+    KestrosCardImpl pageCard = new KestrosCardImpl(pageWithImage(), "Read more", newDataSource(),
+            "card", "uncheckedCard", service);
+
+    KestrosImage cardImage = pageCard.getImageElement();
+    assertNotNull("the card must still be built", cardImage);
+    assertEquals("the image path still comes from the page", "/content/assets/photo.jpg",
+            cardImage.getImagePath());
+    assertNull("with no resolvable asset there is no title to show", cardImage.getAltText());
+  }
+
+  /**
+   * A page with no image must not warn about a missing AssetRetrievalService. The blank-path check
+   * runs first, so an instance without the service does not log once per card per page.
+   */
+  @Test
+  public void testPageWithNoImageDoesNotWarnAboutTheMissingAssetService() throws Exception {
+    ListAppender<ILoggingEvent> appender = attachAppenderToCardLogger();
+
+    Map<String, Object> pageProperties = new HashMap<>();
+    pageProperties.put("jcr:primaryType", "kes:Page");
+    Resource pageResource = context.create().resource("/content/pages/no-image", pageProperties);
+    BaseContentPage page = spy(pageResource.adaptTo(BaseContentPage.class));
+    doReturn("").when(page).getImagePath();
+
+    new KestrosCardImpl(page, "Read more", newDataSource(), "card", "noImageCard", null);
+
+    assertTrue("a page with no image must not warn about the asset service",
+            appender.list.stream().noneMatch(
+                    event -> event.getFormattedMessage().contains("No AssetRetrievalService")));
+  }
 }

--- a/kestros-basic-components/src/test/java/io/kestros/cms/components/basic/core/lists/cardlist/CardListChildPagesDataSourceTest.java
+++ b/kestros-basic-components/src/test/java/io/kestros/cms/components/basic/core/lists/cardlist/CardListChildPagesDataSourceTest.java
@@ -29,6 +29,7 @@ public class CardListChildPagesDataSourceTest extends BaseDataSourceTest {
 
   @Override
   public void doComponentSetup() throws AssetCollectionRetrievalException {
+    registerAssetRetrievalService();
     setUpSampleCollection("/content/collection");
     setupSamplePage("/content/page", "/content/collection/asset-1");
 
@@ -337,4 +338,72 @@ public class CardListChildPagesDataSourceTest extends BaseDataSourceTest {
     assertEquals(5, context.request().adaptTo(CardListChildPagesDataSource.class)
         .getCardElements().size());
   }
+
+  /**
+   * The defect this card exists for lives in the DATA SOURCE, not in the card model: the data source
+   * did not pass its AssetRetrievalService when constructing each card, so every card built from a
+   * page lost its image's title and description.
+   *
+   * <p>This test drives the data source, which is the path an author actually exercises. A test that
+   * calls the card constructor directly cannot catch the bug, because the constructor was never the
+   * broken part - it passes whether or not the data source hands the service over.
+   *
+   * <p>The page and the asset carry deliberately different titles ("Title" against "Asset 1 Title"),
+   * so an assertion on the asset's wording cannot pass by accident from the page's.
+   */
+  @Test
+  public void testGetCardElementsResolvesTheAssetTitleAndDescriptionThroughTheDataSource() {
+    // A correctly shaped asset: kes:Asset on the node itself, because AssetResource is declared
+    // @Model(resourceType = "kes:Asset") and extends BasePage, so its text lives on jcr:content.
+    // The shared setUpSampleCollection fixture inverts this and puts kes:Asset on jcr:content, which
+    // no real asset can resolve through AssetRetrievalServiceImpl. See the card.
+    final Map<String, Object> assetProperties = new HashMap<>();
+    assetProperties.put("jcr:primaryType", "kes:Asset");
+    final Map<String, Object> assetContentProperties = new HashMap<>();
+    assetContentProperties.put("jcr:primaryType", "nt:unstructured");
+    assetContentProperties.put("jcr:title", "Asset 1 Title");
+    assetContentProperties.put("jcr:description", "Asset 1 Description");
+    context.create().resource("/content/real-assets/photo", assetProperties);
+    context.create().resource("/content/real-assets/photo/jcr:content", assetContentProperties);
+
+    // A page whose children point their image at that asset. The page's own title and description are
+    // deliberately different, so an assertion on the asset's wording cannot pass from the page's.
+    final Map<String, Object> pageProperties = new HashMap<>();
+    pageProperties.put("jcr:primaryType", "kes:Page");
+    final Map<String, Object> pageContentProperties = new HashMap<>();
+    pageContentProperties.put("jcr:primaryType", "nt:unstructured");
+    pageContentProperties.put("jcr:title", "Page Title");
+    pageContentProperties.put("jcr:description", "Page Description");
+    pageContentProperties.put("cardImage", "/content/real-assets/photo");
+    pageContentProperties.put("image", "/content/real-assets/photo");
+    context.create().resource("/content/asset-root", pageProperties);
+    context.create().resource("/content/asset-root/jcr:content", pageContentProperties);
+    context.create().resource("/content/asset-root/child-1", pageProperties);
+    context.create().resource("/content/asset-root/child-1/jcr:content", pageContentProperties);
+
+    final Map<String, Object> props = new HashMap<>();
+    props.put("pagesPath", "/content/asset-root");
+    props.put("readMoreText", "Button Text");
+    final Resource dataSourceResource = context.create().resource(
+        "/content/asset-root/jcr:content/comp-asset-resolution", props);
+    context.request().setResource(dataSourceResource);
+
+    final CardListChildPagesDataSource dataSource = context.request().adaptTo(
+        CardListChildPagesDataSource.class);
+    assertNotNull(dataSource);
+
+    final List<KestrosCard> cards = dataSource.getCardElements();
+    assertFalse("the root page has a child, so the data source must build a card",
+        cards.isEmpty());
+
+    final KestrosImage image = cards.get(0).getImageElement();
+    assertNotNull("a card built from a page with an image must have an image element", image);
+    assertEquals("alt text must come from the asset, not the page", "Asset 1 Title",
+        image.getAltText());
+    assertEquals("caption must come from the asset, not the page", "Asset 1 Description",
+        image.getCaption());
+    assertEquals("image title must come from the asset, not the page", "Asset 1 Title",
+        image.getImageTitle());
+  }
+
 }

--- a/kestros-basic-components/src/test/java/io/kestros/cms/components/basic/core/lists/cardlist/CardListChildPagesDataSourceTest.java
+++ b/kestros-basic-components/src/test/java/io/kestros/cms/components/basic/core/lists/cardlist/CardListChildPagesDataSourceTest.java
@@ -353,10 +353,9 @@ public class CardListChildPagesDataSourceTest extends BaseDataSourceTest {
    */
   @Test
   public void testGetCardElementsResolvesTheAssetTitleAndDescriptionThroughTheDataSource() {
-    // A correctly shaped asset: kes:Asset on the node itself, because AssetResource is declared
-    // @Model(resourceType = "kes:Asset") and extends BasePage, so its text lives on jcr:content.
-    // The shared setUpSampleCollection fixture inverts this and puts kes:Asset on jcr:content, which
-    // no real asset can resolve through AssetRetrievalServiceImpl. See the card.
+    // This test builds its own asset rather than reusing the shared setUpSampleCollection fixture,
+    // so the wording it asserts on is local to the test and cannot drift when that fixture changes.
+    // (The shared fixture does resolve - an earlier note here claiming otherwise was wrong.)
     final Map<String, Object> assetProperties = new HashMap<>();
     assetProperties.put("jcr:primaryType", "kes:Asset");
     final Map<String, Object> assetContentProperties = new HashMap<>();

--- a/kestros-basic-components/src/test/java/io/kestros/cms/components/basic/core/lists/cardlist/CardListTagSearchDataSourceTest.java
+++ b/kestros-basic-components/src/test/java/io/kestros/cms/components/basic/core/lists/cardlist/CardListTagSearchDataSourceTest.java
@@ -24,7 +24,6 @@ import java.util.Calendar;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import org.apache.sling.api.resource.ModifiableValueMap;
 import org.apache.sling.api.resource.Resource;
 import org.junit.Test;
 import org.mockito.invocation.InvocationOnMock;

--- a/kestros-basic-components/src/test/java/io/kestros/cms/components/basic/core/lists/cardlist/CardListTagSearchDataSourceTest.java
+++ b/kestros-basic-components/src/test/java/io/kestros/cms/components/basic/core/lists/cardlist/CardListTagSearchDataSourceTest.java
@@ -1,6 +1,7 @@
 package io.kestros.cms.components.basic.core.lists.cardlist;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertNotNull;
@@ -23,6 +24,7 @@ import java.util.Calendar;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import org.apache.sling.api.resource.ModifiableValueMap;
 import org.apache.sling.api.resource.Resource;
 import org.junit.Test;
 import org.mockito.invocation.InvocationOnMock;
@@ -39,6 +41,9 @@ public class CardListTagSearchDataSourceTest extends BaseDataSourceTest {
   public void doComponentSetup() throws AssetCollectionRetrievalException {
     tagRetrievalService = mock(TagRetrievalService.class);
     context.registerService(TagRetrievalService.class, tagRetrievalService);
+    // Before anything adapts: Sling Models resolves @OSGiService at the first adaptTo, so a service
+    // registered later never appears on the model.
+    registerAssetRetrievalService();
 
     setUpSampleCollection("/content/collection");
     setupSamplePage("/content/sessions", "/content/collection/asset-1");
@@ -426,5 +431,29 @@ public class CardListTagSearchDataSourceTest extends BaseDataSourceTest {
     props.put("sortBy", "lastModified");
 
     assertEquals(2, twoMatchesWith(props).getCardElements().size());
+  }
+
+  /**
+   * The other half of the fix. CardListTagSearchDataSource had to pass its AssetRetrievalService
+   * too, and nothing tested it: reverting that data source alone left the whole suite green, which
+   * is the same "passes whether the bug is present" fault the child-pages test was written to close.
+   *
+   * <p>The asset and the page carry deliberately different wording, so an assertion on the asset's
+   * title cannot pass from the page's.
+   */
+  @Test
+  public void testGetCardElementsResolvesTheAssetTitleAndDescriptionThroughTheDataSource() {
+    // setupSamplePage points every child at /content/collection/asset-1, whose title and description
+    // ("Asset 1 Title"/"Asset 1 Description") differ from the page's own ("Title"/"Description"), so
+    // an assertion on the asset wording cannot pass from the page's.
+    final List<KestrosCard> cards = cardListTagSearchDataSource.getCardElements();
+    assertFalse("the tag search must match at least one page", cards.isEmpty());
+
+    final KestrosImage image = cards.get(0).getImageElement();
+    assertNotNull("a card built from a tagged page with an image must have an image element", image);
+    assertEquals("alt text must come from the asset, not the page", "Asset 1 Title",
+        image.getAltText());
+    assertEquals("caption must come from the asset, not the page", "Asset 1 Description",
+        image.getCaption());
   }
 }


### PR DESCRIPTION
A card built from a page lost its image's title and description, because the two card-list data sources never passed their `AssetRetrievalService` to the card.

**Merge after #107**, which bumps this module off the released `0.3.1`.

Both data sources are covered by tests proved by mutation: reverting either one fails its own test. Two failure modes found during review are also fixed and covered - an asset that resolves but cannot be read, and an unchecked exception from the asset service, either of which previously escaped the constructor and blanked the whole card list.

`mvn -o -pl kestros-basic-components -Drat.skip=true test`: 532 tests, 0 failures, 1 skipped (pre-existing). Checkstyle 340 on this branch and 340 on develop, measured through the bound gate against a develop worktree, so this adds none. The strict gate is red on both for the same pre-existing violations.

Board card: kestros/0.9.1/card-image-cannot-resolve-its-asset.md
