### PR TITLE
Skip and log a broken page instead of blanking the card list

### DIFF
--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/LogUtils.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/LogUtils.java
@@ -1,0 +1,44 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+package io.kestros.cms.components.basic.core;
+
+import javax.annotation.Nullable;
+
+/**
+ * Helpers for putting untrusted values into a log line.
+ */
+public final class LogUtils {
+
+  private LogUtils() {
+    // static helpers only.
+  }
+
+  /**
+   * Strips CR and LF from a value before it is logged. Applied to every untrusted value, not only
+   * the JCR path: a JCR property is author-controlled and an exception message can carry anything,
+   * so those are the ones that can actually forge a log line.
+   *
+   * @param value Value about to be logged.
+   * @return The value with CR and LF removed, or null unchanged.
+   */
+  @Nullable
+  public static String forLog(@Nullable final String value) {
+    return value == null ? null : value.replaceAll("[\r\n]", "");
+  }
+}

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/card/KestrosCardImpl.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/card/KestrosCardImpl.java
@@ -13,6 +13,7 @@ import io.kestros.cms.components.basic.api.exceptions.ComponentConfigurationExce
 import io.kestros.cms.components.basic.core.BaseContainerSyntheticResource;
 import io.kestros.cms.components.basic.core.BaseSlingModelDataSource;
 import io.kestros.cms.components.basic.core.LinkUtils;
+import io.kestros.cms.components.basic.core.LogUtils;
 import io.kestros.cms.components.basic.core.content.button.KestrosButtonImpl;
 import io.kestros.cms.components.basic.core.content.buttongroup.KestrosButtonGroupImpl;
 import io.kestros.cms.components.basic.core.content.heading.KestrosHeadingImpl;
@@ -117,19 +118,6 @@ public class KestrosCardImpl extends BaseContainerSyntheticResource implements K
   }
 
   /**
-   * Strips CR and LF from a value before it is logged. Applied to every untrusted value, not only
-   * the JCR path: {@code imagePath} is an author-controlled property and an exception message can
-   * carry anything, so those are the ones that can actually forge a log line.
-   *
-   * @param value Value about to be logged.
-   * @return The value with CR and LF removed, or null unchanged.
-   */
-  @Nullable
-  private static String forLog(@Nullable final String value) {
-    return value == null ? null : value.replaceAll("[\r\n]", "");
-  }
-
-  /**
    * The asset's title and description, already read. Reading them is part of resolving the asset:
    * an asset that resolves but whose properties cannot be read is just as unreadable as one that
    * does not resolve, and the caller must not have to guard the getters separately.
@@ -167,10 +155,10 @@ public class KestrosCardImpl extends BaseContainerSyntheticResource implements K
     try {
       return new AssetText(asset.getTitle(), asset.getDescription());
     } catch (final RuntimeException e) {
-      final String safePath = forLog(page.getPath());
+      final String safePath = LogUtils.forLog(page.getPath());
       LOG.warn("Resolved the asset for card image on {} but could not read its properties. {}: {} "
               + "The image renders without the asset's title or description.", safePath,
-              e.getClass().getSimpleName(), forLog(e.getMessage()), e);
+              e.getClass().getSimpleName(), LogUtils.forLog(e.getMessage()), e);
       return new AssetText(null, null);
     }
   }
@@ -194,7 +182,7 @@ public class KestrosCardImpl extends BaseContainerSyntheticResource implements K
     if (StringUtils.isBlank(imagePath)) {
       return null;
     }
-    final String safePath = forLog(page.getPath());
+    final String safePath = LogUtils.forLog(page.getPath());
     if (assetRetrievalService == null) {
       LOG.warn("Unable to resolve the asset for card image on {}. No AssetRetrievalService "
               + "available; the image renders without the asset's title or description.",
@@ -205,17 +193,17 @@ public class KestrosCardImpl extends BaseContainerSyntheticResource implements K
       return assetRetrievalService.getAsset(imagePath, null, page.getResourceResolver());
     } catch (final AssetRetrievalException e) {
       LOG.warn("Unable to resolve asset {} for card image on {}. {} The image renders without the "
-              + "asset's title or description.", forLog(imagePath), safePath,
-              forLog(e.getMessage()), e);
+              + "asset's title or description.", LogUtils.forLog(imagePath), safePath,
+              LogUtils.forLog(e.getMessage()), e);
       return null;
     } catch (final RuntimeException e) {
       // A card that cannot resolve its asset must still render. CardListChildPagesDataSource wraps
       // anything escaping this constructor in a RuntimeException, which loses the WHOLE card list -
       // so one unreadable asset would blank the page rather than drop one caption.
       LOG.warn("Unexpected failure resolving asset {} for card image on {}. {}: {} The image "
-              + "renders without the asset's title or description.", forLog(imagePath),
+              + "renders without the asset's title or description.", LogUtils.forLog(imagePath),
               safePath,
-              e.getClass().getSimpleName(), forLog(e.getMessage()), e);
+              e.getClass().getSimpleName(), LogUtils.forLog(e.getMessage()), e);
       return null;
     }
   }

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/lists/cardlist/CardListChildPagesDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/lists/cardlist/CardListChildPagesDataSource.java
@@ -23,10 +23,14 @@ import org.apache.sling.api.resource.Resource;
 import org.apache.sling.models.annotations.Model;
 import org.apache.sling.models.annotations.Optional;
 import org.apache.sling.models.annotations.injectorspecific.OSGiService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @Model(adaptables = {SlingHttpServletRequest.class, Resource.class})
 public class CardListChildPagesDataSource extends BaseContainerSlingModelDataSource implements
                                                                                     KestrosCardList {
+
+  private static final Logger LOG = LoggerFactory.getLogger(CardListChildPagesDataSource.class);
 
   @OSGiService
   @Optional
@@ -69,6 +73,7 @@ public class CardListChildPagesDataSource extends BaseContainerSlingModelDataSou
     if (root == null) {
       return new ArrayList<>();
     }
+    CardListSupport.requireComponentPrerequisites(this);
     List<BaseContentPage> pages = new ArrayList<>(root.getChildPages());
 
     String sortBy = getResource().getValueMap().get("sortBy", "");
@@ -138,7 +143,9 @@ public class CardListChildPagesDataSource extends BaseContainerSlingModelDataSou
                 page.getName(),
                 assetRetrievalService));
       } catch (Exception e) {
-        throw new RuntimeException(e);
+        // The prerequisites every card shares were checked above, so this failure belongs to this
+        // page. Drop the page, keep the rest of the list, and say which page went and why.
+        CardListSupport.logSkippedCard(LOG, page, getResource().getPath(), e);
       }
     }
     return new ArrayList<>(cards);

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/lists/cardlist/CardListSupport.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/lists/cardlist/CardListSupport.java
@@ -55,10 +55,11 @@ final class CardListSupport {
    * this drifting out of step with that constructor.
    *
    * <p>Only the UI framework is checked for null afterwards. The other four either return a value
-   * or throw: the resolver and the path come off the data source's own resource, the variations are
-   * always a list, and the layout falls back to "default". {@code BaseSyntheticResource} null-checks
-   * all five, and if one of those ever does start returning null the card list would drop every page
-   * for the same reason - which is what the whole-component test is there to catch.
+   * or throw: the resolver and the path come off the data source's own resource, the variations
+   * are always a list, and the layout falls back to "default". {@code BaseSyntheticResource}
+   * null-checks all five, and if one of those ever does start returning null the card list would
+   * drop every page for the same reason - which is what the whole-component test is there to
+   * catch.
    *
    * @param dataSource Data source the cards will be built from.
    * @throws IllegalStateException The component's page has no resolvable UI framework.

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/lists/cardlist/CardListSupport.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/lists/cardlist/CardListSupport.java
@@ -1,0 +1,124 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+package io.kestros.cms.components.basic.core.lists.cardlist;
+
+import io.kestros.cms.components.basic.api.content.KestrosCard;
+import io.kestros.cms.components.basic.core.BaseSlingModelDataSource;
+import io.kestros.cms.components.basic.core.LogUtils;
+import io.kestros.cms.componenttypes.api.models.ComponentVariation;
+import io.kestros.cms.sitebuilding.api.models.BaseContentPage;
+import io.kestros.cms.uiframeworks.api.models.UiFramework;
+import java.util.List;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import org.apache.sling.api.resource.ResourceResolver;
+import org.slf4j.Logger;
+
+/**
+ * Shared behaviour for the card list data sources that build one card per page.
+ *
+ * <p>Between them these two methods are what lets a card list drop a single broken page instead of
+ * rendering empty. The skip in the loop is only safe because the prerequisites have already been
+ * checked: everything the card constructor reads from the data source is known good by then, so
+ * anything still thrown inside the loop depends on the page being skipped.
+ */
+final class CardListSupport {
+
+  private CardListSupport() {
+    // static helpers only.
+  }
+
+  /**
+   * Makes, once and uncaught, the calls that the card constructor makes back against the data
+   * source. These inputs are identical for every card in the list, so a failure here describes the
+   * whole component rather than any one page and must reach the caller.
+   *
+   * <p>This restates by hand what {@code BaseSyntheticResource}'s constructor asks the data source
+   * for. It is a classifier, not an optimisation - the loop still builds each card the same way.
+   * A card list test that asserts a whole-component failure still propagates is the guard against
+   * this drifting out of step with that constructor.
+   *
+   * <p>Only the UI framework is checked for null afterwards. The other four either return a value
+   * or throw: the resolver and the path come off the data source's own resource, the variations are
+   * always a list, and the layout falls back to "default". {@code BaseSyntheticResource} null-checks
+   * all five, and if one of those ever does start returning null the card list would drop every page
+   * for the same reason - which is what the whole-component test is there to catch.
+   *
+   * @param dataSource Data source the cards will be built from.
+   * @throws IllegalStateException The component's page has no resolvable UI framework.
+   */
+  static void requireComponentPrerequisites(@Nonnull final BaseSlingModelDataSource dataSource) {
+    final ResourceResolver resourceResolver = dataSource.getResourceResolver();
+    final String parentPath = dataSource.getResource().getPath();
+    final List<ComponentVariation> variations = dataSource.getElementVariations("cardVariations",
+            KestrosCard.RESOURCE_TYPE);
+    final String layout = dataSource.getLayout("card");
+    final UiFramework uiFramework = dataSource.getUiFramework();
+    if (uiFramework == null) {
+      throw new IllegalStateException(String.format(
+              "Card list at %s cannot build any card: its page resolves to no UI framework. "
+                      + "hasResourceResolver=%s, cardVariations=%s, cardLayout=%s.",
+              LogUtils.forLog(parentPath), resourceResolver != null, variations.size(),
+              LogUtils.forLog(layout)));
+    }
+  }
+
+  /**
+   * Records a page whose card could not be built and was therefore left out of the list.
+   *
+   * <p>The exception class is named before its message because the message is often null, and
+   * "Skipping the card for /x: null" says nothing about what went wrong.
+   *
+   * <p>Nothing read here may throw. The page is the object that has just failed, so asking it for
+   * its path can fail as well, and an exception raised while logging the skip would blank the whole
+   * list again - which is the defect this method exists to prevent.
+   *
+   * @param log Logger of the data source doing the skipping.
+   * @param page Page whose card could not be built.
+   * @param dataSourcePath Path of the card list component.
+   * @param cause Failure that stopped the card being built.
+   */
+  static void logSkippedCard(@Nonnull final Logger log, @Nullable final BaseContentPage page,
+          @Nullable final String dataSourcePath, @Nonnull final Exception cause) {
+    log.warn("Skipping the card for {} in the card list at {}. {}: {} Every other page in the list "
+                    + "still renders.", describePath(page), LogUtils.forLog(dataSourcePath),
+            cause.getClass().getName(), describeMessage(cause), cause);
+  }
+
+  @Nullable
+  private static String describePath(@Nullable final BaseContentPage page) {
+    if (page == null) {
+      return "an unknown page";
+    }
+    try {
+      return LogUtils.forLog(page.getPath());
+    } catch (final RuntimeException e) {
+      return "a page whose path could not be read";
+    }
+  }
+
+  @Nullable
+  private static String describeMessage(@Nonnull final Exception cause) {
+    try {
+      return LogUtils.forLog(cause.getMessage());
+    } catch (final RuntimeException e) {
+      return "a message that could not be read";
+    }
+  }
+}

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/lists/cardlist/CardListTagSearchDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/lists/cardlist/CardListTagSearchDataSource.java
@@ -23,10 +23,14 @@ import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.models.annotations.Model;
 import org.apache.sling.models.annotations.injectorspecific.OSGiService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @Model(adaptables = {SlingHttpServletRequest.class, Resource.class})
 public class CardListTagSearchDataSource extends BaseContainerSlingModelDataSource implements
                                                                                    KestrosCardList {
+
+  private static final Logger LOG = LoggerFactory.getLogger(CardListTagSearchDataSource.class);
 
   @OSGiService
   @org.apache.sling.models.annotations.Optional
@@ -137,6 +141,7 @@ public class CardListTagSearchDataSource extends BaseContainerSlingModelDataSour
   @Nonnull
   @Override
   public List<KestrosCard> getCardElements() {
+    CardListSupport.requireComponentPrerequisites(this);
     List<BaseContentPage> pages = new ArrayList<>(getTaggedPages());
 
     String sortBy = getResource().getValueMap().get("sortBy", "");
@@ -197,7 +202,9 @@ public class CardListTagSearchDataSource extends BaseContainerSlingModelDataSour
                 page.getName(),
                 assetRetrievalService));
       } catch (Exception e) {
-        // Skip cards that fail to construct — null-safe
+        // The prerequisites every card shares were checked above, so this failure belongs to this
+        // page. Skipping in silence is what hid this for months; say which page went and why.
+        CardListSupport.logSkippedCard(LOG, page, getResource().getPath(), e);
       }
     }
     return new ArrayList<>(cards);

--- a/kestros-basic-components/src/test/java/io/kestros/cms/components/basic/core/lists/cardlist/CardListChildPagesDataSourceTest.java
+++ b/kestros-basic-components/src/test/java/io/kestros/cms/components/basic/core/lists/cardlist/CardListChildPagesDataSourceTest.java
@@ -5,6 +5,12 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
 
 import io.kestros.cms.assets.api.exceptions.AssetCollectionRetrievalException;
 import io.kestros.cms.components.basic.api.content.KestrosButton;
@@ -14,6 +20,9 @@ import io.kestros.cms.components.basic.api.content.KestrosImage;
 import io.kestros.cms.components.basic.api.lists.KestrosCardList;
 import io.kestros.cms.components.basic.core.BaseDataSourceTest;
 import io.kestros.cms.components.basic.core.content.image.ImageStaticDataSource;
+import io.kestros.cms.sitebuilding.api.models.BaseContentPage;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Calendar;
 import java.util.HashMap;
 import java.util.List;
@@ -403,6 +412,199 @@ public class CardListChildPagesDataSourceTest extends BaseDataSourceTest {
         image.getCaption());
     assertEquals("image title must come from the asset, not the page", "Asset 1 Title",
         image.getImageTitle());
+  }
+
+  // ---------------------------------------------------------------------------------------------
+  // One broken page must not blank the list.
+  //
+  // These drive getCardElements() with a page list that mixes a page which throws with pages that
+  // do not. Asserting only that no exception escaped would pass against the unfixed code, which
+  // rethrew as a RuntimeException - so every assertion below names the pages that survived.
+  // ---------------------------------------------------------------------------------------------
+
+  /** A page from the repository, adapted the same way the data source's root page adapts them. */
+  private BaseContentPage pageAt(final String path) {
+    final Resource pageResource = context.resourceResolver().getResource(path);
+    assertNotNull("the fixture must create " + path, pageResource);
+    final BaseContentPage page = pageResource.adaptTo(BaseContentPage.class);
+    assertNotNull(path + " must adapt to a page", page);
+    return page;
+  }
+
+  /**
+   * Two healthy pages with titles that tell them apart. The shared fixture titles every child
+   * "Title", which identifies nothing.
+   */
+  private void createDistinctlyTitledPages() {
+    final Map<String, Object> pageProperties = new HashMap<>();
+    pageProperties.put("jcr:primaryType", "kes:Page");
+    context.create().resource("/content/mixed", pageProperties);
+
+    final Map<String, Object> firstContent = new HashMap<>();
+    firstContent.put("jcr:primaryType", "nt:unstructured");
+    firstContent.put("jcr:title", "First Good Page");
+    context.create().resource("/content/mixed/good-1", pageProperties);
+    context.create().resource("/content/mixed/good-1/jcr:content", firstContent);
+
+    final Map<String, Object> secondContent = new HashMap<>();
+    secondContent.put("jcr:primaryType", "nt:unstructured");
+    secondContent.put("jcr:title", "Second Good Page");
+    context.create().resource("/content/mixed/good-2", pageProperties);
+    context.create().resource("/content/mixed/good-2/jcr:content", secondContent);
+  }
+
+  /**
+   * A page that fails while its card is being built. getDisplayDescription() is the first thing
+   * the card constructor asks a page for, and nothing on that path guards it.
+   */
+  private BaseContentPage brokenPage(final String path, final RuntimeException failure) {
+    final BaseContentPage broken = mock(BaseContentPage.class);
+    when(broken.getPath()).thenReturn(path);
+    when(broken.getName()).thenReturn(path.substring(path.lastIndexOf('/') + 1));
+    when(broken.getDisplayDescription()).thenThrow(failure);
+    return broken;
+  }
+
+  /**
+   * A data source whose child pages are exactly the list given. getRootPage() is stubbed rather
+   * than the loop, so getCardElements() itself runs unaltered.
+   */
+  private CardListChildPagesDataSource dataSourceOver(final List<BaseContentPage> childPages) {
+    final Map<String, Object> props = new HashMap<>();
+    props.put("pagesPath", "/content/mixed");
+    props.put("readMoreText", "Button Text");
+    final Resource componentResource = context.create().resource(
+        "/content/page/jcr:content/comp-mixed-" + childPages.size(), props);
+    context.request().setResource(componentResource);
+
+    final CardListChildPagesDataSource dataSource = spy(
+        context.request().adaptTo(CardListChildPagesDataSource.class));
+    final BaseContentPage root = mock(BaseContentPage.class);
+    when(root.getChildPages()).thenReturn(new ArrayList<>(childPages));
+    doReturn(root).when(dataSource).getRootPage();
+    return dataSource;
+  }
+
+  @Test
+  public void testGetCardElementsSkipsTheBrokenPageAndKeepsTheRest() {
+    createDistinctlyTitledPages();
+    final CardListChildPagesDataSource dataSource = dataSourceOver(Arrays.asList(
+        pageAt("/content/mixed/good-1"),
+        brokenPage("/content/mixed/broken", new IllegalStateException("jcr:content will not adapt")),
+        pageAt("/content/mixed/good-2")));
+
+    final List<KestrosCard> cards = dataSource.getCardElements();
+
+    assertEquals("the two healthy pages must still produce cards", 2, cards.size());
+    assertEquals("good-1", cards.get(0).getForcedResourceName());
+    assertEquals("good-2", cards.get(1).getForcedResourceName());
+    assertEquals("First Good Page", cards.get(0).getTitleElement().getHeadingText());
+    assertEquals("Second Good Page", cards.get(1).getTitleElement().getHeadingText());
+  }
+
+  @Test
+  public void testGetCardElementsLogsTheSkippedPageWithTheExceptionClassAndMessage() {
+    createDistinctlyTitledPages();
+    final CardListChildPagesDataSource dataSource = dataSourceOver(Arrays.asList(
+        pageAt("/content/mixed/good-1"),
+        brokenPage("/content/mixed/broken", new IllegalStateException("jcr:content will not adapt"))));
+
+    try (RecordedWarnings warnings = new RecordedWarnings(CardListChildPagesDataSource.class)) {
+      assertEquals(1, dataSource.getCardElements().size());
+
+      assertEquals("exactly one page was skipped, so exactly one warning is expected", 1,
+          warnings.messages().size());
+      final String warning = warnings.messages().get(0);
+      assertTrue("the warning must name the skipped page: " + warning,
+          warning.contains("/content/mixed/broken"));
+      assertTrue("the warning must name the exception class: " + warning,
+          warning.contains("java.lang.IllegalStateException"));
+      assertTrue("the warning must carry the exception message: " + warning,
+          warning.contains("jcr:content will not adapt"));
+    }
+  }
+
+  /**
+   * An exception with no message must still produce a line that names the class. "Skipping the card
+   * for /x: null" tells whoever reads the log nothing at all.
+   */
+  @Test
+  public void testGetCardElementsNamesTheExceptionClassWhenThereIsNoMessage() {
+    createDistinctlyTitledPages();
+    final CardListChildPagesDataSource dataSource = dataSourceOver(Arrays.asList(
+        pageAt("/content/mixed/good-1"),
+        brokenPage("/content/mixed/broken", new NullPointerException()),
+        pageAt("/content/mixed/good-2")));
+
+    try (RecordedWarnings warnings = new RecordedWarnings(CardListChildPagesDataSource.class)) {
+      assertEquals(2, dataSource.getCardElements().size());
+
+      assertEquals(1, warnings.messages().size());
+      assertTrue("the warning must name the exception class even with a null message: "
+          + warnings.messages().get(0),
+          warnings.messages().get(0).contains("java.lang.NullPointerException"));
+    }
+  }
+
+  /** Every page broken is still every page skipped - an empty list, not a thrown exception. */
+  @Test
+  public void testGetCardElementsReturnsEmptyWhenEveryPageIsBroken() {
+    createDistinctlyTitledPages();
+    final CardListChildPagesDataSource dataSource = dataSourceOver(Arrays.asList(
+        brokenPage("/content/mixed/broken-1", new IllegalStateException("first")),
+        brokenPage("/content/mixed/broken-2", new IllegalStateException("second"))));
+
+    assertTrue(dataSource.getCardElements().isEmpty());
+  }
+
+  /** A page that cannot even say where it is must not take the list down with it. */
+  @Test
+  public void testGetCardElementsSurvivesAPageWhosePathAlsoThrows() {
+    createDistinctlyTitledPages();
+    final BaseContentPage broken = mock(BaseContentPage.class);
+    when(broken.getName()).thenReturn("broken");
+    when(broken.getDisplayDescription()).thenThrow(new IllegalStateException("unreadable"));
+    when(broken.getPath()).thenThrow(new IllegalStateException("path is unreadable too"));
+
+    final CardListChildPagesDataSource dataSource = dataSourceOver(Arrays.asList(
+        pageAt("/content/mixed/good-1"), broken, pageAt("/content/mixed/good-2")));
+
+    final List<KestrosCard> cards = dataSource.getCardElements();
+    assertEquals(2, cards.size());
+    assertEquals("good-1", cards.get(0).getForcedResourceName());
+    assertEquals("good-2", cards.get(1).getForcedResourceName());
+  }
+
+  // ---------------------------------------------------------------------------------------------
+  // A failure that belongs to the whole component still surfaces.
+  //
+  // Skipping is only correct per page. If the component itself cannot be resolved, every card would
+  // fail for the same reason, and turning that into an empty list hides an outage.
+  // ---------------------------------------------------------------------------------------------
+
+  @Test
+  public void testGetCardElementsThrowsWhenTheThemeCannotBeResolved() throws Exception {
+    when(themeProviderService.getThemeForPage(any())).thenThrow(
+        new RuntimeException("no theme for this page"));
+
+    try {
+      cardListChildPagesDataSource.getCardElements();
+      fail("a component with no resolvable theme must not render an empty card list");
+    } catch (final RuntimeException expected) {
+      assertNotNull(expected);
+    }
+  }
+
+  @Test
+  public void testGetCardElementsThrowsWhenTheThemeResolvesToNoUiFramework() throws Exception {
+    when(theme.getUiFramework()).thenReturn(null);
+
+    try {
+      cardListChildPagesDataSource.getCardElements();
+      fail("a component whose theme carries no UI framework must not render an empty card list");
+    } catch (final RuntimeException expected) {
+      assertNotNull(expected);
+    }
   }
 
 }

--- a/kestros-basic-components/src/test/java/io/kestros/cms/components/basic/core/lists/cardlist/CardListTagSearchDataSourceTest.java
+++ b/kestros-basic-components/src/test/java/io/kestros/cms/components/basic/core/lists/cardlist/CardListTagSearchDataSourceTest.java
@@ -5,8 +5,11 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
 import io.kestros.cms.assets.api.exceptions.AssetCollectionRetrievalException;
@@ -16,8 +19,10 @@ import io.kestros.cms.components.basic.api.content.KestrosCard;
 import io.kestros.cms.components.basic.api.content.KestrosImage;
 import io.kestros.cms.components.basic.api.lists.KestrosCardList;
 import io.kestros.cms.components.basic.core.BaseDataSourceTest;
+import io.kestros.cms.sitebuilding.api.models.BaseContentPage;
 import io.kestros.cms.tagging.api.models.KestrosTag;
 import io.kestros.cms.tagging.api.services.TagRetrievalService;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Calendar;
@@ -454,5 +459,141 @@ public class CardListTagSearchDataSourceTest extends BaseDataSourceTest {
         image.getAltText());
     assertEquals("caption must come from the asset, not the page", "Asset 1 Description",
         image.getCaption());
+  }
+
+  // ---------------------------------------------------------------------------------------------
+  // The same principle as the child-pages list. This one always skipped, but in complete silence:
+  // it caught Exception and discarded it, with no log statement at all.
+  // ---------------------------------------------------------------------------------------------
+
+  /** Two healthy pages with titles that tell them apart, plus a root to hold them. */
+  private void createDistinctlyTitledPages() {
+    final Map<String, Object> pageProperties = new HashMap<>();
+    pageProperties.put("jcr:primaryType", "kes:Page");
+    context.create().resource("/content/tagged", pageProperties);
+
+    final Map<String, Object> firstContent = new HashMap<>();
+    firstContent.put("jcr:primaryType", "nt:unstructured");
+    firstContent.put("jcr:title", "First Tagged Page");
+    context.create().resource("/content/tagged/good-1", pageProperties);
+    context.create().resource("/content/tagged/good-1/jcr:content", firstContent);
+
+    final Map<String, Object> secondContent = new HashMap<>();
+    secondContent.put("jcr:primaryType", "nt:unstructured");
+    secondContent.put("jcr:title", "Second Tagged Page");
+    context.create().resource("/content/tagged/good-2", pageProperties);
+    context.create().resource("/content/tagged/good-2/jcr:content", secondContent);
+  }
+
+  private BaseContentPage pageAt(final String path) {
+    final Resource pageResource = context.resourceResolver().getResource(path);
+    assertNotNull("the fixture must create " + path, pageResource);
+    final BaseContentPage page = pageResource.adaptTo(BaseContentPage.class);
+    assertNotNull(path + " must adapt to a page", page);
+    return page;
+  }
+
+  private BaseContentPage brokenPage(final String path, final RuntimeException failure) {
+    final BaseContentPage broken = mock(BaseContentPage.class);
+    when(broken.getPath()).thenReturn(path);
+    when(broken.getName()).thenReturn(path.substring(path.lastIndexOf('/') + 1));
+    when(broken.getDisplayDescription()).thenThrow(failure);
+    return broken;
+  }
+
+  /** A data source whose tag search matches exactly the pages given, in that order. */
+  private CardListTagSearchDataSource dataSourceOver(final List<BaseContentPage> matches) {
+    final Map<String, Object> props = new HashMap<>();
+    props.put("tags", new String[]{"/etc/tags/topic/java"});
+    props.put("readMoreText", "View Session");
+    final Resource componentResource = context.create().resource(
+        "/content/sessions/child-1/jcr:content/comp-mixed-" + matches.size(), props);
+    context.request().setResource(componentResource);
+
+    final CardListTagSearchDataSource dataSource = spy(
+        context.request().adaptTo(CardListTagSearchDataSource.class));
+    doReturn(new ArrayList<>(matches)).when(dataSource).getTaggedPages();
+    return dataSource;
+  }
+
+  @Test
+  public void testGetCardElementsSkipsTheBrokenPageAndKeepsTheRest() {
+    createDistinctlyTitledPages();
+    final CardListTagSearchDataSource dataSource = dataSourceOver(Arrays.asList(
+        pageAt("/content/tagged/good-1"),
+        brokenPage("/content/tagged/broken", new IllegalStateException("jcr:content will not adapt")),
+        pageAt("/content/tagged/good-2")));
+
+    final List<KestrosCard> cards = dataSource.getCardElements();
+
+    assertEquals("the two healthy pages must still produce cards", 2, cards.size());
+    assertEquals("good-1", cards.get(0).getForcedResourceName());
+    assertEquals("good-2", cards.get(1).getForcedResourceName());
+    assertEquals("First Tagged Page", cards.get(0).getTitleElement().getHeadingText());
+    assertEquals("Second Tagged Page", cards.get(1).getTitleElement().getHeadingText());
+  }
+
+  @Test
+  public void testGetCardElementsLogsTheSkippedPageWithTheExceptionClassAndMessage() {
+    createDistinctlyTitledPages();
+    final CardListTagSearchDataSource dataSource = dataSourceOver(Arrays.asList(
+        pageAt("/content/tagged/good-1"),
+        brokenPage("/content/tagged/broken", new IllegalStateException("jcr:content will not adapt"))));
+
+    try (RecordedWarnings warnings = new RecordedWarnings(CardListTagSearchDataSource.class)) {
+      assertEquals(1, dataSource.getCardElements().size());
+
+      assertEquals("skipping in silence is the defect; exactly one warning is expected", 1,
+          warnings.messages().size());
+      final String warning = warnings.messages().get(0);
+      assertTrue("the warning must name the skipped page: " + warning,
+          warning.contains("/content/tagged/broken"));
+      assertTrue("the warning must name the exception class: " + warning,
+          warning.contains("java.lang.IllegalStateException"));
+      assertTrue("the warning must carry the exception message: " + warning,
+          warning.contains("jcr:content will not adapt"));
+    }
+  }
+
+  @Test
+  public void testGetCardElementsNamesTheExceptionClassWhenThereIsNoMessage() {
+    createDistinctlyTitledPages();
+    final CardListTagSearchDataSource dataSource = dataSourceOver(Arrays.asList(
+        pageAt("/content/tagged/good-1"),
+        brokenPage("/content/tagged/broken", new NullPointerException())));
+
+    try (RecordedWarnings warnings = new RecordedWarnings(CardListTagSearchDataSource.class)) {
+      assertEquals(1, dataSource.getCardElements().size());
+
+      assertEquals(1, warnings.messages().size());
+      assertTrue("the warning must name the exception class even with a null message: "
+          + warnings.messages().get(0),
+          warnings.messages().get(0).contains("java.lang.NullPointerException"));
+    }
+  }
+
+  @Test
+  public void testGetCardElementsThrowsWhenTheThemeCannotBeResolved() throws Exception {
+    when(themeProviderService.getThemeForPage(any())).thenThrow(
+        new RuntimeException("no theme for this page"));
+
+    try {
+      cardListTagSearchDataSource.getCardElements();
+      fail("a component with no resolvable theme must not render an empty card list");
+    } catch (final RuntimeException expected) {
+      assertNotNull(expected);
+    }
+  }
+
+  @Test
+  public void testGetCardElementsThrowsWhenTheThemeResolvesToNoUiFramework() throws Exception {
+    when(theme.getUiFramework()).thenReturn(null);
+
+    try {
+      cardListTagSearchDataSource.getCardElements();
+      fail("a component whose theme carries no UI framework must not render an empty card list");
+    } catch (final RuntimeException expected) {
+      assertNotNull(expected);
+    }
   }
 }

--- a/kestros-basic-components/src/test/java/io/kestros/cms/components/basic/core/lists/cardlist/RecordedWarnings.java
+++ b/kestros-basic-components/src/test/java/io/kestros/cms/components/basic/core/lists/cardlist/RecordedWarnings.java
@@ -1,0 +1,65 @@
+/*
+ *      Copyright (C) 2020  Kestros, Inc.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+package io.kestros.cms.components.basic.core.lists.cardlist;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import java.util.ArrayList;
+import java.util.List;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Captures the WARN lines a class writes while a test runs.
+ *
+ * <p>The card lists are required to say which page they dropped and why, so that line is part of
+ * the behaviour under test rather than a side effect of it - a skip nobody can attribute is how
+ * the tag search list came to render empty in silence.
+ */
+final class RecordedWarnings implements AutoCloseable {
+
+  private final ch.qos.logback.classic.Logger logger;
+  private final ListAppender<ILoggingEvent> appender = new ListAppender<>();
+
+  RecordedWarnings(final Class<?> recordedClass) {
+    logger = (ch.qos.logback.classic.Logger) LoggerFactory.getLogger(recordedClass);
+    appender.start();
+    logger.addAppender(appender);
+  }
+
+  /**
+   * The WARN lines written since this recorder was opened, already rendered.
+   *
+   * @return Formatted WARN messages, in the order they were written.
+   */
+  List<String> messages() {
+    final List<String> warnings = new ArrayList<>();
+    for (final ILoggingEvent event : appender.list) {
+      if (Level.WARN.equals(event.getLevel())) {
+        warnings.add(event.getFormattedMessage());
+      }
+    }
+    return warnings;
+  }
+
+  @Override
+  public void close() {
+    logger.detachAppender(appender);
+  }
+}


### PR DESCRIPTION
Card #134 — http://174.81.124.79:8100/work_packages/134

## What was wrong

`CardListChildPagesDataSource.getCardElements()` wrapped any failure from building a
single card in a `RuntimeException`, so one bad child page took the whole list with it —
the author saw an empty region and nothing naming the page at fault. The sibling
`CardListTagSearchDataSource` failed the opposite way: it caught `Exception` and
discarded it with no log statement at all.

## What changed

Both data sources now state the same principle.

- The inputs every card in a list shares are made once before the loop, uncaught
  (`CardListSupport.requireComponentPrerequisites`). A component whose page resolves to no
  UI framework still fails loudly rather than rendering an empty list.
- Anything thrown after that point depends on the page, so the page is dropped, the rest
  of the list is returned, and a WARN names the page path, the exception class and its
  message — class first, so an exception with a null message still leaves a usable line.
- Nothing read while logging a skip can throw. A page that cannot say where it is is
  described rather than allowed to blank the list a second time.
- `forLog` moves out of `KestrosCardImpl` into `LogUtils`, so both data sources and the
  card strip CR and LF from one place.

## Tests

New tests drive `getCardElements()` with a page list mixing one page that throws with
pages that do not, and assert the surviving cards are provably the good pages, by
`forcedResourceName` and by heading text. Base branch is `temp-develop/cms-0.10.0`,
cut from `develop` at `84d7007`.

Review comments belong on the card, not here.
