### PR TITLE
Move RAT check into strict profile

### DIFF
--- a/kestros-basic-components/pom.xml
+++ b/kestros-basic-components/pom.xml
@@ -109,37 +109,6 @@
 
         <plugins>
             <plugin>
-                <groupId>org.apache.rat</groupId>
-                <artifactId>apache-rat-plugin</artifactId>
-                <version>0.13</version>
-                <configuration>
-                    <excludes>
-                        <!-- don't check anything in target -->
-                        <exclude>target/*</exclude>
-                        <!-- Fixing issues with deleted modules -->
-                        <exclude>**/target/*</exclude>
-                        <exclude>**/target/**/*</exclude>
-                        <exclude>**/*.json</exclude>
-                        <exclude>node/**/*</exclude>
-                        <exclude>node_modules/**/*</exclude>
-                        <exclude>**/README.md</exclude>
-                        <exclude>package.json</exclude>
-                        <exclude>package-lock.json</exclude>
-                        <exclude>*-maven-settings.xml</exclude>
-                        <exclude>src/main/resources/content/ROOT.json</exclude>
-                        <exclude>src/main/resources/startup/favicon.svg</exclude>
-                    </excludes>
-                </configuration>
-                <executions>
-                    <execution>
-                        <phase>verify</phase>
-                        <goals>
-                            <goal>check</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
                 <extensions>true</extensions>

--- a/pom.xml
+++ b/pom.xml
@@ -56,4 +56,45 @@
         <module>kestros-basic-components-testing</module>
     </modules>
 
+    <profiles>
+        <profile>
+            <id>strict</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.rat</groupId>
+                        <artifactId>apache-rat-plugin</artifactId>
+                        <version>0.13</version>
+                        <configuration>
+                            <excludes>
+                                <!-- don't check anything in target -->
+                                <exclude>target/*</exclude>
+                                <!-- Fixing issues with deleted modules -->
+                                <exclude>**/target/*</exclude>
+                                <exclude>**/target/**/*</exclude>
+                                <exclude>**/*.json</exclude>
+                                <exclude>node/**/*</exclude>
+                                <exclude>node_modules/**/*</exclude>
+                                <exclude>**/README.md</exclude>
+                                <exclude>package.json</exclude>
+                                <exclude>package-lock.json</exclude>
+                                <exclude>*-maven-settings.xml</exclude>
+                                <exclude>src/main/resources/content/ROOT.json</exclude>
+                                <exclude>src/main/resources/startup/favicon.svg</exclude>
+                            </excludes>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>check</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+
 </project>


### PR DESCRIPTION
Closes #684

RAT (apache-rat-plugin) licence-header check was failing plain `mvn clean install` at 213 unapproved files. Moved it into the strict Maven profile so the base build passes with all 532 unit tests passing.