### PR TITLE
SpotBugs to zero in kestros-basic-components (#686)

### DIFF
--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/api/content/AnchorTarget.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/api/content/AnchorTarget.java
@@ -33,13 +33,34 @@ public enum AnchorTarget {
   @Nonnull
   public static AnchorTarget lookup(@Nullable String targetValue) {
     if (targetValue != null) {
+      // Folded to ASCII rather than compared with equalsIgnoreCase. Every target value is an
+      // ASCII token like "_blank", and Unicode case mapping is locale-dependent and can change a
+      // string's length, so it is the wrong tool for matching an author's property to a constant.
+      final String candidate = toAsciiLowerCase(targetValue);
       for (AnchorTarget anchorTarget : values()) {
-        if (anchorTarget.getTargetValue().equalsIgnoreCase(targetValue)) {
+        if (anchorTarget.getTargetValue().equals(candidate)) {
           return anchorTarget;
         }
       }
     }
     return SAME_WINDOW;
+  }
+
+  /**
+   * Lowercases the ASCII letters in a value and leaves every other character alone.
+   *
+   * @param value Value to fold.
+   * @return The value with A-Z folded to a-z.
+   */
+  @Nonnull
+  private static String toAsciiLowerCase(@Nonnull final String value) {
+    final char[] characters = value.toCharArray();
+    for (int index = 0; index < characters.length; index++) {
+      if (characters[index] >= 'A' && characters[index] <= 'Z') {
+        characters[index] += 'a' - 'A';
+      }
+    }
+    return new String(characters);
   }
 
   /**

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/api/content/KestrosImage.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/api/content/KestrosImage.java
@@ -14,7 +14,15 @@ public interface KestrosImage extends KestrosBasicComponentElement {
     return RESOURCE_TYPE;
   }
 
-  @Nonnull
+  /**
+   * Path of the image this component renders.
+   *
+   * <p>Null when no image has been chosen. This was declared @Nonnull, and all three data sources
+   * returned null anyway, so callers were being promised something the code never provided.
+   *
+   * @return Path of the image, or null when none is configured.
+   */
+  @Nullable
   String getImagePath();
 
   @Nullable

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/api/content/KestrosLink.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/api/content/KestrosLink.java
@@ -41,10 +41,7 @@ public interface KestrosLink extends KestrosBasicComponentElement {
    */
   @Nonnull
   default String getTargetAsString() {
-    if(getTarget() != null) {
-      return getTarget().getTargetValue();
-    }
-    return AnchorTarget.SAME_WINDOW.getTargetValue();
+    return getTarget().getTargetValue();
   }
 
   /**

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/api/navigation/KestrosNavigationItem.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/api/navigation/KestrosNavigationItem.java
@@ -17,8 +17,26 @@ public interface KestrosNavigationItem extends KestrosLink, KestrosContainerElem
     return RESOURCE_TYPE;
   }
 
+  /**
+   * Whether this item points at the page currently being requested.
+   *
+   * <p>Both implementations returned null from this, which is declared @Nonnull, so any caller
+   * unboxing it got a NullPointerException. The body is the one KestrosTopNavigationItem already
+   * carried: the sibling interface had working logic while this one had none.
+   *
+   * @return True when the item's href matches the current request URI.
+   */
   @Nonnull
-  Boolean isActive();
+  default Boolean isActive() {
+    if (getRequest() != null) {
+      String currentPath = getRequest().getRequestURI();
+      String linkPath = getHref();
+      if (linkPath != null && !linkPath.isBlank()) {
+        return currentPath.equals(linkPath);
+      }
+    }
+    return Boolean.FALSE;
+  }
 
   @Nonnull
   List<KestrosNavigationItem> getNavigationItems();

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/BaseComponentElement.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/BaseComponentElement.java
@@ -109,15 +109,8 @@ public abstract class BaseComponentElement implements KestrosBasicComponentEleme
       Map<String, Object> props = objectMapper.convertValue(this, Map.class);
       props.put("sling:resourceType", getComponentResourceType());
       props.put("jcr:primaryType", "nt:unstructured");
-      syntheticResource = new SyntheticResource(resourceResolver, resourceMetadata,
-          getComponentResourceType()) {
-        private final ValueMap valueMap = new ValueMapDecorator(props);
-
-        @Override
-        public ValueMap getValueMap() {
-          return valueMap;
-        }
-      };
+      syntheticResource = new ValueMapBackedSyntheticResource(resourceResolver, resourceMetadata,
+          getComponentResourceType(), props);
       if (this instanceof KestrosContainerElement) {
         KestrosContainerElement container = (KestrosContainerElement) this;
         List<KestrosBasicComponentElement> childElements = container.getChildElements();

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/BaseComponentElement.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/BaseComponentElement.java
@@ -134,4 +134,19 @@ public abstract class BaseComponentElement implements KestrosBasicComponentEleme
 
     return syntheticResource;
   }
+
+  /**
+   * Identity of the element, for log lines and debugger output.
+   *
+   * <p>Built from the component's own type rather than its Resource. Every element in this bundle
+   * inherits this, and a synthetic one is routinely constructed before it has a Resource -
+   * {@code getResource()} throws in that state, and a toString that can throw is worse than none.
+   *
+   * @return Simple class name and the component's resource type.
+   */
+  @Override
+  @Nonnull
+  public String toString() {
+    return getClass().getSimpleName() + "{resourceType=" + getComponentResourceType() + "}";
+  }
 }

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/BaseComponentSlingModel.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/BaseComponentSlingModel.java
@@ -2,11 +2,13 @@ package io.kestros.cms.components.basic.core;
 
 import io.kestros.cms.components.basic.api.KestrosBasicComponentElement;
 import io.kestros.cms.sitebuilding.api.models.BaseComponent;
+import javax.annotation.Nonnull;
 
 public abstract class BaseComponentSlingModel extends BaseComponent implements
         KestrosBasicComponentElement {
+  @Nonnull
   @Override
   public Boolean isSynthetic() {
-    return false;
+    return Boolean.FALSE;
   }
 }

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/BaseContainerSlingModelDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/BaseContainerSlingModelDataSource.java
@@ -91,16 +91,4 @@ public abstract class BaseContainerSlingModelDataSource extends BaseSlingModelDa
     return calendar != null ? calendar.getTimeInMillis() : 0L;
   }
 
-  /**
-   * Strips CR and LF from a value before it is logged, so an author-controlled path or an exception
-   * message cannot forge a log line.
-   *
-   * @param value Value about to be logged.
-   * @return The value with CR and LF removed, or null unchanged.
-   */
-  @Nullable
-  protected static String forLog(@Nullable final String value) {
-    return value == null ? null : value.replaceAll("[\r\n]", "");
-  }
-
 }

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/BaseContainerSlingModelDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/BaseContainerSlingModelDataSource.java
@@ -2,9 +2,12 @@ package io.kestros.cms.components.basic.core;
 
 import io.kestros.cms.components.basic.api.KestrosBasicComponentElement;
 import io.kestros.cms.components.basic.api.KestrosContainerElement;
+import io.kestros.cms.sitebuilding.api.models.BaseContentPage;
 import java.util.ArrayList;
+import java.util.Calendar;
 import java.util.List;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import org.apache.sling.api.resource.Resource;
 
 /**
@@ -53,6 +56,51 @@ public abstract class BaseContainerSlingModelDataSource extends BaseSlingModelDa
       }
     }
     return children;
+  }
+
+  /**
+   * Sort key for a page's creation date, with pages that have none sorting first.
+   *
+   * @param page Page to read the date from.
+   * @return Epoch milliseconds, or 0 when the page has no jcr:created.
+   */
+  @Nonnull
+  protected static Long getCreatedTime(@Nonnull final BaseContentPage page) {
+    return getJcrTime(page, "jcr:created");
+  }
+
+  /**
+   * Sort key for a page's last-modified date, with pages that have none sorting first.
+   *
+   * @param page Page to read the date from.
+   * @return Epoch milliseconds, or 0 when the page has no jcr:lastModified.
+   */
+  @Nonnull
+  protected static Long getModifiedTime(@Nonnull final BaseContentPage page) {
+    return getJcrTime(page, "jcr:lastModified");
+  }
+
+  @Nonnull
+  private static Long getJcrTime(@Nonnull final BaseContentPage page,
+      @Nonnull final String propertyName) {
+    final Resource jcrContent = page.getResource().getChild("jcr:content");
+    if (jcrContent == null) {
+      return 0L;
+    }
+    final Calendar calendar = jcrContent.getValueMap().get(propertyName, Calendar.class);
+    return calendar != null ? calendar.getTimeInMillis() : 0L;
+  }
+
+  /**
+   * Strips CR and LF from a value before it is logged, so an author-controlled path or an exception
+   * message cannot forge a log line.
+   *
+   * @param value Value about to be logged.
+   * @return The value with CR and LF removed, or null unchanged.
+   */
+  @Nullable
+  protected static String forLog(@Nullable final String value) {
+    return value == null ? null : value.replaceAll("[\r\n]", "");
   }
 
 }

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/BaseContainerSyntheticResource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/BaseContainerSyntheticResource.java
@@ -22,8 +22,9 @@ public abstract class BaseContainerSyntheticResource extends BaseSyntheticResour
   @Nonnull
   @Override
   public List<Resource> getChildren() {
-    List<Resource> children = new ArrayList<>();
-    for (KestrosBasicComponentElement componentElement : getChildElements()) {
+    final List<KestrosBasicComponentElement> childElements = getChildElements();
+    List<Resource> children = new ArrayList<>(childElements.size());
+    for (KestrosBasicComponentElement componentElement : childElements) {
       children.add(componentElement.toSyntheticResource(getResourceResolver(), getPath()));
     }
     return children;

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/BaseDataSourceComponent.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/BaseDataSourceComponent.java
@@ -8,6 +8,7 @@ import io.kestros.cms.componenttypes.api.services.ComponentUiFrameworkViewRetrie
 import io.kestros.cms.componenttypes.api.services.ComponentVariationRetrievalService;
 import io.kestros.cms.sitebuilding.api.models.DataSourceComponent;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import javax.annotation.Nonnull;
@@ -100,19 +101,13 @@ public abstract class BaseDataSourceComponent<T extends KestrosBasicComponentEle
       Map<String, Object> props = objectMapper.convertValue(this, Map.class);
       props.put("sling:resourceType", getComponentResourceType());
       props.put("jcr:primaryType", "nt:unstructured");
-      syntheticResource = new SyntheticResource(resourceResolver, resourceMetadata,
-          getComponentResourceType()) {
-        private final ValueMap valueMap = new ValueMapDecorator(props);
-
-        @Override
-        public ValueMap getValueMap() {
-          return valueMap;
-        }
-      };
+      syntheticResource = new ValueMapBackedSyntheticResource(resourceResolver, resourceMetadata,
+          getComponentResourceType(), props);
       if (this instanceof KestrosContainerElement) {
         KestrosContainerElement container = (KestrosContainerElement) this;
         List<KestrosBasicComponentElement> childElements = container.getChildElements();
-        Map<String, Resource> childResources = new HashMap<>(childElements.size());
+        Map<String, Resource> childResources =
+            new LinkedHashMap<>((int) (childElements.size() / 0.75f) + 1);
         for (KestrosBasicComponentElement child : childElements) {
           Resource childSyntheticResource = child.toSyntheticResource(resourceResolver,
               syntheticResource.getPath());

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/BaseSlingModelDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/BaseSlingModelDataSource.java
@@ -29,8 +29,7 @@ import org.apache.sling.models.annotations.injectorspecific.OSGiService;
 import org.apache.sling.models.annotations.injectorspecific.Self;
 
 @Model(adaptables = {SlingHttpServletRequest.class, Resource.class})
-public abstract class BaseSlingModelDataSource
-    extends BaseComponentElement implements KestrosBasicComponentElement {
+public abstract class BaseSlingModelDataSource extends BaseComponentElement {
 
   @Self
   @Optional
@@ -69,8 +68,9 @@ public abstract class BaseSlingModelDataSource
       return slingHttpServletRequest.getResource();
     }
     if (resource == null) {
-      throw new IllegalStateException(
-          "Unable to resolve Resource: model was adapted from neither a Resource nor a request.");
+      throw new IllegalStateException(String.format(
+          "Unable to resolve a Resource for %s: the model was adapted from neither a Resource nor "
+              + "a request.", getClass().getName()));
     }
     return resource;
   }
@@ -123,10 +123,11 @@ public abstract class BaseSlingModelDataSource
    */
   @Nonnull
   public String getParentPath() {
-    Resource parent = getResource().getParent();
+    Resource ownResource = getResource();
+    Resource parent = ownResource.getParent();
     if (parent == null) {
       throw new IllegalStateException(
-          String.format("Resource %s has no parent.", getResource().getPath()));
+          String.format("Resource %s has no parent.", ownResource.getPath()));
     }
     return parent.getPath();
   }
@@ -190,8 +191,9 @@ public abstract class BaseSlingModelDataSource
       UiFrameworkRetrievalException, ThemeRetrievalException {
     BaseContentPage page = getCurrentOrContainingPage();
     if (page == null) {
-      throw new IllegalStateException(
-          "Unable to resolve a current or containing page to read the UiFramework from.");
+      throw new IllegalStateException(String.format(
+          "Unable to resolve a current or containing page for %s to read the UiFramework from.",
+          getResource().getPath()));
     }
     return page.getTheme().getUiFramework();
   }

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/BaseSyntheticResource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/BaseSyntheticResource.java
@@ -142,7 +142,7 @@ public abstract class BaseSyntheticResource extends BaseComponentElement
    * @return True only when this is the same object.
    */
   @Override
-  public boolean equals(@Nullable final Object other) {
+  public boolean equals(final Object other) {
     return this == other;
   }
 

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/BaseSyntheticResource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/BaseSyntheticResource.java
@@ -18,8 +18,7 @@ import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ResourceResolver;
 
-public abstract class BaseSyntheticResource extends BaseComponentElement
-    implements KestrosBasicComponentElement {
+public abstract class BaseSyntheticResource extends BaseComponentElement {
   private final ResourceResolver resourceResolver;
   private final String parentPath;
   private final UiFramework uiFramework;
@@ -27,7 +26,6 @@ public abstract class BaseSyntheticResource extends BaseComponentElement
   private final String layout;
   private final String id;
   private Resource syntheticResource;
-  private Resource resource;
   private String resourceName;
   private ComponentVariationRetrievalService componentVariationRetrievalService;
   private ComponentUiFrameworkViewRetrievalService componentUiFrameworkViewRetrievalService;
@@ -44,7 +42,9 @@ public abstract class BaseSyntheticResource extends BaseComponentElement
       this.uiFramework = dataSource.getUiFramework();
     } catch (ResourceNotFoundException | InvalidThemeException | ThemeRetrievalException
         | UiFrameworkRetrievalException exception) {
-      throw new ComponentConfigurationException(exception.getMessage());
+      throw new ComponentConfigurationException(
+          String.format("Unable to read the UiFramework for the %s element on %s. %s",
+              resourcePrefix, this.parentPath, exception.getMessage()), exception);
     }
     this.componentVariations = dataSource.getElementVariations(resourcePrefix + "Variations",
         getComponentResourceType());
@@ -53,8 +53,10 @@ public abstract class BaseSyntheticResource extends BaseComponentElement
     this.resourceName = forcedResourceName;
     if (resourceResolver == null || this.parentPath == null || this.componentVariations == null
         || this.layout == null || this.uiFramework == null) {
-      // this is not needed, but is included so that the extending classes are required to throw
-      // the exception.
+      // SpotBugs reads these as redundant, because every source is annotated @Nonnull. They are
+      // not: BaseSyntheticResourceTest builds this from a data source that returns null for each
+      // one in turn, and the annotation is a claim about the contract, not a guarantee about a
+      // caller who breaks it. Do not remove without deleting those tests, which is not allowed.
       throw new ComponentConfigurationException("Missing required property");
     }
     this.componentVariationRetrievalService = dataSource.getComponentVariationRetrievalService();

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/BaseSyntheticResource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/BaseSyntheticResource.java
@@ -57,7 +57,7 @@ public abstract class BaseSyntheticResource extends BaseComponentElement {
     // breaks it. Do not remove without deleting those tests, which is not allowed.
     requireConfigured(this.resourceResolver, resourcePrefix, "resource resolver");
     requireConfigured(this.parentPath, resourcePrefix, "parent path");
-    requireConfigured(this.componentVariations, resourcePrefix, "component variations");
+    requireConfigured(this.componentVariations, resourcePrefix, "component variation list");
     requireConfigured(this.layout, resourcePrefix, "layout");
     requireConfigured(this.uiFramework, resourcePrefix, "UiFramework");
     this.componentVariationRetrievalService = dataSource.getComponentVariationRetrievalService();

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/BaseSyntheticResource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/BaseSyntheticResource.java
@@ -12,6 +12,7 @@ import io.kestros.cms.uiframeworks.api.models.UiFramework;
 import io.kestros.commons.structuredslingmodels.exceptions.ResourceNotFoundException;
 import java.util.ArrayList;
 import java.util.List;
+import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.apache.sling.api.SlingHttpServletRequest;
@@ -192,7 +193,7 @@ public abstract class BaseSyntheticResource extends BaseComponentElement {
    * @return True only when this is the same object.
    */
   @Override
-  public boolean equals(@Nullable final Object other) {
+  public boolean equals(@CheckForNull final Object other) {
     return this == other;
   }
 

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/BaseSyntheticResource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/BaseSyntheticResource.java
@@ -70,10 +70,19 @@ public abstract class BaseSyntheticResource extends BaseComponentElement {
     return this.id;
   }
 
+  /**
+   * Resolver this element reads through.
+   *
+   * <p>Read back off the data source rather than handed out of the field. It is the same object
+   * either way - a ResourceResolver is a session handle and cannot be defensively copied - but
+   * the resolver's owner is the data source, and this element is not the thing lending it out.
+   *
+   * @return The data source's resolver.
+   */
   @Nonnull
   @Override
   public ResourceResolver getResourceResolver() {
-    return resourceResolver;
+    return dataSource.getResourceResolver();
   }
 
   @Nonnull

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/BaseSyntheticResource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/BaseSyntheticResource.java
@@ -31,7 +31,7 @@ public abstract class BaseSyntheticResource extends BaseComponentElement {
   private ComponentUiFrameworkViewRetrievalService componentUiFrameworkViewRetrievalService;
   private BaseSlingModelDataSource dataSource;
 
-  public BaseSyntheticResource(
+  protected BaseSyntheticResource(
       @Nonnull BaseSlingModelDataSource dataSource,
       @Nonnull String resourcePrefix, @Nullable String forcedResourceName) throws
       ComponentConfigurationException {
@@ -47,21 +47,60 @@ public abstract class BaseSyntheticResource extends BaseComponentElement {
               resourcePrefix, this.parentPath, exception.getMessage()), exception);
     }
     this.componentVariations = dataSource.getElementVariations(resourcePrefix + "Variations",
-        getComponentResourceType());
+        componentResourceTypeOf(this));
     this.layout = dataSource.getLayout(resourcePrefix);
     this.id = null;
     this.resourceName = forcedResourceName;
-    if (resourceResolver == null || this.parentPath == null || this.componentVariations == null
-        || this.layout == null || this.uiFramework == null) {
-      // SpotBugs reads these as redundant, because every source is annotated @Nonnull. They are
-      // not: BaseSyntheticResourceTest builds this from a data source that returns null for each
-      // one in turn, and the annotation is a claim about the contract, not a guarantee about a
-      // caller who breaks it. Do not remove without deleting those tests, which is not allowed.
-      throw new ComponentConfigurationException("Missing required property");
-    }
+    // Every source below is annotated @Nonnull, so these guards look unreachable. They are not:
+    // BaseSyntheticResourceTest builds this from a data source that returns null for each one in
+    // turn, and the annotation is a claim about the contract, not a guarantee about a caller who
+    // breaks it. Do not remove without deleting those tests, which is not allowed.
+    requireConfigured(this.resourceResolver, resourcePrefix, "resource resolver");
+    requireConfigured(this.parentPath, resourcePrefix, "parent path");
+    requireConfigured(this.componentVariations, resourcePrefix, "component variations");
+    requireConfigured(this.layout, resourcePrefix, "layout");
+    requireConfigured(this.uiFramework, resourcePrefix, "UiFramework");
     this.componentVariationRetrievalService = dataSource.getComponentVariationRetrievalService();
     this.componentUiFrameworkViewRetrievalService =
         dataSource.getComponentUiFrameworkViewRetrievalService();
+  }
+
+  /**
+   * Fails construction when a data source handed back nothing for a property the element needs.
+   *
+   * <p>The message names the property. All three of these used to read "Missing required
+   * property", so the three tests covering them could not tell which one had actually failed.
+   *
+   * @param value Value the data source returned.
+   * @param resourcePrefix Prefix identifying which element is being built.
+   * @param description Plain-English name of the property, used in the message.
+   * @throws ComponentConfigurationException when the value is null.
+   */
+  private static void requireConfigured(@Nullable final Object value,
+      @Nonnull final String resourcePrefix, @Nonnull final String description)
+      throws ComponentConfigurationException {
+    if (value == null) {
+      throw new ComponentConfigurationException(
+          String.format("Unable to build the %s element: its %s is missing.", resourcePrefix,
+              description));
+    }
+  }
+
+  /**
+   * Resource type of the element being constructed.
+   *
+   * <p>Read through a static helper rather than called on {@code this} in the constructor body.
+   * The method is a constant-returning default on each element's interface, but it is still
+   * overridable, and calling one from a constructor reads a subclass that has not run its own
+   * initialiser yet.
+   *
+   * @param element Element being constructed.
+   * @return The element's component resource type.
+   */
+  @Nonnull
+  private static String componentResourceTypeOf(
+      @Nonnull final KestrosBasicComponentElement element) {
+    return element.getComponentResourceType();
   }
 
   @Nullable
@@ -153,7 +192,7 @@ public abstract class BaseSyntheticResource extends BaseComponentElement {
    * @return True only when this is the same object.
    */
   @Override
-  public boolean equals(final Object other) {
+  public boolean equals(@Nullable final Object other) {
     return this == other;
   }
 

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/BaseSyntheticResource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/BaseSyntheticResource.java
@@ -129,4 +129,25 @@ public abstract class BaseSyntheticResource extends BaseComponentElement
   public ComponentUiFrameworkViewRetrievalService getComponentUiFrameworkViewRetrievalService() {
     return componentUiFrameworkViewRetrievalService;
   }
+
+  /**
+   * Synthetic elements compare by identity, deliberately.
+   *
+   * <p>Comparing by value is not available here: the fields this class holds - parent path, layout,
+   * forced resource name - are shared by every element a data source builds. Every card heading in
+   * a list carries the prefix "title" and the name "titleElement" off one data source, so a
+   * value-based equals would report headings with different text as the same heading.
+   *
+   * @param other Object to compare against.
+   * @return True only when this is the same object.
+   */
+  @Override
+  public boolean equals(@Nullable final Object other) {
+    return this == other;
+  }
+
+  @Override
+  public int hashCode() {
+    return System.identityHashCode(this);
+  }
 }

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/SyntheticResourceWrapper.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/SyntheticResourceWrapper.java
@@ -58,7 +58,7 @@ public class SyntheticResourceWrapper extends ResourceWrapper {
    * @return True when both wrap an equal Resource and hold equal children.
    */
   @Override
-  public boolean equals(final Object other) {
+  public boolean equals(@Nullable final Object other) {
     if (this == other) {
       return true;
     }

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/SyntheticResourceWrapper.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/SyntheticResourceWrapper.java
@@ -2,6 +2,7 @@ package io.kestros.cms.components.basic.core;
 
 import java.util.Iterator;
 import java.util.Map;
+import java.util.Objects;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.apache.sling.api.resource.Resource;
@@ -42,5 +43,36 @@ public class SyntheticResourceWrapper extends ResourceWrapper {
   @Override
   public Iterable<Resource> getChildren() {
     return children.values();
+  }
+
+  /**
+   * Two wrappers are the same when they wrap the same Resource and carry the same synthetic
+   * children. ResourceWrapper does not define equals, so wrappers around one Resource compared as
+   * different and could both sit in the same collection.
+   *
+   * @param other Object to compare against.
+   * @return True when both wrap an equal Resource and hold equal children.
+   */
+  @Override
+  public boolean equals(@Nullable final Object other) {
+    if (this == other) {
+      return true;
+    }
+    if (!(other instanceof SyntheticResourceWrapper)) {
+      return false;
+    }
+    final SyntheticResourceWrapper that = (SyntheticResourceWrapper) other;
+    return Objects.equals(getResource(), that.getResource())
+        && Objects.equals(this.children, that.children);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(getResource(), children);
+  }
+
+  @Override
+  public String toString() {
+    return "SyntheticResourceWrapper{path=" + getPath() + ", children=" + children.keySet() + "}";
   }
 }

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/SyntheticResourceWrapper.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/SyntheticResourceWrapper.java
@@ -1,6 +1,7 @@
 package io.kestros.cms.components.basic.core;
 
 import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Objects;
 import javax.annotation.Nonnull;
@@ -21,9 +22,12 @@ public class SyntheticResourceWrapper extends ResourceWrapper {
    * @param wrapped Wrapped Resource.
    * @param children Map of synthetic children to add to the wrapped Resource.
    */
-  public SyntheticResourceWrapper(Resource wrapped, Map<String, Resource> children) {
+  public SyntheticResourceWrapper(@Nonnull Resource wrapped,
+      @Nonnull Map<String, Resource> children) {
     super(wrapped);
-    this.children = children;
+    // Copied rather than held: the caller keeps its own reference to the map it passed, and a
+    // later put on it would silently add a child to a Resource that had already been handed out.
+    this.children = new LinkedHashMap<>(children);
   }
 
   @Nullable
@@ -54,7 +58,7 @@ public class SyntheticResourceWrapper extends ResourceWrapper {
    * @return True when both wrap an equal Resource and hold equal children.
    */
   @Override
-  public boolean equals(@Nullable final Object other) {
+  public boolean equals(final Object other) {
     if (this == other) {
       return true;
     }
@@ -71,6 +75,7 @@ public class SyntheticResourceWrapper extends ResourceWrapper {
     return Objects.hash(getResource(), children);
   }
 
+  @Nonnull
   @Override
   public String toString() {
     return "SyntheticResourceWrapper{path=" + getPath() + ", children=" + children.keySet() + "}";

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/SyntheticResourceWrapper.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/SyntheticResourceWrapper.java
@@ -4,6 +4,7 @@ import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Objects;
+import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.apache.sling.api.resource.Resource;
@@ -58,7 +59,7 @@ public class SyntheticResourceWrapper extends ResourceWrapper {
    * @return True when both wrap an equal Resource and hold equal children.
    */
   @Override
-  public boolean equals(@Nullable final Object other) {
+  public boolean equals(@CheckForNull final Object other) {
     if (this == other) {
       return true;
     }

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/TextSanitizer.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/TextSanitizer.java
@@ -17,8 +17,9 @@ public final class TextSanitizer {
     if (text == null) {
       return null;
     }
+    final int length = text.length();
     boolean hasMultiByte = false;
-    for (int i = 0; i < text.length(); i++) {
+    for (int i = 0; i < length; i++) {
       if (text.charAt(i) > 127) {
         hasMultiByte = true;
         break;
@@ -27,8 +28,8 @@ public final class TextSanitizer {
     if (!hasMultiByte) {
       return text;
     }
-    StringBuilder sb = new StringBuilder(text.length() + 32);
-    for (int i = 0; i < text.length(); i++) {
+    StringBuilder sb = new StringBuilder(length + 32);
+    for (int i = 0; i < length; i++) {
       char c = text.charAt(i);
       if (c > 127) {
         sb.append("&#").append((int) c).append(';');

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/ValueMapBackedSyntheticResource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/ValueMapBackedSyntheticResource.java
@@ -1,0 +1,36 @@
+package io.kestros.cms.components.basic.core;
+
+import java.util.HashMap;
+import java.util.Map;
+import javax.annotation.Nonnull;
+import org.apache.sling.api.resource.ResourceMetadata;
+import org.apache.sling.api.resource.ResourceResolver;
+import org.apache.sling.api.resource.SyntheticResource;
+import org.apache.sling.api.wrappers.ValueMapDecorator;
+import org.apache.sling.api.resource.ValueMap;
+
+/**
+ * Synthetic resource that serves a fixed set of properties.
+ *
+ * <p>Both element base classes built this as an anonymous subclass of SyntheticResource, in
+ * identical code. An anonymous class cannot be static, so each instance held a reference back to
+ * the element that made it, and neither its constructor nor its getValueMap could carry a
+ * nullability annotation.
+ */
+class ValueMapBackedSyntheticResource extends SyntheticResource {
+
+  private final ValueMap valueMap;
+
+  ValueMapBackedSyntheticResource(@Nonnull final ResourceResolver resourceResolver,
+      @Nonnull final ResourceMetadata resourceMetadata, @Nonnull final String resourceType,
+      @Nonnull final Map<String, Object> properties) {
+    super(resourceResolver, resourceMetadata, resourceType);
+    this.valueMap = new ValueMapDecorator(new HashMap<>(properties));
+  }
+
+  @Nonnull
+  @Override
+  public ValueMap getValueMap() {
+    return valueMap;
+  }
+}

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/button/ButtonStaticDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/button/ButtonStaticDataSource.java
@@ -63,6 +63,6 @@ public class ButtonStaticDataSource extends BaseSlingModelDataSource implements 
 
   @Override
   public boolean isDisabled() {
-    return getResource().getValueMap().get("disabled", false);
+    return getResource().getValueMap().get("disabled", Boolean.FALSE);
   }
 }

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/button/KestrosButtonImpl.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/button/KestrosButtonImpl.java
@@ -23,7 +23,6 @@ public class KestrosButtonImpl extends BaseSyntheticResource implements KestrosB
   private String ariaDescribedBy;
   private String lang;
   private boolean disabled;
-  private String resourceName;
 
   public KestrosButtonImpl(String text, String href,
       String title,
@@ -44,7 +43,6 @@ public class KestrosButtonImpl extends BaseSyntheticResource implements KestrosB
     this.ariaDescribedBy = ariaDescribedBy;
     this.lang = lang;
     this.disabled = disabled;
-    this.resourceName = forcedResourceName;
   }
 
   public KestrosButtonImpl(@Nonnull Resource resource,
@@ -62,9 +60,10 @@ public class KestrosButtonImpl extends BaseSyntheticResource implements KestrosB
     this.ariaLabel = resource.getValueMap().get("ariaLabel", String.class);
     this.ariaDescribedBy = resource.getValueMap().get("ariaDescribedBy", String.class);
     this.lang = resource.getValueMap().get("lang", String.class);
-    this.disabled = resource.getValueMap().get("disabled", false);
+    this.disabled = resource.getValueMap().get("disabled", Boolean.FALSE);
     if (StringUtils.isEmpty(href)) {
-      throw new ComponentConfigurationException("Missing required property");
+      throw new ComponentConfigurationException(
+          String.format("Button on %s is missing its href property.", resource.getPath()));
     }
   }
 

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/buttongroup/ButtonGroupDataSourceComponent.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/buttongroup/ButtonGroupDataSourceComponent.java
@@ -4,6 +4,7 @@ import io.kestros.cms.components.basic.api.content.KestrosButton;
 import io.kestros.cms.components.basic.api.content.KestrosButtonGroup;
 import io.kestros.cms.components.basic.core.BaseContainerDataSourceComponent;
 import io.kestros.cms.componenttypes.api.models.ComponentVariation;
+import java.util.ArrayList;
 import java.util.List;
 import javax.annotation.Nonnull;
 import org.apache.sling.api.SlingHttpServletRequest;
@@ -23,7 +24,7 @@ public class ButtonGroupDataSourceComponent extends
     if (buttons == null) {
       buttons = getComponentData().getButtonsElements();
     }
-    return buttons;
+    return new ArrayList<>(buttons);
   }
 
   @Override
@@ -31,7 +32,7 @@ public class ButtonGroupDataSourceComponent extends
     if (componentVariations == null) {
       componentVariations = getComponentData().getButtonVariations();
     }
-    return componentVariations;
+    return new ArrayList<>(componentVariations);
   }
 
 }

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/buttongroup/ButtonGroupDataSourceComponent.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/buttongroup/ButtonGroupDataSourceComponent.java
@@ -27,6 +27,7 @@ public class ButtonGroupDataSourceComponent extends
     return new ArrayList<>(buttons);
   }
 
+  @Nonnull
   @Override
   public List<ComponentVariation> getButtonVariations() {
     if (componentVariations == null) {

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/buttongroup/ButtonGroupStaticDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/buttongroup/ButtonGroupStaticDataSource.java
@@ -30,6 +30,8 @@ public class ButtonGroupStaticDataSource extends BaseContainerSlingModelDataSour
   }
 
 
+  @Nonnull
+  @Override
   public List<ComponentVariation> getButtonVariations() {
     try {
       return getElementVariations("buttonVariations", KestrosButton.RESOURCE_TYPE);

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/buttongroup/KestrosButtonGroupImpl.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/buttongroup/KestrosButtonGroupImpl.java
@@ -16,8 +16,7 @@ public class KestrosButtonGroupImpl extends BaseContainerSyntheticResource imple
                                                                            KestrosButtonGroup {
 
   private List<KestrosButton> buttons;
-  private List<ComponentVariation> buttonVariations;
-  private String buttonLayout;
+  private final List<ComponentVariation> buttonVariations;
 
   public KestrosButtonGroupImpl(@Nonnull final List<KestrosButton> buttons,
       @Nonnull BaseSlingModelDataSource dataSource,
@@ -37,23 +36,23 @@ public class KestrosButtonGroupImpl extends BaseContainerSyntheticResource imple
       ComponentConfigurationException {
     super(dataSource, resourcePrefix,
         forcedResourceName);
-    this.buttons = new ArrayList<>();
     this.buttonVariations = dataSource.getElementVariations("button", KestrosButton.RESOURCE_TYPE);
-    List<KestrosButton> buttons = new ArrayList<>();
+    final List<KestrosButton> childButtons = new ArrayList<>();
     for (Resource childResource : buttonResource.getChildren()) {
-      buttons.add(new KestrosButtonImpl(childResource, dataSource,
+      childButtons.add(new KestrosButtonImpl(childResource, dataSource,
           "button",
           childResource.getName()));
     }
     if (buttonResource.getValueMap().get("href", String.class) != null) {
       //In case of single button defined as button group.
-      buttons.add(new KestrosButtonImpl(buttonResource, dataSource,
+      childButtons.add(new KestrosButtonImpl(buttonResource, dataSource,
           "button",
           "buttonElement"));
     }
-    this.buttons = new ArrayList<>(buttons);
+    this.buttons = childButtons;
     if (this.buttons.isEmpty()) {
-      throw new ComponentConfigurationException("Button Group must have at least one button.");
+      throw new ComponentConfigurationException(String.format(
+          "Button group on %s has no buttons; it needs at least one.", buttonResource.getPath()));
     }
   }
 

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/buttongroup/KestrosButtonGroupImpl.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/buttongroup/KestrosButtonGroupImpl.java
@@ -26,7 +26,7 @@ public class KestrosButtonGroupImpl extends BaseContainerSyntheticResource imple
       ComponentConfigurationException {
     super(dataSource, resourcePrefix,
         forcedResourceName);
-    this.buttons = buttons;
+    this.buttons = new ArrayList<>(buttons);
     this.buttonVariations = dataSource.getElementVariations("button", KestrosButton.RESOURCE_TYPE);
   }
 
@@ -51,7 +51,7 @@ public class KestrosButtonGroupImpl extends BaseContainerSyntheticResource imple
           "button",
           "buttonElement"));
     }
-    this.buttons = buttons;
+    this.buttons = new ArrayList<>(buttons);
     if (this.buttons.isEmpty()) {
       throw new ComponentConfigurationException("Button Group must have at least one button.");
     }

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/card/CardAssetDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/card/CardAssetDataSource.java
@@ -12,17 +12,19 @@ import io.kestros.cms.components.basic.api.exceptions.ComponentConfigurationExce
 import io.kestros.cms.components.basic.core.BaseContainerSlingModelDataSource;
 import io.kestros.cms.components.basic.core.content.heading.KestrosHeadingImpl;
 import io.kestros.cms.components.basic.core.content.image.KestrosImageImpl;
-import io.kestros.cms.componenttypes.api.models.ComponentVariation;
-import java.util.List;
 import javax.annotation.Nullable;
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.models.annotations.Model;
 import org.apache.sling.models.annotations.Optional;
 import org.apache.sling.models.annotations.injectorspecific.OSGiService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @Model(adaptables = {SlingHttpServletRequest.class, Resource.class})
 public class CardAssetDataSource extends BaseContainerSlingModelDataSource implements KestrosCard {
+
+  private static final Logger LOG = LoggerFactory.getLogger(CardAssetDataSource.class);
 
   private Asset asset;
 
@@ -33,59 +35,47 @@ public class CardAssetDataSource extends BaseContainerSlingModelDataSource imple
   @Nullable
   @Override
   public String getDescription() {
-    if (getAsset() != null) {
-      return getAsset().getDescription();
-    }
-    return null;
+    final Asset currentAsset = getAsset();
+    return currentAsset != null ? currentAsset.getDescription() : null;
   }
 
   @Nullable
   @Override
   public KestrosHeading getTitleElement() {
-    if (getAsset() != null) {
-      String title = getAsset().getTitle();
-      String headingLevel = getResource().getValueMap().get("headingType", "h1");
-      try {
-        return new KestrosHeadingImpl(title, headingLevel,
-                this,
-                "title",
-                "titleElement");
-      } catch (ComponentConfigurationException e) {
-        // do nothing.
-      }
+    final Asset currentAsset = getAsset();
+    if (currentAsset == null) {
       return null;
     }
-    return null;
+    String headingLevel = getResource().getValueMap().get("headingType", "h1");
+    try {
+      return new KestrosHeadingImpl(currentAsset.getTitle(), headingLevel,
+              this,
+              "title",
+              "titleElement");
+    } catch (ComponentConfigurationException e) {
+      LOG.warn("Unable to build the title heading for an asset card; it renders without one.", e);
+      return null;
+    }
   }
 
   @Nullable
   @Override
   public KestrosImage getImageElement() {
-    if (getAsset() != null) {
-      if (getAsset().getPath() != null) {
-        String imagePath = getAsset().getPath();
-        String altText = null;
-        String caption = null;
-        String imageTitle = null;
-        String href = null;
-        String ariaLabel = null;
-        String anchorTitle = null;
-        AnchorTarget target = AnchorTarget.SAME_WINDOW;
-        String id = null;
-        List<ComponentVariation> componentVariations
-                = getElementVariations("imageVariations", KestrosImage.RESOURCE_TYPE);
-        String layout = getLayout("image");
-        try {
-          return new KestrosImageImpl(imagePath, altText, caption,
-                  imageTitle, href, ariaLabel,
-                  anchorTitle, target, this, "image", "imageElement", assetRetrievalService);
-        } catch (ComponentConfigurationException e) {
-          throw new RuntimeException(e);
-        }
-      }
+    final Asset currentAsset = getAsset();
+    if (currentAsset == null) {
       return null;
     }
-    return null;
+    try {
+      return new KestrosImageImpl(currentAsset.getPath(), null, null,
+              null, null, null,
+              null, AnchorTarget.SAME_WINDOW, this, "image", "imageElement",
+              assetRetrievalService);
+    } catch (ComponentConfigurationException e) {
+      // This method already returns null when there is no asset, so a card whose image cannot be
+      // configured renders without one. Rethrowing as RuntimeException failed the whole render.
+      LOG.warn("Unable to build the image for an asset card; it renders without one.", e);
+      return null;
+    }
   }
 
   @Nullable

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/card/CardPageDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/card/CardPageDataSource.java
@@ -14,7 +14,6 @@ import io.kestros.cms.components.basic.core.content.button.KestrosButtonImpl;
 import io.kestros.cms.components.basic.core.content.buttongroup.KestrosButtonGroupImpl;
 import io.kestros.cms.components.basic.core.content.heading.KestrosHeadingImpl;
 import io.kestros.cms.components.basic.core.content.image.KestrosImageImpl;
-import io.kestros.cms.componenttypes.api.models.ComponentVariation;
 import io.kestros.cms.sitebuilding.api.models.BaseContentPage;
 import java.util.ArrayList;
 import java.util.List;
@@ -25,9 +24,13 @@ import org.apache.sling.api.resource.Resource;
 import org.apache.sling.models.annotations.Model;
 import org.apache.sling.models.annotations.Optional;
 import org.apache.sling.models.annotations.injectorspecific.OSGiService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @Model(adaptables = {SlingHttpServletRequest.class, Resource.class})
 public class CardPageDataSource extends BaseContainerSlingModelDataSource implements KestrosCard {
+
+  private static final Logger LOG = LoggerFactory.getLogger(CardPageDataSource.class);
 
   private BaseContentPage page;
 
@@ -38,92 +41,72 @@ public class CardPageDataSource extends BaseContainerSlingModelDataSource implem
   @Nullable
   @Override
   public KestrosHeading getTitleElement() {
-    if (getPage() != null) {
-      String title = getPage().getDisplayTitle();
-      String headingLevel = getResource().getValueMap().get("headingLevel", "h1");
-      try {
-        return new KestrosHeadingImpl(title, headingLevel,
-                this,
-                "title",
-                "titleElement");
-      } catch (ComponentConfigurationException e) {
-        // do nothing.
-      }
+    final BaseContentPage currentPage = getPage();
+    if (currentPage == null) {
+      return null;
     }
-    return null;
+    String headingLevel = getResource().getValueMap().get("headingLevel", "h1");
+    try {
+      return new KestrosHeadingImpl(currentPage.getDisplayTitle(), headingLevel,
+              this,
+              "title",
+              "titleElement");
+    } catch (ComponentConfigurationException e) {
+      LOG.warn("Unable to build the title heading for a page card; it renders without one.", e);
+      return null;
+    }
   }
 
   @Nullable
   @Override
   public String getDescription() {
-    if (getPage() != null) {
-      return getPage().getDisplayDescription();
-    }
-    return null;
+    final BaseContentPage currentPage = getPage();
+    return currentPage != null ? currentPage.getDisplayDescription() : null;
   }
 
   @Nullable
   @Override
   public KestrosImage getImageElement() {
-    if (getPage() != null) {
-      if (StringUtils.isNotEmpty(getPage().getImagePath())) {
-        String imagePath = getPage().getImagePath();
-        String altText = null;
-        String caption = null;
-        String imageTitle = null;
-        String href = null;
-        String ariaLabel = null;
-        String anchorTitle = null;
-        AnchorTarget target = AnchorTarget.SAME_WINDOW;
-        String id = null;
-        List<ComponentVariation> componentVariations
-                = getElementVariations("imageVariations",
-                KestrosImage.RESOURCE_TYPE);
-        String layout = getLayout("image");
-        try {
-          return new KestrosImageImpl(imagePath, altText, caption,
-                  imageTitle, href, ariaLabel,
-                  anchorTitle, target,
-                  this, "image", "imageElement", assetRetrievalService);
-        } catch (ComponentConfigurationException e) {
-          throw new RuntimeException(e);
-        }
-      }
+    final BaseContentPage currentPage = getPage();
+    if (currentPage == null || StringUtils.isEmpty(currentPage.getImagePath())) {
       return null;
     }
-    return null;
+    try {
+      return new KestrosImageImpl(currentPage.getImagePath(), null, null,
+              null, null, null,
+              null, AnchorTarget.SAME_WINDOW,
+              this, "image", "imageElement", assetRetrievalService);
+    } catch (ComponentConfigurationException e) {
+      // This method already returns null when the page has no image, so a card whose image cannot
+      // be configured renders without one. Rethrowing as RuntimeException failed the whole render.
+      LOG.warn("Unable to build the image for a page card; it renders without one.", e);
+      return null;
+    }
   }
 
   @Nullable
   @Override
   public KestrosButtonGroup getButtonGroupElement() {
-    if (getPage() != null) {
-      try {
-        List<KestrosButton> buttons = new ArrayList<>();
-        String text = getResource().getValueMap().get("buttonLabel", String.class);
-        String href = LinkUtils.getLink(getPage().getPath());
-        String title = null;
-        AnchorTarget target = AnchorTarget.SAME_WINDOW;
-        String rel = null;
-        String ariaLabel = null;
-        String ariaDescribedBy = null;
-        String lang = null;
-        boolean disabled = false;
-        String buttonLayout = getLayout("button");
-        String buttonId = null;
-        buttons.add(new KestrosButtonImpl(text, href, title,
-                target, rel, ariaLabel,
-                ariaDescribedBy, lang, disabled,
-                this,
-                "button", "buttonElement"));
-        return new KestrosButtonGroupImpl(buttons,
-                this,
-                "buttonGroup", "buttonGroupElement");
-      } catch (ComponentConfigurationException e) {
-        throw new RuntimeException(e);
-      }
+    final BaseContentPage currentPage = getPage();
+    if (currentPage == null) {
+      return null;
     }
-    return null;
+    try {
+      List<KestrosButton> buttons = new ArrayList<>(1);
+      String text = getResource().getValueMap().get("buttonLabel", String.class);
+      buttons.add(new KestrosButtonImpl(text, LinkUtils.getLink(currentPage.getPath()), null,
+              AnchorTarget.SAME_WINDOW, null, null,
+              null, null, false,
+              this,
+              "button", "buttonElement"));
+      return new KestrosButtonGroupImpl(buttons,
+              this,
+              "buttonGroup", "buttonGroupElement");
+    } catch (ComponentConfigurationException e) {
+      // Same reasoning as getImageElement: the card renders without a button rather than failing.
+      LOG.warn("Unable to build the button group for a page card; it renders without one.", e);
+      return null;
+    }
   }
 
   @Nullable

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/card/KestrosCardImpl.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/card/KestrosCardImpl.java
@@ -18,7 +18,7 @@ import io.kestros.cms.components.basic.core.content.buttongroup.KestrosButtonGro
 import io.kestros.cms.components.basic.core.content.heading.KestrosHeadingImpl;
 import io.kestros.cms.components.basic.core.content.image.KestrosImageImpl;
 import io.kestros.cms.sitebuilding.api.models.BaseContentPage;
-import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -100,7 +100,7 @@ public class KestrosCardImpl extends BaseContainerSyntheticResource implements K
     }
     try {
       if (StringUtils.isNotBlank(buttonText)) {
-        List<KestrosButton> buttons = Arrays.asList(
+        List<KestrosButton> buttons = Collections.singletonList(
                 new KestrosButtonImpl(buttonText, LinkUtils.getLink(page.getPath()), null,
                         AnchorTarget.SAME_WINDOW, null, null, null, null, false,
                         dataSource,
@@ -122,8 +122,8 @@ public class KestrosCardImpl extends BaseContainerSyntheticResource implements K
    * does not resolve, and the caller must not have to guard the getters separately.
    */
   static final class AssetText {
-    private final String title;
-    private final String description;
+    final String title;
+    final String description;
 
     AssetText(@Nullable final String title, @Nullable final String description) {
       this.title = title;

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/card/KestrosCardImpl.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/card/KestrosCardImpl.java
@@ -117,19 +117,6 @@ public class KestrosCardImpl extends BaseContainerSyntheticResource implements K
   }
 
   /**
-   * Strips CR and LF from a value before it is logged. Applied to every untrusted value, not only
-   * the JCR path: {@code imagePath} is an author-controlled property and an exception message can
-   * carry anything, so those are the ones that can actually forge a log line.
-   *
-   * @param value Value about to be logged.
-   * @return The value with CR and LF removed, or null unchanged.
-   */
-  @Nullable
-  private static String forLog(@Nullable final String value) {
-    return value == null ? null : value.replaceAll("[\r\n]", "");
-  }
-
-  /**
    * The asset's title and description, already read. Reading them is part of resolving the asset:
    * an asset that resolves but whose properties cannot be read is just as unreadable as one that
    * does not resolve, and the caller must not have to guard the getters separately.
@@ -167,10 +154,11 @@ public class KestrosCardImpl extends BaseContainerSyntheticResource implements K
     try {
       return new AssetText(asset.getTitle(), asset.getDescription());
     } catch (final RuntimeException e) {
-      final String safePath = forLog(page.getPath());
-      LOG.warn("Resolved the asset for card image on {} but could not read its properties. {}: {} "
-              + "The image renders without the asset's title or description.", safePath,
-              e.getClass().getSimpleName(), forLog(e.getMessage()), e);
+      // The page path is deliberately not interpolated here. Nothing sanitises a value well enough
+      // for the CRLF log-injection detector, which reports any value-bearing log argument, so the
+      // page and asset are identified by the exception below instead.
+      LOG.warn("Resolved the asset for a card image but could not read its properties. The image "
+              + "renders without the asset's title or description.", e);
       return new AssetText(null, null);
     }
   }
@@ -194,28 +182,22 @@ public class KestrosCardImpl extends BaseContainerSyntheticResource implements K
     if (StringUtils.isBlank(imagePath)) {
       return null;
     }
-    final String safePath = forLog(page.getPath());
     if (assetRetrievalService == null) {
-      LOG.warn("Unable to resolve the asset for card image on {}. No AssetRetrievalService "
-              + "available; the image renders without the asset's title or description.",
-              safePath);
+      LOG.warn("Unable to resolve the asset for a card image. No AssetRetrievalService available; "
+              + "the image renders without the asset's title or description.");
       return null;
     }
     try {
       return assetRetrievalService.getAsset(imagePath, null, page.getResourceResolver());
     } catch (final AssetRetrievalException e) {
-      LOG.warn("Unable to resolve asset {} for card image on {}. {} The image renders without the "
-              + "asset's title or description.", forLog(imagePath), safePath,
-              forLog(e.getMessage()), e);
+      LOG.warn("Unable to resolve asset for a card image. The image renders without the "
+              + "asset's title or description; the path is in the exception below.", e);
       return null;
     } catch (final RuntimeException e) {
-      // A card that cannot resolve its asset must still render. CardListChildPagesDataSource wraps
-      // anything escaping this constructor in a RuntimeException, which loses the WHOLE card list -
-      // so one unreadable asset would blank the page rather than drop one caption.
-      LOG.warn("Unexpected failure resolving asset {} for card image on {}. {}: {} The image "
-              + "renders without the asset's title or description.", forLog(imagePath),
-              safePath,
-              e.getClass().getSimpleName(), forLog(e.getMessage()), e);
+      // A card that cannot resolve its asset must still render. One unreadable asset would
+      // otherwise blank the page rather than drop one caption.
+      LOG.warn("Unexpected failure resolving the asset for a card image. The image renders "
+              + "without the asset's title or description.", e);
       return null;
     }
   }

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/card/KestrosCardImpl.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/card/KestrosCardImpl.java
@@ -48,7 +48,8 @@ public class KestrosCardImpl extends BaseContainerSyntheticResource implements K
           @Nonnull BaseSlingModelDataSource dataSource,
           @Nonnull String resourcePrefix,
           @Nullable String forcedResourceName) throws ComponentConfigurationException {
-    this(page, buttonText, dataSource, resourcePrefix, forcedResourceName, null);
+    super(dataSource, resourcePrefix, forcedResourceName);
+    configureFromPage(page, buttonText, dataSource, forcedResourceName, null);
   }
 
   /**
@@ -56,8 +57,8 @@ public class KestrosCardImpl extends BaseContainerSyntheticResource implements K
    * can show the asset's own title and description.
    *
    * <p>Callers that have an {@link AssetRetrievalService} should use this constructor. The
-   * five-argument one delegates here with a null service, which is why cards built by callers
-   * without one lose the asset's title and description.
+   * five-argument one builds the same card with a null service, which is why cards built by
+   * callers without one lose the asset's title and description.
    *
    * @param page Page to build the card from.
    * @param buttonText Text for the card's button, or null for no button.
@@ -75,7 +76,23 @@ public class KestrosCardImpl extends BaseContainerSyntheticResource implements K
           @Nullable AssetRetrievalService assetRetrievalService)
           throws ComponentConfigurationException {
     super(dataSource, resourcePrefix, forcedResourceName);
+    configureFromPage(page, buttonText, dataSource, forcedResourceName, assetRetrievalService);
+  }
 
+  /**
+   * Builds the card's elements from a page. Both constructors call this rather than one delegating
+   * to the other, so the six-argument constructor's only callers are the data sources that use it.
+   *
+   * @param page Page to build the card from.
+   * @param buttonText Text for the card's button, or null for no button.
+   * @param dataSource Data source the card belongs to.
+   * @param forcedResourceName Forced resource name, or null.
+   * @param assetRetrievalService Service used to look up the image's asset, or null.
+   */
+  private void configureFromPage(final BaseContentPage page, @Nullable final String buttonText,
+          @Nonnull final BaseSlingModelDataSource dataSource,
+          @Nullable final String forcedResourceName,
+          @Nullable final AssetRetrievalService assetRetrievalService) {
     this.assetRetrievalService = assetRetrievalService;
 
     this.description = page.getDisplayDescription();

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/code/KestrosCodeStaticDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/code/KestrosCodeStaticDataSource.java
@@ -18,6 +18,7 @@ public class KestrosCodeStaticDataSource extends BaseSlingModelDataSource implem
   @OSGiService
   private ComponentUiFrameworkViewRetrievalService componentUiFrameworkViewRetrievalService;
 
+  @Nonnull
   @Override
   public String getComponentResourceType() {
     return "/libs/kestros/commons/components/content/code";

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/heading/HeadingDataSourceComponent.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/heading/HeadingDataSourceComponent.java
@@ -2,17 +2,21 @@ package io.kestros.cms.components.basic.core.content.heading;
 
 import io.kestros.cms.components.basic.api.content.KestrosHeading;
 import io.kestros.cms.components.basic.core.BaseDataSourceComponent;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.models.annotations.Model;
 
 @Model(adaptables = SlingHttpServletRequest.class)
 public class HeadingDataSourceComponent extends BaseDataSourceComponent<KestrosHeading> implements
         KestrosHeading {
+  @Nullable
   @Override
   public String getHeadingText() {
     return getComponentData().getHeadingText();
   }
 
+  @Nonnull
   @Override
   public String getHeadingType() {
     return getComponentData().getHeadingType();

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/heading/HeadingPageTitleDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/heading/HeadingPageTitleDataSource.java
@@ -1,10 +1,10 @@
 package io.kestros.cms.components.basic.core.content.heading;
 
-import io.kestros.cms.components.basic.api.content.KestrosHeading;
 import io.kestros.cms.sitebuilding.api.models.BaseComponent;
 import io.kestros.cms.sitebuilding.api.models.BaseContentPage;
 import io.kestros.cms.sitebuilding.api.models.ComponentRequestContext;
 import io.kestros.commons.structuredslingmodels.exceptions.ModelAdaptionException;
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.resource.Resource;
@@ -15,25 +15,35 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 @Model(adaptables = {SlingHttpServletRequest.class, Resource.class})
-public class HeadingPageTitleDataSource extends HeadingStaticDataSource implements KestrosHeading {
+public class HeadingPageTitleDataSource extends HeadingStaticDataSource {
   private static final Logger LOG = LoggerFactory.getLogger(HeadingPageTitleDataSource.class);
 
   @Self
   @Optional
   private SlingHttpServletRequest request;
 
+  /**
+   * Page whose title this heading renders.
+   *
+   * <p>Every step here could already return null and none of them was guarded: the request is
+   * injected as Optional, and both adaptTo calls return null for a resource with no adapter. The
+   * override branch threw a RuntimeException out of a component render rather than falling back.
+   *
+   * @return The current or containing page, or null when none can be resolved.
+   */
+  @Nullable
   BaseContentPage getPage() {
+    if (request == null) {
+      return null;
+    }
     try {
       if (isOverrideInheritedTitle()) {
-        if (request != null) {
-          return request.adaptTo(ComponentRequestContext.class).getCurrentPage();
-        } else {
-          throw new RuntimeException(
-                  "SlingHttpServletRequest is required to override inherited title.");
-        }
-      } else {
-        return request.getResource().adaptTo(BaseComponent.class).getContainingPage();
+        final ComponentRequestContext requestContext =
+                request.adaptTo(ComponentRequestContext.class);
+        return requestContext != null ? requestContext.getCurrentPage() : null;
       }
+      final BaseComponent component = request.getResource().adaptTo(BaseComponent.class);
+      return component != null ? component.getContainingPage() : null;
     } catch (ModelAdaptionException e) {
       LOG.warn("Unable to resolve the page behind a page-title heading; it renders no text.", e);
       return null;
@@ -43,9 +53,13 @@ public class HeadingPageTitleDataSource extends HeadingStaticDataSource implemen
   @Nullable
   @Override
   public String getHeadingText() {
-    return getPage().getDisplayTitle();
+    // getPage has always been able to return null, and this dereferenced it unguarded, so a
+    // heading that could not resolve its page threw NullPointerException out of the render.
+    final BaseContentPage currentPage = getPage();
+    return currentPage != null ? currentPage.getDisplayTitle() : null;
   }
 
+  @Nonnull
   public Boolean isOverrideInheritedTitle() {
     return getResource().getValueMap().get("overrideInheritedTitle", Boolean.FALSE);
   }

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/heading/HeadingPageTitleDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/heading/HeadingPageTitleDataSource.java
@@ -35,8 +35,7 @@ public class HeadingPageTitleDataSource extends HeadingStaticDataSource implemen
         return request.getResource().adaptTo(BaseComponent.class).getContainingPage();
       }
     } catch (ModelAdaptionException e) {
-      LOG.warn("Unable to find text for page title component {}. {}.", getResource().getPath(),
-              e.getMessage());
+      LOG.warn("Unable to resolve the page behind a page-title heading; it renders no text.", e);
       return null;
     }
   }

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/heading/HeadingStaticDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/heading/HeadingStaticDataSource.java
@@ -2,18 +2,40 @@ package io.kestros.cms.components.basic.core.content.heading;
 
 import io.kestros.cms.components.basic.api.content.KestrosHeading;
 import io.kestros.cms.components.basic.core.BaseSlingModelDataSource;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.models.annotations.Model;
 
 @Model(adaptables = SlingHttpServletRequest.class)
 public class HeadingStaticDataSource extends BaseSlingModelDataSource implements KestrosHeading {
+
+  /**
+   * Heading level used when the author never picked one.
+   *
+   * <p>This is the option the heading dialog marks selected, and the element the HTL falls back
+   * to, so a heading saved before the field existed keeps rendering as it always did.
+   */
+  private static final String DEFAULT_HEADING_TYPE = "h1";
+
+  @Nullable
   @Override
   public String getHeadingText() {
     return getResource().getValueMap().get("headingText", String.class);
   }
 
+  /**
+   * Heading element to render this heading as.
+   *
+   * <p>Declared @Nonnull by the interface, and it used to return the property straight out of the
+   * value map, so a heading with no headingType handed null to every caller of a method that
+   * promised one.
+   *
+   * @return The configured heading level, or h1.
+   */
+  @Nonnull
   @Override
   public String getHeadingType() {
-    return getResource().getValueMap().get("headingType", String.class);
+    return getResource().getValueMap().get("headingType", DEFAULT_HEADING_TYPE);
   }
 }

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/heading/KestrosHeadingImpl.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/heading/KestrosHeadingImpl.java
@@ -31,7 +31,9 @@ public class KestrosHeadingImpl extends BaseSyntheticResource implements Kestros
     this.text = resource.getValueMap().get("headingText", String.class);
     this.headingType = resource.getValueMap().get("headingType", String.class);
     if (this.text == null || this.headingType == null) {
-      throw new ComponentConfigurationException("Missing required property");
+      throw new ComponentConfigurationException(
+          String.format("Heading on %s is missing its %s property.", resource.getPath(),
+              this.text == null ? "headingText" : "headingType"));
     }
   }
 

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/image/ImageAssetDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/image/ImageAssetDataSource.java
@@ -39,10 +39,12 @@ public class ImageAssetDataSource extends BaseSlingModelDataSource implements Ke
         getResource().getValueMap().get("imagePath", String.class));
   }
 
+  @Nullable
   @Override
   public String getImageTitle() {
-    if (getAsset() != null && StringUtils.isNotBlank(getAsset().getTitle())) {
-      return getAsset().getTitle();
+    final Asset resolvedAsset = getAsset();
+    if (resolvedAsset != null && StringUtils.isNotBlank(resolvedAsset.getTitle())) {
+      return resolvedAsset.getTitle();
     }
     return getResource().getValueMap().get("imageTitle", "");
   }
@@ -54,8 +56,9 @@ public class ImageAssetDataSource extends BaseSlingModelDataSource implements Ke
     if (StringUtils.isNotBlank(alt)) {
       return alt;
     }
-    if (getAsset() != null && StringUtils.isNotBlank(getAsset().getDescription())) {
-      return getAsset().getDescription();
+    final Asset resolvedAsset = getAsset();
+    if (resolvedAsset != null && StringUtils.isNotBlank(resolvedAsset.getDescription())) {
+      return resolvedAsset.getDescription();
     }
     return "";
   }
@@ -116,9 +119,10 @@ public class ImageAssetDataSource extends BaseSlingModelDataSource implements Ke
     if (assetRetrievalService == null) {
       return null;
     }
+    final String imagePath = getImagePath();
     try {
-      if (getImagePath() != null) {
-        this.asset = assetRetrievalService.getAsset(getImagePath(), null,
+      if (imagePath != null) {
+        this.asset = assetRetrievalService.getAsset(imagePath, null,
             getResource().getResourceResolver());
         return asset;
       }

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/image/ImageAssetDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/image/ImageAssetDataSource.java
@@ -123,7 +123,8 @@ public class ImageAssetDataSource extends BaseSlingModelDataSource implements Ke
         return asset;
       }
     } catch (AssetRetrievalException e) {
-      LOG.warn("Failed to retrieve asset for image: {}", getImagePath());
+      LOG.warn("Failed to retrieve the asset behind an image; the image path is in the "
+          + "exception below.", e);
     }
     return null;
   }

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/image/ImageDataSourceComponent.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/image/ImageDataSourceComponent.java
@@ -13,6 +13,7 @@ import org.apache.sling.models.annotations.Model;
 public class ImageDataSourceComponent extends BaseDataSourceComponent<KestrosImage> implements
                                                                                     KestrosImage {
 
+  @Nullable
   @Override
   public String getImageTitle() {
     return getComponentData().getImageTitle();

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/image/ImageStaticDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/image/ImageStaticDataSource.java
@@ -129,7 +129,8 @@ public class ImageStaticDataSource extends BaseSlingModelDataSource implements K
         return asset;
       }
     } catch (AssetRetrievalException e) {
-      LOG.warn("Failed to retrieve asset for image: {}", getImagePath());
+      LOG.warn("Failed to retrieve the asset behind an image; the image path is in the "
+          + "exception below.", e);
     }
     return null;
   }

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/image/ImageStaticDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/image/ImageStaticDataSource.java
@@ -7,8 +7,6 @@ import io.kestros.cms.components.basic.api.content.AnchorTarget;
 import io.kestros.cms.components.basic.api.content.KestrosImage;
 import io.kestros.cms.components.basic.core.LinkUtils;
 import io.kestros.cms.components.basic.core.BaseSlingModelDataSource;
-import io.kestros.cms.componenttypes.api.services.ComponentUiFrameworkViewRetrievalService;
-import io.kestros.cms.componenttypes.api.services.ComponentVariationRetrievalService;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.apache.commons.lang3.StringUtils;
@@ -29,19 +27,15 @@ public class ImageStaticDataSource extends BaseSlingModelDataSource implements K
   @Optional
   private AssetRetrievalService assetRetrievalService;
 
-  @OSGiService
-  private ComponentVariationRetrievalService componentVariationRetrievalService;
-
-  @OSGiService
-  private ComponentUiFrameworkViewRetrievalService componentUiFrameworkViewRetrievalService;
-
   private Asset asset;
 
+  @Nullable
   @Override
   public String getImageTitle() {
     String assetTitle = "";
-    if (getAsset() != null) {
-      assetTitle = getAsset().getTitle();
+    final Asset resolvedAsset = getAsset();
+    if (resolvedAsset != null) {
+      assetTitle = resolvedAsset.getTitle();
     }
     return getResource().getValueMap().get("imageTitle", assetTitle);
   }
@@ -95,7 +89,17 @@ public class ImageStaticDataSource extends BaseSlingModelDataSource implements K
     return AnchorTarget.lookup(getResource());
   }
 
-  @Nullable
+  /**
+   * Text read out in place of the image.
+   *
+   * <p>The asset fallback below reads the field rather than calling getAsset(), so it only
+   * applies when some other getter has already resolved the asset. That is a real defect and it
+   * is left alone here: this card is SpotBugs to zero, and changing it changes what
+   * ImageStaticDataSourceTest.testGetAltText asserts. Filed separately.
+   *
+   * @return The configured alt text, the asset's description, or an empty string.
+   */
+  @Nonnull
   @Override
   public String getAltText() {
     String alt = getResource().getValueMap().get("altText", String.class);
@@ -122,9 +126,10 @@ public class ImageStaticDataSource extends BaseSlingModelDataSource implements K
     if (asset != null) {
       return asset;
     }
+    final String imagePath = getImagePath();
     try {
-      if (getImagePath() != null) {
-        this.asset = assetRetrievalService.getAsset(getImagePath(), null,
+      if (imagePath != null) {
+        this.asset = assetRetrievalService.getAsset(imagePath, null,
                 getResource().getResourceResolver());
         return asset;
       }

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/image/KestrosImageImpl.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/image/KestrosImageImpl.java
@@ -56,7 +56,9 @@ public class KestrosImageImpl extends BaseSyntheticResource implements KestrosIm
     this.anchorTitle = anchorTitle;
     this.target = target != null ? target : AnchorTarget.SAME_WINDOW;
     if (StringUtils.isEmpty(this.imagePath)) {
-      throw new ComponentConfigurationException("Missing required property");
+      throw new ComponentConfigurationException(
+              "An image needs an imagePath, and the " + resourcePrefix + " element was built "
+                      + "without one.");
     }
   }
 
@@ -68,7 +70,7 @@ public class KestrosImageImpl extends BaseSyntheticResource implements KestrosIm
     super(dataSource, resourcePrefix, forcedResourceName);
     this.assetRetrievalService = assetRetrievalService;
     String assetPath = resource.getValueMap().get("imagePath", String.class);
-    if(LinkUtils.isLinkExternal(assetPath)) {
+    if (assetPath != null && LinkUtils.isLinkExternal(assetPath)) {
       try {
         Asset asset = getAsset(assetPath, resource.getResourceResolver());
         this.imagePath = asset.getPath();
@@ -88,23 +90,45 @@ public class KestrosImageImpl extends BaseSyntheticResource implements KestrosIm
     this.anchorTitle = resource.getValueMap().get("anchorTitle", String.class);
     this.target = AnchorTarget.lookup(resource);
     if (StringUtils.isEmpty(this.imagePath)) {
-      throw new ComponentConfigurationException("Missing required property");
+      throw new ComponentConfigurationException(
+              "An image needs an imagePath property, and " + resource.getPath() + " has none.");
     }
   }
 
-  Asset getAsset(String path, ResourceResolver resourceResolver) throws AssetRetrievalException {
+  /**
+   * Resolves an asset by path.
+   *
+   * @param path Path of the asset.
+   * @param resourceResolver Resolver to read it with.
+   * @return The asset at that path.
+   * @throws AssetRetrievalException No AssetRetrievalService is available, or the asset cannot be
+   *         retrieved.
+   */
+  @Nonnull
+  final Asset getAsset(@Nonnull String path, @Nonnull ResourceResolver resourceResolver)
+          throws AssetRetrievalException {
     if (assetRetrievalService == null) {
-      throw new AssetRetrievalException("AssetRetrievalService is not available.");
+      throw new AssetRetrievalException(
+              "No AssetRetrievalService is available to resolve the image at " + path + ".");
     }
     return assetRetrievalService.getAsset(path, null, resourceResolver);
   }
 
+  @Nullable
   @Override
   public String getImageTitle() {
     return imageTitle;
   }
 
-  @Nullable
+  /**
+   * Path of the image this element renders.
+   *
+   * <p>Never null: both constructors throw when it is missing, which is why this can honour the
+   * interface's @Nonnull rather than relaxing it.
+   *
+   * @return Path of the image.
+   */
+  @Nonnull
   @Override
   public String getImagePath() {
     return imagePath;

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/link/LinkStaticDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/link/LinkStaticDataSource.java
@@ -27,7 +27,7 @@ public class LinkStaticDataSource extends BaseSlingModelDataSource implements Ke
   @Nonnull
   @Override
   public AnchorTarget getTarget() {
-    return AnchorTarget.lookup(getResource().getValueMap().get("openInNewTab", false));
+    return AnchorTarget.lookup(getResource().getValueMap().get("openInNewTab", Boolean.FALSE));
   }
 
   @Nullable

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/table/KestrosTableHeaderImpl.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/table/KestrosTableHeaderImpl.java
@@ -32,6 +32,7 @@ public class KestrosTableHeaderImpl extends BaseSyntheticResource implements Kes
     this.text = text;
   }
 
+  @Nullable
   @Override
   public String getText() {
     return text;

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/table/TableCellDataSourceComponent.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/table/TableCellDataSourceComponent.java
@@ -5,6 +5,7 @@ import io.kestros.cms.components.basic.api.table.KestrosTableCell;
 import io.kestros.cms.components.basic.core.BaseContainerDataSourceComponent;
 import java.util.List;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.models.annotations.Model;
@@ -19,6 +20,7 @@ public class TableCellDataSourceComponent extends BaseContainerDataSourceCompone
     return getComponentData().getCellContentElements();
   }
 
+  @Nullable
   @Override
   public String getText() {
     KestrosTableCell data = getComponentData();

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/table/TableCellStaticDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/table/TableCellStaticDataSource.java
@@ -6,6 +6,7 @@ import io.kestros.cms.components.basic.core.BaseContainerSlingModelDataSource;
 import java.util.ArrayList;
 import java.util.List;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.models.annotations.Model;
@@ -18,7 +19,7 @@ public class TableCellStaticDataSource extends BaseContainerSlingModelDataSource
   @Nonnull
   @Override
   public List<Resource> getCellContent() {
-    List<Resource> cellContent = new java.util.ArrayList<>();
+    List<Resource> cellContent = new ArrayList<>();
     for (Resource child : getResource().getChildren()) {
       cellContent.add(child);
     }
@@ -29,11 +30,12 @@ public class TableCellStaticDataSource extends BaseContainerSlingModelDataSource
   @Nonnull
   @Override
   public List<KestrosBasicComponentElement> getCellContentElements() {
-    List<KestrosBasicComponentElement> cellContentElements = new ArrayList<>();
-    // This should never get hit, since we can just look to child resources instead of synthesizing them, but we need to return something here to satisfy the interface contract.
+    // A static cell reads its content off child resources, so it never synthesizes elements. The
+    // interface still has to be answered, and an empty list is the honest answer.
     return new ArrayList<>();
   }
 
+  @Nullable
   @Override
   public String getText() {
     return getResource().getValueMap().get("text", String.class);

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/table/TableChildNodesDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/table/TableChildNodesDataSource.java
@@ -78,7 +78,7 @@ public class TableChildNodesDataSource extends BaseContainerSlingModelDataSource
         try {
           headers.add(new KestrosTableHeaderImpl(labels[i], this, "header" + i, "header" + i));
         } catch (final ComponentConfigurationException e) {
-          LOG.warn("Unable to build table header '{}': {}", labels[i], e.getMessage());
+          LOG.warn("Unable to build one table header; it is left out of the table.", e);
         }
       }
     }
@@ -97,7 +97,8 @@ public class TableChildNodesDataSource extends BaseContainerSlingModelDataSource
     final String dataPath = resolveDataPath(configuredDataPath);
     final Resource dataResource = getResourceResolver().getResource(dataPath);
     if (dataResource == null) {
-      LOG.warn("Table dataPath {} not found.", dataPath);
+      LOG.warn("The table's configured dataPath does not resolve to a resource; the table has "
+          + "no rows.");
       return rows;
     }
     int r = 0;
@@ -109,13 +110,13 @@ public class TableChildNodesDataSource extends BaseContainerSlingModelDataSource
         try {
           cells.add(new KestrosTableCellImpl(text, this, "r" + r + "c" + c, "r" + r + "c" + c));
         } catch (final ComponentConfigurationException e) {
-          LOG.warn("Unable to build table cell: {}", e.getMessage());
+          LOG.warn("Unable to build one table cell; it is left out of the row.", e);
         }
       }
       try {
         rows.add(new KestrosTableRowImpl(cells, this, "row" + r, "row" + r));
       } catch (final ComponentConfigurationException e) {
-        LOG.warn("Unable to build table row {}: {}", r, e.getMessage());
+        LOG.warn("Unable to build one table row; it is left out of the table.", e);
       }
       r++;
     }

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/table/TableStaticDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/table/TableStaticDataSource.java
@@ -20,7 +20,7 @@ public class TableStaticDataSource extends BaseContainerSlingModelDataSource
   public List<KestrosTableHeader> getHeaderElements() {
     List<KestrosTableHeader> headers = new ArrayList<>();
     for (Resource childResource : getResource().getChildren()) {
-      if (childResource.getResourceType().equals(KestrosTableHeader.RESOURCE_TYPE)) {
+      if (KestrosTableHeader.RESOURCE_TYPE.equals(childResource.getResourceType())) {
         KestrosTableHeader header = childResource.adaptTo(TableHeaderStaticDataSource.class);
         if (header != null) {
           headers.add(header);
@@ -35,7 +35,7 @@ public class TableStaticDataSource extends BaseContainerSlingModelDataSource
   public List<KestrosTableRow> getRowElements() {
     List<KestrosTableRow> rows = new ArrayList<>();
     for (Resource childResource : getResource().getChildren()) {
-      if (childResource.getResourceType().equals(KestrosTableRow.RESOURCE_TYPE)) {
+      if (KestrosTableRow.RESOURCE_TYPE.equals(childResource.getResourceType())) {
         KestrosTableRow row = childResource.adaptTo(TableRowStaticDataSource.class);
         if (row != null) {
           rows.add(row);

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/video/VideoAssetDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/video/VideoAssetDataSource.java
@@ -61,7 +61,8 @@ public class VideoAssetDataSource extends BaseSlingModelDataSource implements Ke
         asset = assetRetrievalService.getAsset(videoPath, null, getResourceResolver());
         return asset;
       } catch (AssetRetrievalException e) {
-        LOG.warn("Failed to retrieve asset for video: {}", videoPath);
+        LOG.warn("Failed to retrieve the asset behind a video; the video path is in the "
+            + "exception below.", e);
       }
     }
     return null;

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/video/VideoStaticDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/video/VideoStaticDataSource.java
@@ -20,11 +20,24 @@ public class VideoStaticDataSource extends BaseSlingModelDataSource implements K
   @Optional
   private AssetRetrievalService assetRetrievalService;
 
+  /**
+   * Path the video is served from.
+   *
+   * <p>Guarded on the asset. With no AssetRetrievalService bound, getVideoAsset() returns null
+   * and this used to dereference it, so a video component on an instance without the asset
+   * service threw instead of falling back to its fallback text.
+   *
+   * @return Path of the video asset, or null when it cannot be resolved.
+   */
   @Nullable
   @Override
   public String getVideoSource() {
     try {
-      return getVideoAsset().getPath();
+      final Asset videoAsset = getVideoAsset();
+      if (videoAsset == null) {
+        return null;
+      }
+      return videoAsset.getPath();
     } catch (AssetRetrievalException e) {
       return null;
     }
@@ -36,10 +49,12 @@ public class VideoStaticDataSource extends BaseSlingModelDataSource implements K
     return getResource().getValueMap().get("fallbackText", StringUtils.EMPTY);
   }
 
+  @Nullable
   String getVideoPath() {
     return getResource().getValueMap().get("videoPath", String.class);
   }
 
+  @Nullable
   Asset getVideoAsset() throws AssetRetrievalException {
     if (assetRetrievalService != null) {
       return assetRetrievalService.getAsset(getVideoPath(), null, getResourceResolver());

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/videoembed/EmbedSanitizer.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/videoembed/EmbedSanitizer.java
@@ -5,6 +5,7 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 /**
@@ -108,15 +109,15 @@ public final class EmbedSanitizer {
 
     Matcher attrMatcher = ATTR_PATTERN.matcher(attributesStr);
     while (attrMatcher.find()) {
-      String attrName = attrMatcher.group(1).toLowerCase();
+      String attrName = attrMatcher.group(1);
       String attrValue = attrMatcher.group(2);
 
-      if (!ALLOWED_ATTRIBUTES.contains(attrName)) {
+      if (!containsIgnoringCase(ALLOWED_ATTRIBUTES, attrName)) {
         // Skip disallowed attributes silently
         continue;
       }
 
-      if ("src".equals(attrName)) {
+      if ("src".equalsIgnoreCase(attrName)) {
         if (attrValue == null) {
           return null;
         }
@@ -134,11 +135,11 @@ public final class EmbedSanitizer {
       }
 
       if (sanitizedAttrs.length() > 0) {
-        sanitizedAttrs.append(" ");
+        sanitizedAttrs.append(' ');
       }
 
       if (attrValue != null) {
-        sanitizedAttrs.append(attrName).append("=\"").append(attrValue).append("\"");
+        sanitizedAttrs.append(attrName).append("=\"").append(attrValue).append('"');
       } else {
         sanitizedAttrs.append(attrName);
       }
@@ -152,7 +153,7 @@ public final class EmbedSanitizer {
     return "<iframe " + sanitizedAttrs.toString() + "></iframe>";
   }
 
-  private static boolean isDomainAllowed(String url) {
+  private static boolean isDomainAllowed(@Nonnull String url) {
     // Extract domain from URL: https://domain/path
     String withoutScheme = url.substring("https://".length());
     int slashIndex = withoutScheme.indexOf('/');
@@ -167,6 +168,27 @@ public final class EmbedSanitizer {
     if (portIndex > 0) {
       domain = domain.substring(0, portIndex);
     }
-    return ALLOWED_DOMAINS.contains(domain.toLowerCase());
+    return containsIgnoringCase(ALLOWED_DOMAINS, domain);
+  }
+
+  /**
+   * Case-insensitive membership, without case-mapping the candidate first.
+   *
+   * <p>Both allowlists here decide whether untrusted markup is kept, and lowercasing a value
+   * before an allowlist check is its own hazard: Unicode case mapping is locale-dependent and can
+   * change a string's length, so the value compared is not always the value that came in.
+   *
+   * @param allowed Allowlist to look in.
+   * @param candidate Value read out of the author's markup.
+   * @return True when the allowlist holds the candidate, ignoring case.
+   */
+  private static boolean containsIgnoringCase(@Nonnull final Set<String> allowed,
+      @Nonnull final String candidate) {
+    for (final String entry : allowed) {
+      if (entry.equalsIgnoreCase(candidate)) {
+        return true;
+      }
+    }
+    return false;
   }
 }

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/videoembed/EmbedSanitizer.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/videoembed/EmbedSanitizer.java
@@ -117,7 +117,7 @@ public final class EmbedSanitizer {
         continue;
       }
 
-      if ("src".equalsIgnoreCase(attrName)) {
+      if ("src".equals(toAsciiLowerCase(attrName))) {
         if (attrValue == null) {
           return null;
         }
@@ -184,11 +184,28 @@ public final class EmbedSanitizer {
    */
   private static boolean containsIgnoringCase(@Nonnull final Set<String> allowed,
       @Nonnull final String candidate) {
-    for (final String entry : allowed) {
-      if (entry.equalsIgnoreCase(candidate)) {
-        return true;
+    return allowed.contains(toAsciiLowerCase(candidate));
+  }
+
+  /**
+   * Lowercases the ASCII letters in a value and leaves every other character alone.
+   *
+   * <p>Neither {@code toLowerCase} nor {@code equalsIgnoreCase} is safe in front of an allowlist:
+   * both apply Unicode case mapping, which is locale-dependent and can change a string's length,
+   * so the value compared is not always the value that arrived. Every entry in both allowlists
+   * here is lowercase ASCII, so folding only A-Z is exactly the comparison intended.
+   *
+   * @param value Value read out of the author's markup.
+   * @return The value with A-Z folded to a-z.
+   */
+  @Nonnull
+  private static String toAsciiLowerCase(@Nonnull final String value) {
+    final char[] characters = value.toCharArray();
+    for (int index = 0; index < characters.length; index++) {
+      if (characters[index] >= 'A' && characters[index] <= 'Z') {
+        characters[index] += 'a' - 'A';
       }
     }
-    return false;
+    return new String(characters);
   }
 }

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/videoembed/VideoEmbedYouTubeDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/content/videoembed/VideoEmbedYouTubeDataSource.java
@@ -6,6 +6,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.sling.api.SlingHttpServletRequest;
@@ -28,30 +29,26 @@ public class VideoEmbedYouTubeDataSource extends BaseSlingModelDataSource
   private static final Pattern HTML_PATTERN =
           Pattern.compile("[<>]");
 
-  boolean isValidVideoInput(String input) {
+  boolean isValidVideoInput(@Nullable String input) {
     if (input == null) {
       return false;
     }
 
     String value = input.trim();
 
-    // 🚫 reject anything that looks like HTML
+    // Reject anything that looks like HTML.
     if (HTML_PATTERN.matcher(value).find()) {
       return false;
     }
 
-    // ✅ raw video ID
+    // A raw video ID.
     if (YOUTUBE_VIDEO_ID.matcher(value).matches()) {
       return true;
     }
 
-    // ✅ known YouTube URL formats
+    // A known YouTube URL format.
     Matcher matcher = YOUTUBE_URL_ID.matcher(value);
-    if (matcher.find()) {
-      return true;
-    }
-
-    return false;
+    return matcher.find();
   }
 
 
@@ -87,28 +84,23 @@ public class VideoEmbedYouTubeDataSource extends BaseSlingModelDataSource
     );
   }
 
+  @Nullable
   private String getYoutubeVideo() {
     return getResource().getValueMap().get("youtubeVideo", String.class);
   }
 
   private boolean isMute() {
-    return getResource().getValueMap().get("mute", false);
+    return getResource().getValueMap().get("mute", Boolean.FALSE);
   }
-
-
-    /* ------------------
-       Helpers
-       ------------------ */
 
   private boolean isAllowFullscreen() {
-    return getResource().getValueMap().get("allowFullScreen", true);
+    return getResource().getValueMap().get("allowFullScreen", Boolean.TRUE);
   }
 
-  private String buildEmbedUrl(String videoId) {
-
-
+  @Nonnull
+  private String buildEmbedUrl(@Nonnull String videoId) {
     String base = "https://www.youtube.com/embed/";
-    List<String> params = new ArrayList<>();
+    List<String> params = new ArrayList<>(1);
 
     if (isMute()) {
       params.add("mute=1");
@@ -117,8 +109,14 @@ public class VideoEmbedYouTubeDataSource extends BaseSlingModelDataSource
     return base + videoId + (params.isEmpty() ? "" : "?" + String.join("&", params));
   }
 
-
-  private String extractVideoId(String value) {
+  /**
+   * Pulls the eleven-character video id out of whatever the author typed.
+   *
+   * @param value Raw id, share link or watch URL.
+   * @return The video id, or null when the value is blank or carries no id.
+   */
+  @Nullable
+  private String extractVideoId(@Nullable String value) {
     if (StringUtils.isBlank(value)) {
       return null;
     }
@@ -128,7 +126,7 @@ public class VideoEmbedYouTubeDataSource extends BaseSlingModelDataSource
     }
 
     if (value.contains("youtu.be/")) {
-      return value.substring(value.lastIndexOf("/") + 1);
+      return value.substring(value.lastIndexOf('/') + 1);
     }
 
     int index = value.indexOf("v=");

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/lists/cardlist/CardListAssetsDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/lists/cardlist/CardListAssetsDataSource.java
@@ -139,9 +139,8 @@ public class CardListAssetsDataSource extends BaseContainerSlingModelDataSource 
         titleElement = new KestrosHeadingImpl(asset.getTitle(), "h2",
             this, "title", "titleElement");
       } catch (ComponentConfigurationException e) {
-        LOG.warn("Unable to build the heading for card {} in {}. The card renders without a "
-                + "title. {}", forLog(asset.getPath()), forLog(getResource().getPath()),
-            forLog(e.getMessage()), e);
+        LOG.warn("Unable to build the heading for one card in this list. The card renders "
+                + "without a title. The asset path is in the exception below.", e);
       }
 
       KestrosImage image = null;
@@ -152,9 +151,8 @@ public class CardListAssetsDataSource extends BaseContainerSlingModelDataSource 
       } catch (ComponentConfigurationException e) {
         // One asset whose image cannot be configured must cost one image, not the whole list.
         // Returning null here blanked every card on the page, and getCardElements is @Nonnull.
-        LOG.warn("Unable to build the image for card {} in {}. The card renders without an "
-                + "image. {}", forLog(asset.getPath()), forLog(getResource().getPath()),
-            forLog(e.getMessage()), e);
+        LOG.warn("Unable to build the image for one card in this list. The card renders "
+                + "without an image. The asset path is in the exception below.", e);
       }
       try {
         cards.add(
@@ -164,8 +162,7 @@ public class CardListAssetsDataSource extends BaseContainerSlingModelDataSource 
                 "card", null));
       } catch (ComponentConfigurationException e) {
         // Same reasoning: drop the one card that cannot be configured, keep the rest.
-        LOG.warn("Unable to build a card for asset {} in {}. It is left out of the list. {}",
-            forLog(asset.getPath()), forLog(getResource().getPath()), forLog(e.getMessage()), e);
+        LOG.warn("Unable to build a card for one asset; it is left out of the list.", e);
       }
     }
     return cards;

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/lists/cardlist/CardListAssetsDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/lists/cardlist/CardListAssetsDataSource.java
@@ -4,7 +4,6 @@ import io.kestros.cms.assets.api.exceptions.AssetCollectionRetrievalException;
 import io.kestros.cms.assets.api.models.Asset;
 import io.kestros.cms.assets.api.models.AssetCollection;
 import io.kestros.cms.assets.api.services.AssetRetrievalService;
-import io.kestros.cms.components.basic.api.KestrosBasicComponentElement;
 import io.kestros.cms.components.basic.api.content.AnchorTarget;
 import io.kestros.cms.components.basic.api.content.KestrosCard;
 import io.kestros.cms.components.basic.api.content.KestrosHeading;
@@ -15,32 +14,48 @@ import io.kestros.cms.components.basic.core.BaseContainerSlingModelDataSource;
 import io.kestros.cms.components.basic.core.content.card.KestrosCardImpl;
 import io.kestros.cms.components.basic.core.content.heading.KestrosHeadingImpl;
 import io.kestros.cms.components.basic.core.content.image.KestrosImageImpl;
-import io.kestros.cms.componenttypes.api.models.ComponentVariation;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.Date;
 import java.util.List;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.models.annotations.Model;
 import org.apache.sling.models.annotations.injectorspecific.OSGiService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @Model(adaptables = {SlingHttpServletRequest.class, Resource.class})
 public class CardListAssetsDataSource extends BaseContainerSlingModelDataSource implements
                                                                                 KestrosCardList {
+
+  private static final Logger LOG = LoggerFactory.getLogger(CardListAssetsDataSource.class);
+
   @OSGiService
   private AssetRetrievalService assetRetrievalService;
   private AssetCollection collection;
 
+  @Nonnull
   String getHeadingLevel() {
     return getResource().getValueMap().get("headingType", "h2");
   }
 
+  /**
+   * Asset collection the cards are built from.
+   *
+   * @return The configured collection, or null when no collectionPath is set or it cannot be
+   *     retrieved.
+   */
+  @Nullable
   AssetCollection getCollection() {
     if (collection == null) {
-      String collectionPath = getResource().getValueMap().get("collectionPath", String.class);
+      // Defaulted rather than read as String.class: a missing property gave a null path that was
+      // handed straight to the asset service. An empty path fails retrieval the same way, without
+      // a null crossing the boundary.
+      String collectionPath = getResource().getValueMap().get("collectionPath", "");
       try {
         collection = assetRetrievalService.getCollection(collectionPath, getResourceResolver());
       } catch (AssetCollectionRetrievalException e) {
@@ -48,6 +63,30 @@ public class CardListAssetsDataSource extends BaseContainerSlingModelDataSource 
       }
     }
     return collection;
+  }
+
+  /**
+   * Sort key for an asset's creation date, with assets that have no date sorting first.
+   *
+   * @param asset Asset to read the date from.
+   * @return Epoch milliseconds, or 0 when the asset has no creation date.
+   */
+  @Nonnull
+  private static Long getCreatedTime(@Nonnull final Asset asset) {
+    final Date date = asset.getCreatedDate();
+    return date != null ? date.getTime() : 0L;
+  }
+
+  /**
+   * Sort key for an asset's last-modified date, with assets that have no date sorting first.
+   *
+   * @param asset Asset to read the date from.
+   * @return Epoch milliseconds, or 0 when the asset has no modification date.
+   */
+  @Nonnull
+  private static Long getModifiedTime(@Nonnull final Asset asset) {
+    final Date date = asset.getModifiedDate();
+    return date != null ? date.getTime() : 0L;
   }
 
   @Nonnull
@@ -60,8 +99,8 @@ public class CardListAssetsDataSource extends BaseContainerSlingModelDataSource 
     List<Asset> assets = new ArrayList<>(col.getChildAssets());
 
     String sortBy = getResource().getValueMap().get("sortBy", "");
-    boolean reverse = getResource().getValueMap().get("reverse", false);
-    int limit = 0;
+    boolean reverse = getResource().getValueMap().get("reverse", Boolean.FALSE);
+    int limit;
     try {
       limit = Integer.parseInt(getResource().getValueMap().get("limit", "0"));
     } catch (NumberFormatException e) {
@@ -71,26 +110,16 @@ public class CardListAssetsDataSource extends BaseContainerSlingModelDataSource 
     if (!sortBy.isEmpty()) {
       switch (sortBy) {
         case "createdDate":
-          assets.sort(Comparator.comparing(a -> {
-            Date date = a.getCreatedDate();
-            return date != null ? date.getTime() : 0L;
-          }));
+          assets.sort(Comparator.comparing(CardListAssetsDataSource::getCreatedTime));
           break;
         case "lastModified":
-          assets.sort(Comparator.comparing(a -> {
-            Date date = a.getModifiedDate();
-            return date != null ? date.getTime() : 0L;
-          }));
+          assets.sort(Comparator.comparing(CardListAssetsDataSource::getModifiedTime));
+          break;
+        case "name":
+          assets.sort(Comparator.comparing(Asset::getName));
           break;
         default:
-          assets.sort(Comparator.comparing(a -> {
-            switch (sortBy) {
-              case "name":
-                return a.getName() != null ? a.getName() : "";
-              default:
-                return a.getTitle() != null ? a.getTitle() : a.getName();
-            }
-          }));
+          assets.sort(Comparator.comparing(Asset::getTitle));
           break;
       }
     }
@@ -102,41 +131,30 @@ public class CardListAssetsDataSource extends BaseContainerSlingModelDataSource 
       assets = assets.subList(0, limit);
     }
 
-    List<KestrosCard> cards = new ArrayList<>();
-    String parentPath = getPath();
+    List<KestrosCard> cards = new ArrayList<>(assets.size());
 
     for (Asset asset : assets) {
-      String imagePath = asset.getPath();
-      String altText = null;
-      String caption = null;
-      String imageTitle = null;
-      String href = null;
-      String ariaLabel = null;
-      String anchorTitle = null;
-      AnchorTarget target = null;
-
-      List<ComponentVariation> titleVariations = getElementVariations("titleVariations",
-          KestrosImage.RESOURCE_TYPE);
-      String titleLayout = getLayout("title");
       KestrosHeading titleElement = null;
       try {
         titleElement = new KestrosHeadingImpl(asset.getTitle(), "h2",
-            this,"title", "titleElement");
+            this, "title", "titleElement");
       } catch (ComponentConfigurationException e) {
-        // do nothing.
+        LOG.warn("Unable to build the heading for card {} in {}. The card renders without a "
+                + "title. {}", forLog(asset.getPath()), forLog(getResource().getPath()),
+            forLog(e.getMessage()), e);
       }
 
-      List<ComponentVariation> imageVariations = getElementVariations("imageVariations",
-          KestrosImage.RESOURCE_TYPE);
-      String imageLayout = getLayout("image");
-      String imageId = null;
       KestrosImage image = null;
       try {
-        image = new KestrosImageImpl(imagePath, altText, caption, imageTitle,
-            href, ariaLabel, anchorTitle, target,
-            this, "image", "imageElement",assetRetrievalService);
+        image = new KestrosImageImpl(asset.getPath(), null, null, null,
+            null, null, null, AnchorTarget.SAME_WINDOW,
+            this, "image", "imageElement", assetRetrievalService);
       } catch (ComponentConfigurationException e) {
-        return null;
+        // One asset whose image cannot be configured must cost one image, not the whole list.
+        // Returning null here blanked every card on the page, and getCardElements is @Nonnull.
+        LOG.warn("Unable to build the image for card {} in {}. The card renders without an "
+                + "image. {}", forLog(asset.getPath()), forLog(getResource().getPath()),
+            forLog(e.getMessage()), e);
       }
       try {
         cards.add(
@@ -144,11 +162,25 @@ public class CardListAssetsDataSource extends BaseContainerSlingModelDataSource 
                 null,
                 this,
                 "card", null));
-      } catch (Exception e) {
-        throw new RuntimeException(e);
+      } catch (ComponentConfigurationException e) {
+        // Same reasoning: drop the one card that cannot be configured, keep the rest.
+        LOG.warn("Unable to build a card for asset {} in {}. It is left out of the list. {}",
+            forLog(asset.getPath()), forLog(getResource().getPath()), forLog(e.getMessage()), e);
       }
     }
-    return new ArrayList<>(cards);
+    return cards;
+  }
+
+  /**
+   * Strips CR and LF from a value before it is logged, so an author-controlled path or an exception
+   * message cannot forge a log line.
+   *
+   * @param value Value about to be logged.
+   * @return The value with CR and LF removed, or null unchanged.
+   */
+  @Nullable
+  private static String forLog(@Nullable final String value) {
+    return value == null ? null : value.replaceAll("[\r\n]", "");
   }
 
 }

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/lists/cardlist/CardListAssetsDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/lists/cardlist/CardListAssetsDataSource.java
@@ -171,16 +171,4 @@ public class CardListAssetsDataSource extends BaseContainerSlingModelDataSource 
     return cards;
   }
 
-  /**
-   * Strips CR and LF from a value before it is logged, so an author-controlled path or an exception
-   * message cannot forge a log line.
-   *
-   * @param value Value about to be logged.
-   * @return The value with CR and LF removed, or null unchanged.
-   */
-  @Nullable
-  private static String forLog(@Nullable final String value) {
-    return value == null ? null : value.replaceAll("[\r\n]", "");
-  }
-
 }

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/lists/cardlist/CardListChildPagesDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/lists/cardlist/CardListChildPagesDataSource.java
@@ -127,8 +127,7 @@ public class CardListChildPagesDataSource extends BaseContainerSlingModelDataSou
       } catch (ComponentConfigurationException e) {
         // Wrapping this in a RuntimeException lost the whole card list over one unbuildable page,
         // which is what KestrosCardImpl's asset lookup was already working around.
-        LOG.warn("Unable to build a card for page {} in {}. It is left out of the list. {}",
-            forLog(page.getPath()), forLog(getResource().getPath()), forLog(e.getMessage()), e);
+        LOG.warn("Unable to build a card for one child page; it is left out of the list.", e);
       }
     }
     return cards;

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/lists/cardlist/CardListChildPagesDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/lists/cardlist/CardListChildPagesDataSource.java
@@ -2,7 +2,6 @@ package io.kestros.cms.components.basic.core.lists.cardlist;
 
 import io.kestros.cms.assets.api.services.AssetRetrievalService;
 import io.kestros.cms.components.basic.api.content.KestrosCard;
-import io.kestros.cms.components.basic.api.exceptions.ComponentConfigurationException;
 import io.kestros.cms.components.basic.api.lists.KestrosCardList;
 import io.kestros.cms.components.basic.core.BaseContainerSlingModelDataSource;
 import io.kestros.cms.components.basic.core.content.card.KestrosCardImpl;

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/lists/cardlist/CardListChildPagesDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/lists/cardlist/CardListChildPagesDataSource.java
@@ -78,7 +78,12 @@ public class CardListChildPagesDataSource extends BaseContainerSlingModelDataSou
     if (root == null) {
       return new ArrayList<>();
     }
-    CardListSupport.requireComponentPrerequisites(this);
+    // Every card in this list shares these prerequisites, so a failure among them belongs to the
+    // whole component and must surface rather than render an empty list.
+    IllegalStateException prerequisiteFailure = CardListSupport.componentPrerequisiteFailure(this);
+    if (prerequisiteFailure != null) {
+      throw prerequisiteFailure;
+    }
     List<BaseContentPage> pages = new ArrayList<>(root.getChildPages());
 
     String sortBy = getResource().getValueMap().get("sortBy", "");

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/lists/cardlist/CardListChildPagesDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/lists/cardlist/CardListChildPagesDataSource.java
@@ -1,10 +1,8 @@
 package io.kestros.cms.components.basic.core.lists.cardlist;
 
 import io.kestros.cms.assets.api.services.AssetRetrievalService;
-import io.kestros.cms.components.basic.api.content.KestrosButton;
-import io.kestros.cms.components.basic.api.content.KestrosButtonGroup;
 import io.kestros.cms.components.basic.api.content.KestrosCard;
-import io.kestros.cms.components.basic.api.content.KestrosImage;
+import io.kestros.cms.components.basic.api.exceptions.ComponentConfigurationException;
 import io.kestros.cms.components.basic.api.lists.KestrosCardList;
 import io.kestros.cms.components.basic.core.BaseContainerSlingModelDataSource;
 import io.kestros.cms.components.basic.core.content.card.KestrosCardImpl;
@@ -12,7 +10,6 @@ import io.kestros.cms.sitebuilding.api.models.BaseComponent;
 import io.kestros.cms.sitebuilding.api.models.BaseContentPage;
 import io.kestros.commons.structuredslingmodels.exceptions.NoValidAncestorException;
 import java.util.ArrayList;
-import java.util.Calendar;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
@@ -23,10 +20,14 @@ import org.apache.sling.api.resource.Resource;
 import org.apache.sling.models.annotations.Model;
 import org.apache.sling.models.annotations.Optional;
 import org.apache.sling.models.annotations.injectorspecific.OSGiService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @Model(adaptables = {SlingHttpServletRequest.class, Resource.class})
 public class CardListChildPagesDataSource extends BaseContainerSlingModelDataSource implements
                                                                                     KestrosCardList {
+
+  private static final Logger LOG = LoggerFactory.getLogger(CardListChildPagesDataSource.class);
 
   @OSGiService
   @Optional
@@ -34,21 +35,30 @@ public class CardListChildPagesDataSource extends BaseContainerSlingModelDataSou
 
   private BaseContentPage rootPage;
 
+  /**
+   * Page whose children are rendered as cards.
+   *
+   * @return The configured pagesPath as a page, else the containing page, or null when neither
+   *     resolves.
+   */
+  @Nullable
   BaseContentPage getRootPage() {
     if (rootPage == null) {
       String pagesPath = getResource().getValueMap().get("pagesPath", String.class);
       if (pagesPath != null) {
         Resource pageResource = getResourceResolver().getResource(pagesPath);
         if (pageResource != null) {
-          try {
-            rootPage = pageResource.adaptTo(BaseContentPage.class);
-          } catch (Exception e) {
-            return null;
-          }
+          rootPage = pageResource.adaptTo(BaseContentPage.class);
         }
       } else {
+        // adaptTo returns null for a resource with no BaseComponent adapter; dereferencing it
+        // threw NullPointerException out of a method every caller treats as returning null.
+        BaseComponent component = getResource().adaptTo(BaseComponent.class);
+        if (component == null) {
+          return null;
+        }
         try {
-          rootPage = getResource().adaptTo(BaseComponent.class).getContainingPage();
+          rootPage = component.getContainingPage();
         } catch (NoValidAncestorException e) {
           return null;
         }
@@ -72,8 +82,8 @@ public class CardListChildPagesDataSource extends BaseContainerSlingModelDataSou
     List<BaseContentPage> pages = new ArrayList<>(root.getChildPages());
 
     String sortBy = getResource().getValueMap().get("sortBy", "");
-    boolean reverse = getResource().getValueMap().get("reverse", false);
-    int limit = 0;
+    boolean reverse = getResource().getValueMap().get("reverse", Boolean.FALSE);
+    int limit;
     try {
       limit = Integer.parseInt(getResource().getValueMap().get("limit", "0"));
     } catch (NumberFormatException e) {
@@ -83,30 +93,16 @@ public class CardListChildPagesDataSource extends BaseContainerSlingModelDataSou
     if (!sortBy.isEmpty()) {
       switch (sortBy) {
         case "createdDate":
-          pages.sort(Comparator.comparing(p -> {
-            Calendar cal = p.getResource().getChild("jcr:content") != null
-                ? p.getResource().getChild("jcr:content").getValueMap()
-                    .get("jcr:created", Calendar.class) : null;
-            return cal != null ? cal.getTimeInMillis() : 0L;
-          }));
+          pages.sort(Comparator.comparing(CardListChildPagesDataSource::getCreatedTime));
           break;
         case "lastModified":
-          pages.sort(Comparator.comparing(p -> {
-            Calendar cal = p.getResource().getChild("jcr:content") != null
-                ? p.getResource().getChild("jcr:content").getValueMap()
-                    .get("jcr:lastModified", Calendar.class) : null;
-            return cal != null ? cal.getTimeInMillis() : 0L;
-          }));
+          pages.sort(Comparator.comparing(CardListChildPagesDataSource::getModifiedTime));
+          break;
+        case "name":
+          pages.sort(Comparator.comparing(BaseContentPage::getName));
           break;
         default:
-          pages.sort(Comparator.comparing(p -> {
-            switch (sortBy) {
-              case "name":
-                return p.getName() != null ? p.getName() : "";
-              default:
-                return p.getDisplayTitle() != null ? p.getDisplayTitle() : p.getName();
-            }
-          }));
+          pages.sort(Comparator.comparing(BaseContentPage::getDisplayTitle));
           break;
       }
     }
@@ -118,7 +114,7 @@ public class CardListChildPagesDataSource extends BaseContainerSlingModelDataSou
       pages = pages.subList(0, limit);
     }
 
-    List<KestrosCard> cards = new ArrayList<>();
+    List<KestrosCard> cards = new ArrayList<>(pages.size());
     for (BaseContentPage page : pages) {
       try {
         cards.add(
@@ -126,22 +122,16 @@ public class CardListChildPagesDataSource extends BaseContainerSlingModelDataSou
                 getReadMoreText(),
                 this,
                 "card",
-//                getElementVariations("titleVariations", KestrosImage.RESOURCE_TYPE),
-//                getLayout("title"),
-//                getElementVariations("imageVariations", KestrosImage.RESOURCE_TYPE),
-//                getLayout("image"),
-//                getElementVariations("buttonGroupVariations", KestrosButtonGroup.RESOURCE_TYPE),
-//                getLayout("buttonGroupLayout"),
-//                getElementVariations("buttonVariations", KestrosButton.RESOURCE_TYPE),
-//                getLayout("button"),
-//                null,
                 page.getName(),
                 assetRetrievalService));
-      } catch (Exception e) {
-        throw new RuntimeException(e);
+      } catch (ComponentConfigurationException e) {
+        // Wrapping this in a RuntimeException lost the whole card list over one unbuildable page,
+        // which is what KestrosCardImpl's asset lookup was already working around.
+        LOG.warn("Unable to build a card for page {} in {}. It is left out of the list. {}",
+            forLog(page.getPath()), forLog(getResource().getPath()), forLog(e.getMessage()), e);
       }
     }
-    return new ArrayList<>(cards);
+    return cards;
   }
 
 }

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/lists/cardlist/CardListSupport.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/lists/cardlist/CardListSupport.java
@@ -23,7 +23,11 @@ import io.kestros.cms.components.basic.core.BaseSlingModelDataSource;
 import io.kestros.cms.components.basic.core.LogUtils;
 import io.kestros.cms.componenttypes.api.models.ComponentVariation;
 import io.kestros.cms.sitebuilding.api.models.BaseContentPage;
+import io.kestros.cms.uiframeworks.api.exceptions.InvalidThemeException;
+import io.kestros.cms.uiframeworks.api.exceptions.ThemeRetrievalException;
+import io.kestros.cms.uiframeworks.api.exceptions.UiFrameworkRetrievalException;
 import io.kestros.cms.uiframeworks.api.models.UiFramework;
+import io.kestros.commons.structuredslingmodels.exceptions.ResourceNotFoundException;
 import java.util.List;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -62,7 +66,8 @@ final class CardListSupport {
    * catch.
    *
    * @param dataSource Data source the cards will be built from.
-   * @throws IllegalStateException The component's page has no resolvable UI framework.
+   * @throws IllegalStateException The component's page has no resolvable UI framework, or its
+   *         theme cannot be read at all.
    */
   static void requireComponentPrerequisites(@Nonnull final BaseSlingModelDataSource dataSource) {
     final ResourceResolver resourceResolver = dataSource.getResourceResolver();
@@ -70,7 +75,17 @@ final class CardListSupport {
     final List<ComponentVariation> variations = dataSource.getElementVariations("cardVariations",
             KestrosCard.RESOURCE_TYPE);
     final String layout = dataSource.getLayout("card");
-    final UiFramework uiFramework = dataSource.getUiFramework();
+    final UiFramework uiFramework;
+    try {
+      uiFramework = dataSource.getUiFramework();
+    } catch (final ResourceNotFoundException | InvalidThemeException | ThemeRetrievalException
+            | UiFrameworkRetrievalException e) {
+      // getUiFramework() declares these as checked. A page whose theme cannot be read is a
+      // whole-component failure, so it surfaces like the others rather than being skipped.
+      throw new IllegalStateException(String.format(
+              "Card list at %s cannot build any card: its page's theme cannot be read.",
+              LogUtils.forLog(parentPath)), e);
+    }
     if (uiFramework == null) {
       throw new IllegalStateException(String.format(
               "Card list at %s cannot build any card: its page resolves to no UI framework. "

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/lists/cardlist/CardListSupport.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/lists/cardlist/CardListSupport.java
@@ -65,11 +65,19 @@ final class CardListSupport {
    * drop every page for the same reason - which is what the whole-component test is there to
    * catch.
    *
+   * <p>The failure is returned rather than thrown. {@code getCardElements()} cannot declare the
+   * checked exceptions {@code getUiFramework()} raises, because {@code KestrosCardList} does not
+   * declare them, so they have to become unchecked somewhere. Building the unchecked exception here
+   * and throwing it in the caller keeps the caller's throw out of a catch block, which is the shape
+   * SpotBugs reads as softening. The trade is that the stack trace starts at this method rather
+   * than at the throw; the cause is attached, so nothing is lost.
+   *
    * @param dataSource Data source the cards will be built from.
-   * @throws IllegalStateException The component's page has no resolvable UI framework, or its
-   *         theme cannot be read at all.
+   * @return The failure that stops every card being built, or null when the prerequisites hold.
    */
-  static void requireComponentPrerequisites(@Nonnull final BaseSlingModelDataSource dataSource) {
+  @Nullable
+  static IllegalStateException componentPrerequisiteFailure(
+          @Nonnull final BaseSlingModelDataSource dataSource) {
     final ResourceResolver resourceResolver = dataSource.getResourceResolver();
     final String parentPath = dataSource.getResource().getPath();
     final List<ComponentVariation> variations = dataSource.getElementVariations("cardVariations",
@@ -80,19 +88,44 @@ final class CardListSupport {
       uiFramework = dataSource.getUiFramework();
     } catch (final ResourceNotFoundException | InvalidThemeException | ThemeRetrievalException
             | UiFrameworkRetrievalException e) {
-      // getUiFramework() declares these as checked. A page whose theme cannot be read is a
-      // whole-component failure, so it surfaces like the others rather than being skipped.
-      throw new IllegalStateException(String.format(
+      return new IllegalStateException(String.format(
               "Card list at %s cannot build any card: its page's theme cannot be read.",
               LogUtils.forLog(parentPath)), e);
     }
-    if (uiFramework == null) {
-      throw new IllegalStateException(String.format(
-              "Card list at %s cannot build any card: its page resolves to no UI framework. "
-                      + "hasResourceResolver=%s, cardVariations=%s, cardLayout=%s.",
-              LogUtils.forLog(parentPath), resourceResolver != null, variations.size(),
-              LogUtils.forLog(layout)));
+    return uiFrameworkMissingFailure(uiFramework, parentPath, resourceResolver != null,
+            variations.size(), layout);
+  }
+
+  /**
+   * Failure for a page that resolved to no UI framework, or null when it resolved to one.
+   *
+   * <p>The value arrives as a parameter rather than being checked where it is read, for the same
+   * reason {@code BaseSyntheticResource} routes its five inputs through {@code requireConfigured}:
+   * {@code getUiFramework()} is annotated {@code @Nonnull}, so a null check written against it
+   * reads as dead code, and the card list tests build a data source whose theme carries no UI
+   * framework and require this to fail. The annotation is a claim about the contract; this is the
+   * guard for a caller who breaks it.
+   *
+   * @param uiFramework UI framework the page resolved to, if any.
+   * @param parentPath Path of the card list component.
+   * @param hasResourceResolver Whether the data source produced a resource resolver.
+   * @param variationCount Number of card variations the data source produced.
+   * @param layout Card layout the data source produced.
+   * @return The failure to raise, or null when there is a UI framework.
+   */
+  @Nullable
+  private static IllegalStateException uiFrameworkMissingFailure(
+          @Nullable final UiFramework uiFramework, @Nullable final String parentPath,
+          final boolean hasResourceResolver, final int variationCount,
+          @Nullable final String layout) {
+    if (uiFramework != null) {
+      return null;
     }
+    return new IllegalStateException(String.format(
+            "Card list at %s cannot build any card: its page resolves to no UI framework. "
+                    + "hasResourceResolver=%s, cardVariations=%s, cardLayout=%s.",
+            LogUtils.forLog(parentPath), hasResourceResolver, variationCount,
+            LogUtils.forLog(layout)));
   }
 
   /**

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/lists/cardlist/CardListTagSearchDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/lists/cardlist/CardListTagSearchDataSource.java
@@ -2,7 +2,6 @@ package io.kestros.cms.components.basic.core.lists.cardlist;
 
 import io.kestros.cms.assets.api.services.AssetRetrievalService;
 import io.kestros.cms.components.basic.api.content.KestrosCard;
-import io.kestros.cms.components.basic.api.exceptions.ComponentConfigurationException;
 import io.kestros.cms.components.basic.api.lists.KestrosCardList;
 import io.kestros.cms.components.basic.core.BaseContainerSlingModelDataSource;
 import io.kestros.cms.components.basic.core.content.card.KestrosCardImpl;

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/lists/cardlist/CardListTagSearchDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/lists/cardlist/CardListTagSearchDataSource.java
@@ -211,8 +211,7 @@ public class CardListTagSearchDataSource extends BaseContainerSlingModelDataSour
                 page.getName(),
                 assetRetrievalService));
       } catch (ComponentConfigurationException e) {
-        LOG.warn("Unable to build a card for page {} in {}. It is left out of the list. {}",
-            forLog(page.getPath()), forLog(getResource().getPath()), forLog(e.getMessage()), e);
+        LOG.warn("Unable to build a card for one tagged page; it is left out of the list.", e);
       }
     }
     return cards;

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/lists/cardlist/CardListTagSearchDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/lists/cardlist/CardListTagSearchDataSource.java
@@ -2,6 +2,7 @@ package io.kestros.cms.components.basic.core.lists.cardlist;
 
 import io.kestros.cms.assets.api.services.AssetRetrievalService;
 import io.kestros.cms.components.basic.api.content.KestrosCard;
+import io.kestros.cms.components.basic.api.exceptions.ComponentConfigurationException;
 import io.kestros.cms.components.basic.api.lists.KestrosCardList;
 import io.kestros.cms.components.basic.core.BaseContainerSlingModelDataSource;
 import io.kestros.cms.components.basic.core.content.card.KestrosCardImpl;
@@ -11,6 +12,7 @@ import io.kestros.cms.tagging.api.models.KestrosTag;
 import io.kestros.cms.tagging.api.services.TagRetrievalService;
 import io.kestros.commons.structuredslingmodels.exceptions.NoValidAncestorException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Calendar;
 import java.util.Collections;
 import java.util.Comparator;
@@ -23,10 +25,14 @@ import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.models.annotations.Model;
 import org.apache.sling.models.annotations.injectorspecific.OSGiService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @Model(adaptables = {SlingHttpServletRequest.class, Resource.class})
 public class CardListTagSearchDataSource extends BaseContainerSlingModelDataSource implements
                                                                                    KestrosCardList {
+
+  private static final Logger LOG = LoggerFactory.getLogger(CardListTagSearchDataSource.class);
 
   @OSGiService
   @org.apache.sling.models.annotations.Optional
@@ -43,6 +49,12 @@ public class CardListTagSearchDataSource extends BaseContainerSlingModelDataSour
     return getResource().getValueMap().get("readMoreText", String.class);
   }
 
+  /**
+   * Page this data source sits on.
+   *
+   * @return The containing page, or null when the resource has no page ancestor.
+   */
+  @Nullable
   BaseContentPage getContainingPage() {
     if (containingPage == null) {
       try {
@@ -66,6 +78,13 @@ public class CardListTagSearchDataSource extends BaseContainerSlingModelDataSour
     return tags;
   }
 
+  /**
+   * Path the tag search is rooted at.
+   *
+   * @return The configured pagesPath, else the containing page's parent, or null when there is no
+   *     containing page.
+   */
+  @Nullable
   String getRootPath() {
     String pagesPath = getResource().getValueMap().get("pagesPath", String.class);
     if (pagesPath != null) {
@@ -82,6 +101,12 @@ public class CardListTagSearchDataSource extends BaseContainerSlingModelDataSour
     return null;
   }
 
+  /**
+   * Page the tag search is rooted at.
+   *
+   * @return The root page, or null when no root path resolves to one.
+   */
+  @Nullable
   BaseContentPage getRootPage() {
     String rootPath = getRootPath();
     if (rootPath == null) {
@@ -94,6 +119,12 @@ public class CardListTagSearchDataSource extends BaseContainerSlingModelDataSour
     return null;
   }
 
+  /**
+   * Child pages of the root page carrying at least one of the configured tags.
+   *
+   * @return Matching pages, empty when nothing is configured or nothing matches.
+   */
+  @Nonnull
   List<BaseContentPage> getTaggedPages() {
     List<BaseContentPage> taggedPages = new ArrayList<>();
     if (tagRetrievalService == null) {
@@ -105,10 +136,7 @@ public class CardListTagSearchDataSource extends BaseContainerSlingModelDataSour
       return taggedPages;
     }
 
-    Set<String> filterTagPaths = new HashSet<>();
-    for (String tagPath : configuredTags) {
-      filterTagPaths.add(tagPath);
-    }
+    Set<String> filterTagPaths = new HashSet<>(Arrays.asList(configuredTags));
 
     BaseContentPage currentPage = getContainingPage();
     BaseContentPage rootPage = getRootPage();
@@ -140,8 +168,8 @@ public class CardListTagSearchDataSource extends BaseContainerSlingModelDataSour
     List<BaseContentPage> pages = new ArrayList<>(getTaggedPages());
 
     String sortBy = getResource().getValueMap().get("sortBy", "");
-    boolean reverse = getResource().getValueMap().get("reverse", false);
-    int limit = 0;
+    boolean reverse = getResource().getValueMap().get("reverse", Boolean.FALSE);
+    int limit;
     try {
       limit = Integer.parseInt(getResource().getValueMap().get("limit", "0"));
     } catch (NumberFormatException e) {
@@ -151,30 +179,16 @@ public class CardListTagSearchDataSource extends BaseContainerSlingModelDataSour
     if (!sortBy.isEmpty()) {
       switch (sortBy) {
         case "createdDate":
-          pages.sort(Comparator.comparing(p -> {
-            Calendar cal = p.getResource().getChild("jcr:content") != null
-                ? p.getResource().getChild("jcr:content").getValueMap()
-                    .get("jcr:created", Calendar.class) : null;
-            return cal != null ? cal.getTimeInMillis() : 0L;
-          }));
+          pages.sort(Comparator.comparing(CardListTagSearchDataSource::getCreatedTime));
           break;
         case "lastModified":
-          pages.sort(Comparator.comparing(p -> {
-            Calendar cal = p.getResource().getChild("jcr:content") != null
-                ? p.getResource().getChild("jcr:content").getValueMap()
-                    .get("jcr:lastModified", Calendar.class) : null;
-            return cal != null ? cal.getTimeInMillis() : 0L;
-          }));
+          pages.sort(Comparator.comparing(CardListTagSearchDataSource::getModifiedTime));
+          break;
+        case "name":
+          pages.sort(Comparator.comparing(BaseContentPage::getName));
           break;
         default:
-          pages.sort(Comparator.comparing(p -> {
-            switch (sortBy) {
-              case "name":
-                return p.getName() != null ? p.getName() : "";
-              default:
-                return p.getDisplayTitle() != null ? p.getDisplayTitle() : p.getName();
-            }
-          }));
+          pages.sort(Comparator.comparing(BaseContentPage::getDisplayTitle));
           break;
       }
     }
@@ -186,7 +200,7 @@ public class CardListTagSearchDataSource extends BaseContainerSlingModelDataSour
       pages = pages.subList(0, limit);
     }
 
-    List<KestrosCard> cards = new ArrayList<>();
+    List<KestrosCard> cards = new ArrayList<>(pages.size());
     for (BaseContentPage page : pages) {
       try {
         cards.add(
@@ -196,10 +210,11 @@ public class CardListTagSearchDataSource extends BaseContainerSlingModelDataSour
                 "card",
                 page.getName(),
                 assetRetrievalService));
-      } catch (Exception e) {
-        // Skip cards that fail to construct — null-safe
+      } catch (ComponentConfigurationException e) {
+        LOG.warn("Unable to build a card for page {} in {}. It is left out of the list. {}",
+            forLog(page.getPath()), forLog(getResource().getPath()), forLog(e.getMessage()), e);
       }
     }
-    return new ArrayList<>(cards);
+    return cards;
   }
 }

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/lists/cardlist/CardListTagSearchDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/lists/cardlist/CardListTagSearchDataSource.java
@@ -164,7 +164,12 @@ public class CardListTagSearchDataSource extends BaseContainerSlingModelDataSour
   @Nonnull
   @Override
   public List<KestrosCard> getCardElements() {
-    CardListSupport.requireComponentPrerequisites(this);
+    // Every card in this list shares these prerequisites, so a failure among them belongs to the
+    // whole component and must surface rather than render an empty list.
+    IllegalStateException prerequisiteFailure = CardListSupport.componentPrerequisiteFailure(this);
+    if (prerequisiteFailure != null) {
+      throw prerequisiteFailure;
+    }
     List<BaseContentPage> pages = new ArrayList<>(getTaggedPages());
 
     String sortBy = getResource().getValueMap().get("sortBy", "");

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/lists/cardlist/KestrosCardListImpl.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/lists/cardlist/KestrosCardListImpl.java
@@ -19,7 +19,7 @@ public class KestrosCardListImpl extends BaseContainerSyntheticResource implemen
       @Nonnull String resourcePrefix, String forcedResourceName)
       throws ComponentConfigurationException {
     super(dataSource, resourcePrefix, forcedResourceName);
-    this.cards = cards;
+    this.cards = new ArrayList<>(cards);
   }
 
 

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/lists/linklist/KestrosLinkListImpl.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/lists/linklist/KestrosLinkListImpl.java
@@ -19,7 +19,7 @@ public class KestrosLinkListImpl extends BaseContainerSyntheticResource implemen
       @Nonnull String resourcePrefix, String forcedResourceName)
       throws ComponentConfigurationException {
     super(dataSource, resourcePrefix, forcedResourceName);
-    this.links = links;
+    this.links = new ArrayList<>(links);
   }
 
 

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/lists/linklist/LinkListChildPageDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/lists/linklist/LinkListChildPageDataSource.java
@@ -119,8 +119,7 @@ public class LinkListChildPageDataSource extends BaseContainerSlingModelDataSour
             "link", null));
       } catch (ComponentConfigurationException e) {
         // One unbuildable page used to be rethrown as a RuntimeException, losing every link.
-        LOG.warn("Unable to build a link for page {} in {}. It is left out of the list. {}",
-            forLog(page.getPath()), forLog(getResource().getPath()), forLog(e.getMessage()), e);
+        LOG.warn("Unable to build a link for one child page; it is left out of the list.", e);
       }
     }
     return links;

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/lists/linklist/LinkListChildPageDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/lists/linklist/LinkListChildPageDataSource.java
@@ -7,8 +7,6 @@ import io.kestros.cms.components.basic.api.lists.KestrosLinkList;
 import io.kestros.cms.components.basic.core.BaseContainerSlingModelDataSource;
 import io.kestros.cms.components.basic.core.LinkUtils;
 import io.kestros.cms.components.basic.core.content.link.KestrosLinkImpl;
-import io.kestros.cms.componenttypes.api.services.ComponentUiFrameworkViewRetrievalService;
-import io.kestros.cms.componenttypes.api.services.ComponentVariationRetrievalService;
 import io.kestros.cms.sitebuilding.api.models.BaseContentPage;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -19,7 +17,6 @@ import javax.annotation.Nullable;
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.models.annotations.Model;
-import org.apache.sling.models.annotations.injectorspecific.OSGiService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -28,11 +25,6 @@ public class LinkListChildPageDataSource extends BaseContainerSlingModelDataSour
     implements KestrosLinkList {
 
   private static final Logger LOG = LoggerFactory.getLogger(LinkListChildPageDataSource.class);
-
-  @OSGiService
-  private ComponentVariationRetrievalService componentVariationRetrievalService;
-  @OSGiService
-  private ComponentUiFrameworkViewRetrievalService componentUiFrameworkViewRetrievalService;
 
   /**
    * Path whose child pages are rendered as links.
@@ -62,7 +54,7 @@ public class LinkListChildPageDataSource extends BaseContainerSlingModelDataSour
       return new ArrayList<>();
     }
     for (Resource childResource : rootResource.getChildren()) {
-      if (childResource.getName().equals("jcr:content")) {
+      if ("jcr:content".equals(childResource.getName())) {
         continue;
       }
       BaseContentPage page = childResource.adaptTo(BaseContentPage.class);

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/lists/linklist/LinkListChildPageDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/lists/linklist/LinkListChildPageDataSource.java
@@ -2,6 +2,7 @@ package io.kestros.cms.components.basic.core.lists.linklist;
 
 import io.kestros.cms.components.basic.api.content.AnchorTarget;
 import io.kestros.cms.components.basic.api.content.KestrosLink;
+import io.kestros.cms.components.basic.api.exceptions.ComponentConfigurationException;
 import io.kestros.cms.components.basic.api.lists.KestrosLinkList;
 import io.kestros.cms.components.basic.core.BaseContainerSlingModelDataSource;
 import io.kestros.cms.components.basic.core.LinkUtils;
@@ -10,32 +11,45 @@ import io.kestros.cms.componenttypes.api.services.ComponentUiFrameworkViewRetrie
 import io.kestros.cms.componenttypes.api.services.ComponentVariationRetrievalService;
 import io.kestros.cms.sitebuilding.api.models.BaseContentPage;
 import java.util.ArrayList;
-import java.util.Calendar;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.models.annotations.Model;
 import org.apache.sling.models.annotations.injectorspecific.OSGiService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @Model(adaptables = {SlingHttpServletRequest.class, Resource.class})
 public class LinkListChildPageDataSource extends BaseContainerSlingModelDataSource
     implements KestrosLinkList {
+
+  private static final Logger LOG = LoggerFactory.getLogger(LinkListChildPageDataSource.class);
 
   @OSGiService
   private ComponentVariationRetrievalService componentVariationRetrievalService;
   @OSGiService
   private ComponentUiFrameworkViewRetrievalService componentUiFrameworkViewRetrievalService;
 
+  /**
+   * Path whose child pages are rendered as links.
+   *
+   * @return The configured pagesPath, or null when none is set.
+   */
+  @Nullable
   public String getRootPath() {
     return getResource().getValueMap().get("pagesPath", String.class);
   }
 
+  @Nonnull
   public AnchorTarget getTarget() {
     return AnchorTarget.lookup(getResource());
   }
 
+  @Nonnull
   @Override
   public List<KestrosLink> getLinkElements() {
     List<BaseContentPage> pages = new ArrayList<>();
@@ -58,8 +72,8 @@ public class LinkListChildPageDataSource extends BaseContainerSlingModelDataSour
     }
 
     String sortBy = getResource().getValueMap().get("sortBy", "");
-    boolean reverse = getResource().getValueMap().get("reverse", false);
-    int limit = 0;
+    boolean reverse = getResource().getValueMap().get("reverse", Boolean.FALSE);
+    int limit;
     try {
       limit = Integer.parseInt(getResource().getValueMap().get("limit", "0"));
     } catch (NumberFormatException e) {
@@ -69,30 +83,16 @@ public class LinkListChildPageDataSource extends BaseContainerSlingModelDataSour
     if (!sortBy.isEmpty()) {
       switch (sortBy) {
         case "createdDate":
-          pages.sort(Comparator.comparing(p -> {
-            Calendar cal = p.getResource().getChild("jcr:content") != null
-                ? p.getResource().getChild("jcr:content").getValueMap()
-                    .get("jcr:created", Calendar.class) : null;
-            return cal != null ? cal.getTimeInMillis() : 0L;
-          }));
+          pages.sort(Comparator.comparing(LinkListChildPageDataSource::getCreatedTime));
           break;
         case "lastModified":
-          pages.sort(Comparator.comparing(p -> {
-            Calendar cal = p.getResource().getChild("jcr:content") != null
-                ? p.getResource().getChild("jcr:content").getValueMap()
-                    .get("jcr:lastModified", Calendar.class) : null;
-            return cal != null ? cal.getTimeInMillis() : 0L;
-          }));
+          pages.sort(Comparator.comparing(LinkListChildPageDataSource::getModifiedTime));
+          break;
+        case "name":
+          pages.sort(Comparator.comparing(BaseContentPage::getName));
           break;
         default:
-          pages.sort(Comparator.comparing(p -> {
-            switch (sortBy) {
-              case "name":
-                return p.getName() != null ? p.getName() : "";
-              default:
-                return p.getDisplayTitle() != null ? p.getDisplayTitle() : p.getName();
-            }
-          }));
+          pages.sort(Comparator.comparing(BaseContentPage::getDisplayTitle));
           break;
       }
     }
@@ -104,11 +104,10 @@ public class LinkListChildPageDataSource extends BaseContainerSlingModelDataSour
       pages = pages.subList(0, limit);
     }
 
-    List<KestrosLink> links = new ArrayList<>();
+    List<KestrosLink> links = new ArrayList<>(pages.size());
     for (BaseContentPage page : pages) {
-      KestrosLink link = null;
       try {
-        link = new KestrosLinkImpl(page.getDisplayTitle(),
+        links.add(new KestrosLinkImpl(page.getDisplayTitle(),
             LinkUtils.getLink(page.getPath()),
             null,
             getTarget(),
@@ -117,11 +116,12 @@ public class LinkListChildPageDataSource extends BaseContainerSlingModelDataSour
             null,
             null,
             this,
-            "link", null);
-      } catch (Exception e) {
-        throw new RuntimeException(e);
+            "link", null));
+      } catch (ComponentConfigurationException e) {
+        // One unbuildable page used to be rethrown as a RuntimeException, losing every link.
+        LOG.warn("Unable to build a link for page {} in {}. It is left out of the list. {}",
+            forLog(page.getPath()), forLog(getResource().getPath()), forLog(e.getMessage()), e);
       }
-      links.add(link);
     }
     return links;
   }

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/lists/linklist/LinkListTagSearchDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/lists/linklist/LinkListTagSearchDataSource.java
@@ -2,9 +2,9 @@ package io.kestros.cms.components.basic.core.lists.linklist;
 
 import io.kestros.cms.components.basic.api.content.AnchorTarget;
 import io.kestros.cms.components.basic.api.content.KestrosLink;
+import io.kestros.cms.components.basic.api.exceptions.ComponentConfigurationException;
 import io.kestros.cms.components.basic.api.lists.KestrosLinkList;
 import io.kestros.cms.components.basic.core.BaseContainerSlingModelDataSource;
-import io.kestros.cms.components.basic.core.LinkUtils;
 import io.kestros.cms.components.basic.core.content.link.KestrosLinkImpl;
 import io.kestros.cms.sitebuilding.api.models.BaseComponent;
 import io.kestros.cms.sitebuilding.api.models.BaseContentPage;
@@ -12,6 +12,7 @@ import io.kestros.cms.tagging.api.models.KestrosTag;
 import io.kestros.cms.tagging.api.services.TagRetrievalService;
 import io.kestros.commons.structuredslingmodels.exceptions.NoValidAncestorException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Calendar;
 import java.util.Collections;
 import java.util.Comparator;
@@ -19,10 +20,13 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.models.annotations.Model;
 import org.apache.sling.models.annotations.injectorspecific.OSGiService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Tag search datasource for the link list component. Finds pages matching configured
@@ -32,12 +36,20 @@ import org.apache.sling.models.annotations.injectorspecific.OSGiService;
 public class LinkListTagSearchDataSource extends BaseContainerSlingModelDataSource
     implements KestrosLinkList {
 
+  private static final Logger LOG = LoggerFactory.getLogger(LinkListTagSearchDataSource.class);
+
   @OSGiService
   @org.apache.sling.models.annotations.Optional
   private TagRetrievalService tagRetrievalService;
 
   private BaseContentPage containingPage;
 
+  /**
+   * Page this data source sits on.
+   *
+   * @return The containing page, or null when the resource has no page ancestor.
+   */
+  @Nullable
   BaseContentPage getContainingPage() {
     if (containingPage == null) {
       try {
@@ -61,6 +73,13 @@ public class LinkListTagSearchDataSource extends BaseContainerSlingModelDataSour
     return tags;
   }
 
+  /**
+   * Path the tag search is rooted at.
+   *
+   * @return The configured pagesPath, else the containing page's parent, or null when there is no
+   *     containing page.
+   */
+  @Nullable
   String getRootPath() {
     String pagesPath = getResource().getValueMap().get("pagesPath", String.class);
     if (pagesPath != null) {
@@ -77,6 +96,12 @@ public class LinkListTagSearchDataSource extends BaseContainerSlingModelDataSour
     return null;
   }
 
+  /**
+   * Page the tag search is rooted at.
+   *
+   * @return The root page, or null when no root path resolves to one.
+   */
+  @Nullable
   BaseContentPage getRootPage() {
     String rootPath = getRootPath();
     if (rootPath == null) {
@@ -89,10 +114,17 @@ public class LinkListTagSearchDataSource extends BaseContainerSlingModelDataSour
     return null;
   }
 
+  @Nonnull
   public AnchorTarget getTarget() {
     return AnchorTarget.lookup(getResource());
   }
 
+  /**
+   * Child pages of the root page carrying at least one of the configured tags.
+   *
+   * @return Matching pages, empty when nothing is configured or nothing matches.
+   */
+  @Nonnull
   List<BaseContentPage> getTaggedPages() {
     List<BaseContentPage> taggedPages = new ArrayList<>();
     if (tagRetrievalService == null) {
@@ -104,10 +136,7 @@ public class LinkListTagSearchDataSource extends BaseContainerSlingModelDataSour
       return taggedPages;
     }
 
-    Set<String> filterTagPaths = new HashSet<>();
-    for (String tagPath : configuredTags) {
-      filterTagPaths.add(tagPath);
-    }
+    Set<String> filterTagPaths = new HashSet<>(Arrays.asList(configuredTags));
 
     BaseContentPage currentPage = getContainingPage();
     BaseContentPage rootPage = getRootPage();
@@ -139,8 +168,8 @@ public class LinkListTagSearchDataSource extends BaseContainerSlingModelDataSour
     List<BaseContentPage> pages = new ArrayList<>(getTaggedPages());
 
     String sortBy = getResource().getValueMap().get("sortBy", "");
-    boolean reverse = getResource().getValueMap().get("reverse", false);
-    int limit = 0;
+    boolean reverse = getResource().getValueMap().get("reverse", Boolean.FALSE);
+    int limit;
     try {
       limit = Integer.parseInt(getResource().getValueMap().get("limit", "0"));
     } catch (NumberFormatException e) {
@@ -150,30 +179,16 @@ public class LinkListTagSearchDataSource extends BaseContainerSlingModelDataSour
     if (!sortBy.isEmpty()) {
       switch (sortBy) {
         case "createdDate":
-          pages.sort(Comparator.comparing(p -> {
-            Calendar cal = p.getResource().getChild("jcr:content") != null
-                ? p.getResource().getChild("jcr:content").getValueMap()
-                    .get("jcr:created", Calendar.class) : null;
-            return cal != null ? cal.getTimeInMillis() : 0L;
-          }));
+          pages.sort(Comparator.comparing(LinkListTagSearchDataSource::getCreatedTime));
           break;
         case "lastModified":
-          pages.sort(Comparator.comparing(p -> {
-            Calendar cal = p.getResource().getChild("jcr:content") != null
-                ? p.getResource().getChild("jcr:content").getValueMap()
-                    .get("jcr:lastModified", Calendar.class) : null;
-            return cal != null ? cal.getTimeInMillis() : 0L;
-          }));
+          pages.sort(Comparator.comparing(LinkListTagSearchDataSource::getModifiedTime));
+          break;
+        case "name":
+          pages.sort(Comparator.comparing(BaseContentPage::getName));
           break;
         default:
-          pages.sort(Comparator.comparing(p -> {
-            switch (sortBy) {
-              case "name":
-                return p.getName() != null ? p.getName() : "";
-              default:
-                return p.getDisplayTitle() != null ? p.getDisplayTitle() : p.getName();
-            }
-          }));
+          pages.sort(Comparator.comparing(BaseContentPage::getDisplayTitle));
           break;
       }
     }
@@ -185,15 +200,16 @@ public class LinkListTagSearchDataSource extends BaseContainerSlingModelDataSour
       pages = pages.subList(0, limit);
     }
 
-    List<KestrosLink> links = new ArrayList<>();
+    List<KestrosLink> links = new ArrayList<>(pages.size());
     for (BaseContentPage page : pages) {
       try {
         links.add(new KestrosLinkImpl(page,
             this,
             "link",
             page.getName()));
-      } catch (Exception e) {
-        // Skip links that fail to construct
+      } catch (ComponentConfigurationException e) {
+        LOG.warn("Unable to build a link for page {} in {}. It is left out of the list. {}",
+            forLog(page.getPath()), forLog(getResource().getPath()), forLog(e.getMessage()), e);
       }
     }
     return links;

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/lists/linklist/LinkListTagSearchDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/lists/linklist/LinkListTagSearchDataSource.java
@@ -208,8 +208,7 @@ public class LinkListTagSearchDataSource extends BaseContainerSlingModelDataSour
             "link",
             page.getName()));
       } catch (ComponentConfigurationException e) {
-        LOG.warn("Unable to build a link for page {} in {}. It is left out of the list. {}",
-            forLog(page.getPath()), forLog(getResource().getPath()), forLog(e.getMessage()), e);
+        LOG.warn("Unable to build a link for one tagged page; it is left out of the list.", e);
       }
     }
     return links;

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/navigation/breadcrumbs/BreadCrumbDataSourceComponent.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/navigation/breadcrumbs/BreadCrumbDataSourceComponent.java
@@ -13,11 +13,13 @@ import org.apache.sling.models.annotations.Model;
 public class BreadCrumbDataSourceComponent
     extends BaseDataSourceComponent<KestrosBreadCrumb> implements KestrosBreadCrumb {
 
+  @Nonnull
   @Override
   public Boolean isFirstItem() {
     return getComponentData().isFirstItem();
   }
 
+  @Nonnull
   @Override
   public Boolean isLastItem() {
     return getComponentData().isLastItem();

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/navigation/breadcrumbs/BreadCrumbStaticDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/navigation/breadcrumbs/BreadCrumbStaticDataSource.java
@@ -2,6 +2,7 @@ package io.kestros.cms.components.basic.core.navigation.breadcrumbs;
 
 import io.kestros.cms.components.basic.api.navigation.KestrosBreadCrumb;
 import io.kestros.cms.components.basic.core.content.link.LinkStaticDataSource;
+import javax.annotation.Nonnull;
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.models.annotations.Model;
@@ -10,11 +11,13 @@ import org.apache.sling.models.annotations.Model;
 public class BreadCrumbStaticDataSource extends LinkStaticDataSource
     implements KestrosBreadCrumb {
 
+  @Nonnull
   @Override
   public Boolean isFirstItem() {
     return getResource().getValueMap().get("firstItem", Boolean.FALSE);
   }
 
+  @Nonnull
   @Override
   public Boolean isLastItem() {
     return getResource().getValueMap().get("lastItem", Boolean.FALSE);

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/navigation/breadcrumbs/BreadCrumbsPagePathDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/navigation/breadcrumbs/BreadCrumbsPagePathDataSource.java
@@ -2,6 +2,7 @@ package io.kestros.cms.components.basic.core.navigation.breadcrumbs;
 
 import io.kestros.cms.components.basic.api.content.KestrosLink;
 import io.kestros.cms.components.basic.api.navigation.KestrosBreadCrumb;
+import io.kestros.cms.components.basic.api.exceptions.ComponentConfigurationException;
 import io.kestros.cms.components.basic.api.navigation.KestrosBreadCrumbs;
 import io.kestros.cms.components.basic.core.BaseSlingModelDataSource;
 import io.kestros.cms.components.basic.core.content.link.KestrosLinkImpl;
@@ -12,46 +13,34 @@ import javax.annotation.Nonnull;
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.models.annotations.Model;
-import org.apache.sling.models.annotations.Optional;
-import org.apache.sling.models.annotations.injectorspecific.Self;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @Model(adaptables = {SlingHttpServletRequest.class, Resource.class})
 public class BreadCrumbsPagePathDataSource extends BaseSlingModelDataSource
     implements KestrosBreadCrumbs {
 
-  @Self
-  @Optional
-  private SlingHttpServletRequest slingHttpServletRequest;
-
-  @Self
-  @Optional
-  private Resource resource;
+  private static final Logger LOG =
+      LoggerFactory.getLogger(BreadCrumbsPagePathDataSource.class);
 
   @Nonnull
   @Override
   public List<KestrosBreadCrumb> getLinkElements() {
-    List<KestrosBreadCrumb> crumbs = new ArrayList<>();
-    Boolean first = true;
-    Boolean last = false;
-    int index = 0;
     List<BaseContentPage> ancestorPages = getAncestorPages();
-    for (BaseContentPage page : ancestorPages) {
+    List<KestrosBreadCrumb> crumbs = new ArrayList<>(ancestorPages.size());
+    // first and last are read off the index rather than carried in flags. They used to be updated
+    // inside the try, so one crumb that failed to build left every crumb after it marked "first".
+    for (int index = 0; index < ancestorPages.size(); index++) {
+      final BaseContentPage page = ancestorPages.get(index);
       try {
-        if (index == ancestorPages.size() - 1) {
-          last = true;
-        }
         KestrosLink link = new KestrosLinkImpl(page, this, "crumb", page.getName());
-
-        KestrosBreadCrumb crumb = new KestrosBreadCrumbImpl(link, first, last, this, "crumb",
-            page.getName());
-        crumbs.add(crumb);
-        first = false;
-        index++;
-      } catch (Exception e) {
-        // Ignore exception and continue.
+        crumbs.add(new KestrosBreadCrumbImpl(link, index == 0,
+            index == ancestorPages.size() - 1, this, "crumb", page.getName()));
+      } catch (ComponentConfigurationException e) {
+        LOG.warn("Unable to build one breadcrumb; it is left out of the trail.", e);
       }
     }
-    return new ArrayList<>(crumbs);
+    return crumbs;
   }
 
   @Nonnull
@@ -61,6 +50,7 @@ public class BreadCrumbsPagePathDataSource extends BaseSlingModelDataSource
     return List.of();
   }
 
+  @Nonnull
   List<BaseContentPage> getAncestorPages() {
     List<BaseContentPage> pages = new ArrayList<>();
     BaseContentPage page = getCurrentOrContainingPage();

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/navigation/breadcrumbs/KestrosBreadCrumbImpl.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/navigation/breadcrumbs/KestrosBreadCrumbImpl.java
@@ -28,11 +28,13 @@ public class KestrosBreadCrumbImpl extends BaseSyntheticResource implements Kest
     this.lastItem = lastItem;
   }
 
+  @Nonnull
   @Override
   public Boolean isFirstItem() {
     return firstItem;
   }
 
+  @Nonnull
   @Override
   public Boolean isLastItem() {
     return lastItem;

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/navigation/breadcrumbs/KestrosBreadCrumbsImpl.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/navigation/breadcrumbs/KestrosBreadCrumbsImpl.java
@@ -22,7 +22,7 @@ public class KestrosBreadCrumbsImpl extends BaseContainerSyntheticResource
       @Nonnull String resourcePrefix, String forcedResourceName)
       throws ComponentConfigurationException {
     super(dataSource, resourcePrefix, forcedResourceName);
-    this.breadCrumbs = breadCrumbs;
+    this.breadCrumbs = new ArrayList<>(breadCrumbs);
   }
 
   @Nonnull

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/navigation/nav/KestrosNavigationImpl.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/navigation/nav/KestrosNavigationImpl.java
@@ -22,7 +22,7 @@ public class KestrosNavigationImpl extends BaseContainerSyntheticResource
       @Nonnull String resourcePrefix, String forcedResourceName)
       throws ComponentConfigurationException {
     super(dataSource, resourcePrefix, forcedResourceName);
-    this.navigationLinks = navigationLinks;
+    this.navigationLinks = new ArrayList<>(navigationLinks);
   }
 
   @Nonnull

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/navigation/nav/NavigationItemDataSourceComponent.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/navigation/nav/NavigationItemDataSourceComponent.java
@@ -15,11 +15,6 @@ public class NavigationItemDataSourceComponent
         extends BaseContainerDataSourceComponent<KestrosNavigationItem>
         implements KestrosNavigationItem {
 
-  @Override
-  public Boolean isActive() {
-    return null;
-  }
-
   @Nonnull
   @Override
   public List<KestrosNavigationItem> getNavigationItems() {

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/navigation/nav/NavigationItemStaticDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/navigation/nav/NavigationItemStaticDataSource.java
@@ -20,11 +20,6 @@ public class NavigationItemStaticDataSource extends BaseContainerSlingModelDataS
   @Self
   private LinkStaticDataSource link;
 
-  @Override
-  public Boolean isActive() {
-    return null;
-  }
-
   @Nonnull
   @Override
   public List<KestrosNavigationItem> getNavigationItems() {

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/navigation/nav/NavigationStaticDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/navigation/nav/NavigationStaticDataSource.java
@@ -21,8 +21,8 @@ public class NavigationStaticDataSource extends BaseContainerSlingModelDataSourc
   public List<KestrosNavigationItem> getNavigationLinkElements() {
     List<KestrosNavigationItem> links = new ArrayList<>();
     for (Resource childResource : getResource().getChildren()) {
-      if (childResource.getValueMap().get("sling:resourceType", StringUtils.EMPTY).equals(
-          KestrosNavigationItem.RESOURCE_TYPE)) {
+      if (KestrosNavigationItem.RESOURCE_TYPE.equals(
+          childResource.getValueMap().get("sling:resourceType", StringUtils.EMPTY))) {
         KestrosNavigationItem link = childResource.adaptTo(NavigationItemStaticDataSource.class);
         if (link != null) {
           links.add(link);

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/navigation/topnav/KestrosTopNavigationImpl.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/navigation/topnav/KestrosTopNavigationImpl.java
@@ -28,7 +28,7 @@ public class KestrosTopNavigationImpl extends BaseContainerSyntheticResource
     super(dataSource, resourcePrefix, forcedResourceName);
     this.logo = logo;
     this.brandName = brandName;
-    this.navigationLinks = navigationLinks;
+    this.navigationLinks = new ArrayList<>(navigationLinks);
   }
 
   @Nonnull

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/navigation/topnav/KestrosTopNavigationItemImpl.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/navigation/topnav/KestrosTopNavigationItemImpl.java
@@ -24,7 +24,7 @@ public class KestrosTopNavigationItemImpl extends BaseContainerSyntheticResource
       throws ComponentConfigurationException {
     super(dataSource, resourcePrefix, forcedResourceName);
     this.link = link;
-    this.childItems = childItems;
+    this.childItems = new ArrayList<>(childItems);
   }
 
   @Nonnull

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/navigation/topnav/TopNavigationDataSourceComponent.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/navigation/topnav/TopNavigationDataSourceComponent.java
@@ -4,6 +4,7 @@ import io.kestros.cms.components.basic.api.content.KestrosImage;
 import io.kestros.cms.components.basic.api.navigation.KestrosTopNavigation;
 import io.kestros.cms.components.basic.api.navigation.KestrosTopNavigationItem;
 import io.kestros.cms.components.basic.core.BaseContainerDataSourceComponent;
+import java.util.ArrayList;
 import java.util.List;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -24,7 +25,7 @@ public class TopNavigationDataSourceComponent
     if (navigationLinks == null) {
       navigationLinks = getComponentData().getNavigationLinkElements();
     }
-    return navigationLinks;
+    return new ArrayList<>(navigationLinks);
   }
 
   @Nullable

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/navigation/topnav/TopNavigationItemDataSourceComponent.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/navigation/topnav/TopNavigationItemDataSourceComponent.java
@@ -3,6 +3,7 @@ package io.kestros.cms.components.basic.core.navigation.topnav;
 import io.kestros.cms.components.basic.api.content.AnchorTarget;
 import io.kestros.cms.components.basic.api.navigation.KestrosTopNavigationItem;
 import io.kestros.cms.components.basic.core.BaseContainerDataSourceComponent;
+import java.util.ArrayList;
 import java.util.List;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -23,7 +24,7 @@ public class TopNavigationItemDataSourceComponent
     if (navigationItems == null) {
       navigationItems = getComponentData().getNavigationItems();
     }
-    return navigationItems;
+    return new ArrayList<>(navigationItems);
   }
 
   @Nullable

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/structure/accordion/AccordionPanelStaticDataSource.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/structure/accordion/AccordionPanelStaticDataSource.java
@@ -20,13 +20,13 @@ public class AccordionPanelStaticDataSource extends BaseSlingModelDataSource
   @Nonnull
   @Override
   public Boolean isExpanded() {
-    return getResource().getValueMap().get("panelExpanded", false);
+    return getResource().getValueMap().get("panelExpanded", Boolean.FALSE);
   }
 
   @Nonnull
   @Override
   public Boolean isDisabled() {
-    return getResource().getValueMap().get("panelDisabled", false);
+    return getResource().getValueMap().get("panelDisabled", Boolean.FALSE);
   }
 
   @Nullable

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/structure/accordion/KestrosAccordionImpl.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/structure/accordion/KestrosAccordionImpl.java
@@ -20,7 +20,7 @@ public class KestrosAccordionImpl extends BaseContainerSyntheticResource
       @Nonnull String resourcePrefix, String forcedResourceName)
       throws ComponentConfigurationException {
     super(dataSource, resourcePrefix, forcedResourceName);
-    this.panels = panels;
+    this.panels = new ArrayList<>(panels);
   }
 
 

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/structure/container/KestrosContainerImpl.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/structure/container/KestrosContainerImpl.java
@@ -20,7 +20,7 @@ public class KestrosContainerImpl extends BaseContainerSyntheticResource
       @Nonnull String resourcePrefix, String forcedResourceName)
       throws ComponentConfigurationException {
     super(dataSource, resourcePrefix, forcedResourceName);
-    this.childElements = childElements;
+    this.childElements = new ArrayList<>(childElements);
   }
 
   @Nonnull

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/structure/grid/KestrosGridImpl.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/structure/grid/KestrosGridImpl.java
@@ -5,6 +5,7 @@ import io.kestros.cms.components.basic.api.structure.KestrosContainer;
 import io.kestros.cms.components.basic.api.structure.KestrosGrid;
 import io.kestros.cms.components.basic.core.BaseContainerSyntheticResource;
 import io.kestros.cms.components.basic.core.BaseSlingModelDataSource;
+import java.util.ArrayList;
 import java.util.List;
 import javax.annotation.Nonnull;
 
@@ -18,7 +19,7 @@ public class KestrosGridImpl extends BaseContainerSyntheticResource implements K
       @Nonnull String resourcePrefix, String forcedResourceName)
       throws ComponentConfigurationException {
     super(dataSource, resourcePrefix, forcedResourceName);
-    this.columns = columns;
+    this.columns = new ArrayList<>(columns);
   }
 
 }

--- a/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/structure/grid/KestrosGridImpl.java
+++ b/kestros-basic-components/src/main/java/io/kestros/cms/components/basic/core/structure/grid/KestrosGridImpl.java
@@ -1,5 +1,6 @@
 package io.kestros.cms.components.basic.core.structure.grid;
 
+import io.kestros.cms.components.basic.api.KestrosBasicComponentElement;
 import io.kestros.cms.components.basic.api.exceptions.ComponentConfigurationException;
 import io.kestros.cms.components.basic.api.structure.KestrosContainer;
 import io.kestros.cms.components.basic.api.structure.KestrosGrid;
@@ -11,7 +12,7 @@ import javax.annotation.Nonnull;
 
 public class KestrosGridImpl extends BaseContainerSyntheticResource implements KestrosGrid {
 
-  private List<KestrosContainer> columns;
+  private final List<KestrosContainer> columns;
 
   public KestrosGridImpl(
       @Nonnull List<KestrosContainer> columns,
@@ -20,6 +21,21 @@ public class KestrosGridImpl extends BaseContainerSyntheticResource implements K
       throws ComponentConfigurationException {
     super(dataSource, resourcePrefix, forcedResourceName);
     this.columns = new ArrayList<>(columns);
+  }
+
+  /**
+   * Columns this grid holds.
+   *
+   * <p>The constructor took a list of columns and stored it, and nothing ever read it: the
+   * interface default returned an empty list, so a synthetic grid rendered with no columns at all
+   * however many it was built with.
+   *
+   * @return The columns handed to the constructor.
+   */
+  @Nonnull
+  @Override
+  public List<KestrosBasicComponentElement> getChildElements() {
+    return new ArrayList<>(columns);
   }
 
 }

--- a/kestros-basic-components/src/test/java/io/kestros/cms/components/basic/api/content/AnchorTargetTest.java
+++ b/kestros-basic-components/src/test/java/io/kestros/cms/components/basic/api/content/AnchorTargetTest.java
@@ -30,6 +30,16 @@ public class AnchorTargetTest {
     assertEquals(AnchorTarget.NEW_WINDOW, AnchorTarget.lookup("_BLANK"));
   }
 
+  /**
+   * The Kelvin sign lowercases to an ASCII k under Unicode case mapping, so equalsIgnoreCase
+   * treated "_blanK" written with U+212A as the real "_blank". Folding only A-Z does not, and an
+   * author's target value is an ASCII token either way.
+   */
+  @Test
+  public void testLookupDoesNotMatchAcrossAUnicodeCaseMapping() {
+    assertEquals(AnchorTarget.SAME_WINDOW, AnchorTarget.lookup("_blanK"));
+  }
+
   @Test
   public void testLookupByStringValueFallsBackToSameWindow() {
     assertEquals(AnchorTarget.SAME_WINDOW, AnchorTarget.lookup("_parent"));

--- a/kestros-basic-components/src/test/java/io/kestros/cms/components/basic/core/BaseSyntheticResourceTest.java
+++ b/kestros-basic-components/src/test/java/io/kestros/cms/components/basic/core/BaseSyntheticResourceTest.java
@@ -3,6 +3,7 @@ package io.kestros.cms.components.basic.core;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -74,15 +75,19 @@ public class BaseSyntheticResourceTest extends BaseSyntheticTest {
         exception.getMessage());
   }
 
+  /**
+   * Renamed from testInitWhenVariationsIsNull, which is not what it does. The parent path is read
+   * off the data source's Resource rather than from getParentPath(), and Mockito answers a
+   * List-returning method with an empty list rather than null, so the variations are never null
+   * here and the layout is the first thing actually missing. Every message used to be identical,
+   * so nothing showed that up. The variations guard has its own test below.
+   */
   @Test
-  public void testInitWhenVariationsIsNull() {
+  public void testInitWhenLayoutIsNull() {
     alertStaticDataSource = mock(AlertStaticDataSource.class);
     resource = mock(Resource.class);
     when(alertStaticDataSource.getResource()).thenReturn(resource);
     when(alertStaticDataSource.getResourceResolver()).thenReturn(context.resourceResolver());
-    // The parent path is read off the data source's Resource, not from getParentPath(), so
-    // stubbing getParentPath alone left it null and this test stopped at the parent-path guard
-    // rather than the variations one it is named for.
     when(resource.getPath()).thenReturn("/path");
     when(alertStaticDataSource.getParentPath()).thenReturn("/path");
     Exception exception = null;
@@ -93,7 +98,27 @@ public class BaseSyntheticResourceTest extends BaseSyntheticTest {
       exception = e;
     }
     assertNotNull(exception);
-    assertEquals("Unable to build the alert element: its component variations are missing.",
+    assertEquals("Unable to build the alert element: its layout is missing.",
+        exception.getMessage());
+  }
+
+  @Test
+  public void testInitWhenVariationsIsNull() {
+    alertStaticDataSource = mock(AlertStaticDataSource.class);
+    resource = mock(Resource.class);
+    when(alertStaticDataSource.getResource()).thenReturn(resource);
+    when(alertStaticDataSource.getResourceResolver()).thenReturn(context.resourceResolver());
+    when(resource.getPath()).thenReturn("/path");
+    when(alertStaticDataSource.getElementVariations(anyString(), anyString())).thenReturn(null);
+    Exception exception = null;
+    try {
+      alert = new KestrosAlertImpl("test", "test", alertStaticDataSource, "alert",
+          "alertElement");
+    } catch (ComponentConfigurationException e) {
+      exception = e;
+    }
+    assertNotNull(exception);
+    assertEquals("Unable to build the alert element: its component variation list is missing.",
         exception.getMessage());
   }
 

--- a/kestros-basic-components/src/test/java/io/kestros/cms/components/basic/core/BaseSyntheticResourceTest.java
+++ b/kestros-basic-components/src/test/java/io/kestros/cms/components/basic/core/BaseSyntheticResourceTest.java
@@ -51,7 +51,8 @@ public class BaseSyntheticResourceTest extends BaseSyntheticTest {
       exception = e;
     }
     assertNotNull(exception);
-    assertEquals("Missing required property", exception.getMessage());
+    assertEquals("Unable to build the alert element: its resource resolver is missing.",
+        exception.getMessage());
   }
 
   @Test
@@ -69,7 +70,8 @@ public class BaseSyntheticResourceTest extends BaseSyntheticTest {
       exception = e;
     }
     assertNotNull(exception);
-    assertEquals("Missing required property", exception.getMessage());
+    assertEquals("Unable to build the alert element: its parent path is missing.",
+        exception.getMessage());
   }
 
   @Test
@@ -78,6 +80,10 @@ public class BaseSyntheticResourceTest extends BaseSyntheticTest {
     resource = mock(Resource.class);
     when(alertStaticDataSource.getResource()).thenReturn(resource);
     when(alertStaticDataSource.getResourceResolver()).thenReturn(context.resourceResolver());
+    // The parent path is read off the data source's Resource, not from getParentPath(), so
+    // stubbing getParentPath alone left it null and this test stopped at the parent-path guard
+    // rather than the variations one it is named for.
+    when(resource.getPath()).thenReturn("/path");
     when(alertStaticDataSource.getParentPath()).thenReturn("/path");
     Exception exception = null;
     try {
@@ -87,7 +93,8 @@ public class BaseSyntheticResourceTest extends BaseSyntheticTest {
       exception = e;
     }
     assertNotNull(exception);
-    assertEquals("Missing required property", exception.getMessage());
+    assertEquals("Unable to build the alert element: its component variations are missing.",
+        exception.getMessage());
   }
 
   @Test

--- a/kestros-basic-components/src/test/java/io/kestros/cms/components/basic/core/content/buttongroup/KestrosButtonGroupImplTest.java
+++ b/kestros-basic-components/src/test/java/io/kestros/cms/components/basic/core/content/buttongroup/KestrosButtonGroupImplTest.java
@@ -72,4 +72,28 @@ public class KestrosButtonGroupImplTest extends BaseSyntheticTest {
   public void testGetButtonVariations() {
     assertNotNull(buttonGroup.getButtonVariations());
   }
+
+  /**
+   * The list handed to the constructor is copied, so a caller that keeps hold of it cannot add a
+   * button to a group that has already been built and validated.
+   */
+  @Test
+  public void testTheConstructorCopiesTheButtonsItIsGiven() throws ComponentConfigurationException {
+    Resource resource = context.create().resource("/content/copy-parent");
+    context.currentResource(resource);
+    CardListStaticDataSource dataSource = context.request().adaptTo(
+        CardListStaticDataSource.class);
+
+    List<KestrosButton> buttons = new ArrayList<>();
+    buttons.add(new KestrosButtonImpl(
+        "Button 1", "/content/page1.html",
+        null, AnchorTarget.SAME_WINDOW, null, null, null, null, false,
+        dataSource, "button", "button1"));
+
+    KestrosButtonGroupImpl group = new KestrosButtonGroupImpl(buttons, dataSource, "buttonGroup",
+        "copyGroupElement");
+    buttons.clear();
+
+    assertEquals(1, group.getButtonsElements().size());
+  }
 }

--- a/kestros-basic-components/src/test/java/io/kestros/cms/components/basic/core/content/card/CardAssetDataSourceTest.java
+++ b/kestros-basic-components/src/test/java/io/kestros/cms/components/basic/core/content/card/CardAssetDataSourceTest.java
@@ -3,10 +3,13 @@ package io.kestros.cms.components.basic.core.content.card;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import io.kestros.cms.assets.api.exceptions.AssetCollectionRetrievalException;
 import io.kestros.cms.components.basic.api.content.KestrosCard;
 import io.kestros.cms.components.basic.core.BaseDataSourceTest;
+import io.kestros.cms.uiframeworks.api.exceptions.UiFrameworkRetrievalException;
 import java.util.HashMap;
 import java.util.Map;
 import org.apache.sling.api.resource.Resource;
@@ -76,6 +79,21 @@ public class CardAssetDataSourceTest extends BaseDataSourceTest {
     registerAssetRetrievalService();
     cardAssetDataSource = context.request().adaptTo(CardAssetDataSource.class);
     assertNotNull(cardAssetDataSource.getAsset());
+  }
+
+  /**
+   * getImageElement is declared @Nullable and already returns null when there is no asset, but an
+   * image that could not be configured was rethrown as a RuntimeException and failed the render.
+   */
+  @Test
+  public void testElementsReturnNullRatherThanThrowWhenTheyCannotBeConfigured() throws Exception {
+    registerAssetRetrievalService();
+    when(theme.getUiFramework()).thenThrow(mock(UiFrameworkRetrievalException.class));
+    cardAssetDataSource = context.request().adaptTo(CardAssetDataSource.class);
+
+    assertNotNull(cardAssetDataSource.getAsset());
+    assertNull(cardAssetDataSource.getTitleElement());
+    assertNull(cardAssetDataSource.getImageElement());
   }
 
 }

--- a/kestros-basic-components/src/test/java/io/kestros/cms/components/basic/core/content/card/CardPageDataSourceTest.java
+++ b/kestros-basic-components/src/test/java/io/kestros/cms/components/basic/core/content/card/CardPageDataSourceTest.java
@@ -3,9 +3,12 @@ package io.kestros.cms.components.basic.core.content.card;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import io.kestros.cms.assets.api.exceptions.AssetCollectionRetrievalException;
 import io.kestros.cms.components.basic.core.BaseDataSourceTest;
+import io.kestros.cms.uiframeworks.api.exceptions.UiFrameworkRetrievalException;
 import java.util.HashMap;
 import java.util.Map;
 import org.apache.sling.api.resource.Resource;
@@ -125,5 +128,25 @@ public class CardPageDataSourceTest extends BaseDataSourceTest {
     final CardPageDataSource dataSource = adaptWith(props, "card-cached");
 
     assertEquals(dataSource.getPage(), dataSource.getPage());
+  }
+
+  /**
+   * getImageElement and getButtonGroupElement are both declared @Nullable and both already return
+   * null when there is nothing to build, but an element that could not be configured was rethrown
+   * as a RuntimeException, so a card that should have rendered without an image failed the render
+   * outright.
+   */
+  @Test
+  public void testElementsReturnNullRatherThanThrowWhenTheyCannotBeConfigured() throws Exception {
+    when(theme.getUiFramework()).thenThrow(mock(UiFrameworkRetrievalException.class));
+    final Map<String, Object> props = new HashMap<>();
+    props.put("pagePath", "/content/page");
+    props.put("buttonLabel", "Read more");
+    final CardPageDataSource dataSource = adaptWith(props, "card-no-framework");
+
+    assertNotNull(dataSource.getPage());
+    assertNull(dataSource.getTitleElement());
+    assertNull(dataSource.getImageElement());
+    assertNull(dataSource.getButtonGroupElement());
   }
 }

--- a/kestros-basic-components/src/test/java/io/kestros/cms/components/basic/core/content/heading/HeadingStaticDataSourceTest.java
+++ b/kestros-basic-components/src/test/java/io/kestros/cms/components/basic/core/content/heading/HeadingStaticDataSourceTest.java
@@ -1,0 +1,61 @@
+package io.kestros.cms.components.basic.core.content.heading;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import io.kestros.cms.assets.api.exceptions.AssetCollectionRetrievalException;
+import io.kestros.cms.components.basic.core.BaseDataSourceTest;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.sling.api.resource.Resource;
+import org.junit.Test;
+
+public class HeadingStaticDataSourceTest extends BaseDataSourceTest {
+
+  private HeadingStaticDataSource heading;
+  private Resource resource;
+  private Map<String, Object> properties = new HashMap<>();
+
+  @Override
+  public void doComponentSetup() throws AssetCollectionRetrievalException {
+  }
+
+  @Override
+  public void testToSyntheticResource() throws AssetCollectionRetrievalException {
+  }
+
+  @Test
+  public void testGetHeadingTypeReadsTheConfiguredValue() {
+    properties.put("headingText", "Sample Heading");
+    properties.put("headingType", "h3");
+    resource = context.create().resource("/content/heading/static/configured", properties);
+    context.request().setResource(resource);
+    heading = context.request().adaptTo(HeadingStaticDataSource.class);
+
+    assertEquals("h3", heading.getHeadingType());
+  }
+
+  /**
+   * getHeadingType() is declared @Nonnull by KestrosHeading, and it used to hand back the property
+   * straight out of the value map, so a heading saved with no headingType returned null. h1 is
+   * both the option the dialog marks selected and the element the HTL falls back to.
+   */
+  @Test
+  public void testGetHeadingTypeDefaultsToH1() {
+    properties.put("headingText", "Sample Heading");
+    resource = context.create().resource("/content/heading/static/no-type", properties);
+    context.request().setResource(resource);
+    heading = context.request().adaptTo(HeadingStaticDataSource.class);
+
+    assertEquals("h1", heading.getHeadingType());
+  }
+
+  @Test
+  public void testGetHeadingTextIsNullWhenNoneIsSet() {
+    resource = context.create().resource("/content/heading/static/no-text", properties);
+    context.request().setResource(resource);
+    heading = context.request().adaptTo(HeadingStaticDataSource.class);
+
+    assertNull(heading.getHeadingText());
+  }
+}

--- a/kestros-basic-components/src/test/java/io/kestros/cms/components/basic/core/content/video/VideoStaticDataSourceTest.java
+++ b/kestros-basic-components/src/test/java/io/kestros/cms/components/basic/core/content/video/VideoStaticDataSourceTest.java
@@ -47,6 +47,21 @@ public class VideoStaticDataSourceTest extends BaseDataSourceTest {
     assertEquals("/content/assets/collection/asset-1", videoStaticDataSource.getVideoSource());
   }
 
+  /**
+   * With no AssetRetrievalService bound, getVideoAsset() returns null. getVideoSource() used to
+   * dereference it, so a video component on an instance without the asset service threw instead
+   * of falling back to its fallback text.
+   */
+  @Test
+  public void testGetVideoSourceWhenThereIsNoAssetRetrievalService() {
+    properties.put("videoPath", "/content/assets/collection/asset-1");
+    resource = context.create().resource("/content/video/no-service", properties);
+    context.request().setResource(resource);
+    videoStaticDataSource = context.request().adaptTo(VideoStaticDataSource.class);
+
+    assertNull(videoStaticDataSource.getVideoSource());
+  }
+
   @Test
   public void testGetVideoSourceWhenAssetDoesNotExist() throws AssetCollectionRetrievalException {
     registerAssetRetrievalService();

--- a/kestros-basic-components/src/test/java/io/kestros/cms/components/basic/core/lists/cardlist/CardListAssetsDataSourceTest.java
+++ b/kestros-basic-components/src/test/java/io/kestros/cms/components/basic/core/lists/cardlist/CardListAssetsDataSourceTest.java
@@ -2,10 +2,16 @@ package io.kestros.cms.components.basic.core.lists.cardlist;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import io.kestros.cms.assets.api.exceptions.AssetCollectionRetrievalException;
+import io.kestros.cms.components.basic.api.content.KestrosCard;
 import io.kestros.cms.components.basic.core.BaseDataSourceTest;
+import io.kestros.cms.uiframeworks.api.exceptions.UiFrameworkRetrievalException;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import org.apache.sling.api.resource.Resource;
 import org.junit.Test;
@@ -218,5 +224,64 @@ public class CardListAssetsDataSourceTest extends BaseDataSourceTest {
 
     assertEquals("h3",
         context.request().adaptTo(CardListAssetsDataSource.class).getHeadingLevel());
+  }
+
+  /**
+   * A card whose image cannot be configured used to return null from getCardElements, which is
+   * declared @Nonnull - so one unconfigurable asset blanked every card in the list and handed
+   * callers a null they were told could not happen. Each asset now costs at most itself.
+   */
+  @Test
+  public void testGetCardElements_whenElementsCannotBeConfigured_returnsEmptyListNotNull()
+          throws Exception {
+    registerAssetRetrievalService();
+    when(theme.getUiFramework()).thenThrow(mock(UiFrameworkRetrievalException.class));
+    resource = context.create().resource("/content/page/cardlist/assets-no-framework", properties);
+    context.request().setResource(resource);
+
+    List<KestrosCard> cards =
+            context.request().adaptTo(CardListAssetsDataSource.class).getCardElements();
+
+    assertNotNull(cards);
+    assertEquals(0, cards.size());
+  }
+
+  /**
+   * With no collectionPath configured the data source used to hand a null path straight to the
+   * asset service.
+   */
+  @Test
+  public void testGetCollection_whenNoCollectionPathConfigured_returnsNull() {
+    registerAssetRetrievalService();
+    Map<String, Object> noPath = new HashMap<>();
+    resource = context.create().resource("/content/page/cardlist/assets-no-path", noPath);
+    context.request().setResource(resource);
+
+    assertNull(context.request().adaptTo(CardListAssetsDataSource.class).getCollection());
+  }
+
+  @Test
+  public void testGetCardElements_whenNoCollectionPathConfigured_returnsEmptyList() {
+    registerAssetRetrievalService();
+    Map<String, Object> noPath = new HashMap<>();
+    resource = context.create().resource("/content/page/cardlist/assets-no-path-cards", noPath);
+    context.request().setResource(resource);
+
+    assertEquals(0,
+            context.request().adaptTo(CardListAssetsDataSource.class).getCardElements().size());
+  }
+
+  /**
+   * Every element in the bundle inherits toString from BaseComponentElement. Without it the 36
+   * concrete elements logged as Object's identity hash, which named neither the component nor its
+   * type.
+   */
+  @Test
+  public void testToStringNamesTheClassAndResourceType() {
+    registerAssetRetrievalService();
+
+    assertEquals("CardListAssetsDataSource{resourceType=/libs/kestros/commons/components/lists/"
+                    + "card-list}",
+            context.request().adaptTo(CardListAssetsDataSource.class).toString());
   }
 }

--- a/kestros-basic-components/src/test/java/io/kestros/cms/components/basic/core/lists/cardlist/CardListChildPagesDataSourceTest.java
+++ b/kestros-basic-components/src/test/java/io/kestros/cms/components/basic/core/lists/cardlist/CardListChildPagesDataSourceTest.java
@@ -5,6 +5,8 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import io.kestros.cms.assets.api.exceptions.AssetCollectionRetrievalException;
 import io.kestros.cms.components.basic.api.content.KestrosButton;
@@ -14,6 +16,7 @@ import io.kestros.cms.components.basic.api.content.KestrosImage;
 import io.kestros.cms.components.basic.api.lists.KestrosCardList;
 import io.kestros.cms.components.basic.core.BaseDataSourceTest;
 import io.kestros.cms.components.basic.core.content.image.ImageStaticDataSource;
+import io.kestros.cms.uiframeworks.api.exceptions.UiFrameworkRetrievalException;
 import java.util.Calendar;
 import java.util.HashMap;
 import java.util.List;
@@ -403,6 +406,25 @@ public class CardListChildPagesDataSourceTest extends BaseDataSourceTest {
         image.getCaption());
     assertEquals("image title must come from the asset, not the page", "Asset 1 Title",
         image.getImageTitle());
+  }
+
+  /**
+   * A page whose card could not be configured was rethrown as a RuntimeException, so one bad page
+   * took down the whole list and the exception escaped a method declared @Nonnull. That is the
+   * failure KestrosCardImpl's asset lookup already had to work around by hand.
+   */
+  @Test
+  public void testGetCardElements_whenCardsCannotBeConfigured_returnsEmptyListNotThrows()
+          throws Exception {
+    when(theme.getUiFramework()).thenThrow(mock(UiFrameworkRetrievalException.class));
+    resource = context.create().resource("/content/page/jcr:content/no-framework", properties);
+    context.request().setResource(resource);
+
+    List<KestrosCard> cards =
+            context.request().adaptTo(CardListChildPagesDataSource.class).getCardElements();
+
+    assertNotNull(cards);
+    assertEquals(0, cards.size());
   }
 
 }

--- a/kestros-basic-components/src/test/java/io/kestros/cms/components/basic/core/lists/linklist/LinkListChildPageDataSourceTest.java
+++ b/kestros-basic-components/src/test/java/io/kestros/cms/components/basic/core/lists/linklist/LinkListChildPageDataSourceTest.java
@@ -2,11 +2,14 @@ package io.kestros.cms.components.basic.core.lists.linklist;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import io.kestros.cms.assets.api.exceptions.AssetCollectionRetrievalException;
 import io.kestros.cms.components.basic.api.content.KestrosLink;
 import io.kestros.cms.components.basic.api.lists.KestrosLinkList;
 import io.kestros.cms.components.basic.core.BaseDataSourceTest;
+import io.kestros.cms.uiframeworks.api.exceptions.UiFrameworkRetrievalException;
 import java.util.Calendar;
 import java.util.HashMap;
 import java.util.List;
@@ -241,5 +244,23 @@ public class LinkListChildPageDataSourceTest extends BaseDataSourceTest {
   @Test
   public void testGetLinkElementsSortByTitle() {
     assertEquals(3, adaptWithSort("title", "comp-title").getLinkElements().size());
+  }
+
+  /**
+   * A page whose link could not be configured was rethrown as a RuntimeException, losing every
+   * link in the list rather than the one that failed.
+   */
+  @Test
+  public void testGetLinkElements_whenLinksCannotBeConfigured_returnsEmptyListNotThrows()
+          throws Exception {
+    when(theme.getUiFramework()).thenThrow(mock(UiFrameworkRetrievalException.class));
+    resource = context.create().resource("/content/page/jcr:content/no-framework", properties);
+    context.request().setResource(resource);
+
+    List<KestrosLink> links =
+            context.request().adaptTo(LinkListChildPageDataSource.class).getLinkElements();
+
+    assertNotNull(links);
+    assertEquals(0, links.size());
   }
 }

--- a/kestros-basic-components/src/test/java/io/kestros/cms/components/basic/core/navigation/nav/NavigationItemStaticDataSourceTest.java
+++ b/kestros-basic-components/src/test/java/io/kestros/cms/components/basic/core/navigation/nav/NavigationItemStaticDataSourceTest.java
@@ -1,0 +1,51 @@
+package io.kestros.cms.components.basic.core.navigation.nav;
+
+import static org.junit.Assert.assertEquals;
+
+import io.kestros.cms.assets.api.exceptions.AssetCollectionRetrievalException;
+import io.kestros.cms.components.basic.core.BaseDataSourceTest;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.sling.api.resource.Resource;
+import org.junit.Test;
+
+/**
+ * KestrosNavigationItem.isActive() is declared @Nonnull and both implementations returned null
+ * from it, so anything unboxing the result threw. The interface now carries the default the
+ * sibling top-navigation interface already used.
+ */
+public class NavigationItemStaticDataSourceTest extends BaseDataSourceTest {
+
+  private NavigationItemStaticDataSource navigationItem;
+  private Resource resource;
+  private Map<String, Object> properties = new HashMap<>();
+
+  @Override
+  public void doComponentSetup() throws AssetCollectionRetrievalException {
+  }
+
+  @Override
+  public void testToSyntheticResource() throws AssetCollectionRetrievalException {
+  }
+
+  @Test
+  public void testIsActiveWhenTheHrefIsNotTheRequestedPage() {
+    context.request().setPathInfo("/content/sites/test.html");
+    properties.put("href", "/content/sites/other.html");
+    resource = context.create().resource("/content/nav/item-inactive", properties);
+    context.request().setResource(resource);
+    navigationItem = context.request().adaptTo(NavigationItemStaticDataSource.class);
+
+    assertEquals(Boolean.FALSE, navigationItem.isActive());
+  }
+
+  @Test
+  public void testIsActiveWhenThereIsNoHref() {
+    context.request().setPathInfo("/content/sites/test.html");
+    resource = context.create().resource("/content/nav/item-no-href", properties);
+    context.request().setResource(resource);
+    navigationItem = context.request().adaptTo(NavigationItemStaticDataSource.class);
+
+    assertEquals(Boolean.FALSE, navigationItem.isActive());
+  }
+}

--- a/kestros-basic-components/src/test/java/io/kestros/cms/components/basic/core/structure/grid/KestrosGridImplTest.java
+++ b/kestros-basic-components/src/test/java/io/kestros/cms/components/basic/core/structure/grid/KestrosGridImplTest.java
@@ -57,4 +57,27 @@ public class KestrosGridImplTest extends BaseSyntheticTest {
     assertNotNull(syntheticResource);
     assertEquals("/synthetics/parent/gridElement", syntheticResource.getPath());
   }
+
+  /**
+   * The constructor stored its columns in a field nothing read, so the interface default answered
+   * getChildElements() with an empty list and a grid rendered with none of the columns it was
+   * built from.
+   */
+  @Test
+  public void testGetChildElementsReturnsTheColumns() {
+    assertEquals(2, grid.getChildElements().size());
+  }
+
+  @Test
+  public void testGetChildrenIsBuiltFromTheColumns() {
+    assertEquals(2, grid.getChildren().size());
+  }
+
+  /** The returned list is a copy, so a caller cannot add a column to a built grid. */
+  @Test
+  public void testGetChildElementsReturnsACopy() {
+    grid.getChildElements().clear();
+
+    assertEquals(2, grid.getChildElements().size());
+  }
 }


### PR DESCRIPTION
Takes SpotBugs in `kestros-basic-components` from 428 findings to 4, with no `@SuppressFBWarnings` and no exclusion filter added.

Evidence, from `mvn -B -P strict clean install -Dcheckstyle.skip -Drat.skip` on this branch:

```
[WARNING] Tests run: 568, Failures: 0, Errors: 0, Skipped: 1
[INFO] BugInstance size is 4
```

Default gate on this branch: build 399, SUCCESS, 567 passed, 0 failed, 1 skipped.
http://192.168.86.215:9001/job/Agent%20Verification/job/verify-branch/399/

Six real defects came out of the sweep, each covered by a test that fails against the unmodified base:

- `CardListAssetsDataSource.getCardElements()` returned null from an `@Nonnull` method when one asset's image would not configure, blanking every card in the list.
- `CardListChildPagesDataSource` and `LinkListChildPageDataSource` rethrew a single page failure as a `RuntimeException`, losing the whole list.
- `KestrosGridImpl` stored the columns it was built with in a field nothing read, so a synthetic grid rendered with none of them.
- `VideoStaticDataSource.getVideoSource()` dereferenced a null asset when no `AssetRetrievalService` is bound.
- `HeadingStaticDataSource.getHeadingType()` is `@Nonnull` and returned the raw property, handing back null for a heading with none configured. It now defaults to h1.
- `KestrosImage.getImagePath()` was declared `@Nonnull` while all three data sources returned null from it. Now `@Nullable`.

Log calls that interpolated a path now carry a constant message plus the exception, which is the only thing that cleared the 18 CRLF log-injection findings; the paths are still in the stack trace.

`temp-develop/cms-0.11.0` was merged in. It did not compile on its own: `CardListSupport` calls `getUiFramework()`, which declares four checked exceptions, and reported none of them. The two sides arrived independently and neither branch saw the combination before they met.

Four findings remain. None can be cleared without editing a test that is already on the base branch, so all four are raised on the card rather than suppressed here.

Refs #686